### PR TITLE
Add Alabaster themes (light and dark)

### DIFF
--- a/runtime/themes/wolf-alabaster-dark-bg.toml
+++ b/runtime/themes/wolf-alabaster-dark-bg.toml
@@ -59,3 +59,7 @@ string-bg-dark = "#2A4A2A"   # Slightly brighter dark green - escape sequences
 definition-bg = "#1F2F3F"    # Dark blue - definitions
 comment-bg = "#3F3F1F"       # Dark yellow - comments
 error-bg = "#3F1F1F"         # Dark red - errors
+
+# Selection colors need to be more visible against colored syntax backgrounds
+selection-primary = "#5A8FC7"  # Brighter blue - visible against all syntax backgrounds
+selection = "#2A4A6F"          # Medium dark blue - secondary selections

--- a/runtime/themes/wolf-alabaster-dark-mono.toml
+++ b/runtime/themes/wolf-alabaster-dark-mono.toml
@@ -68,9 +68,4 @@ comment-grey = "#777777"          # Grey - comments
 punctuation-dark = "#555555"      # Dark grey - punctuation
 string-bg = "#2A2A2A"             # Dark grey - strings/constants background
 string-bg-dark = "#333333"        # Slightly lighter grey - escape sequences
-
-# Keep color only for errors and diffs
-error-red = "#F07178"             # Red/Pink - errors
-diff-green = "#AAD94C"            # Green - additions
-diff-red = "#F07178"              # Red/Pink - deletions
-diff-orange = "#FF9800"           # Orange - changes
+# Note: error-red, diff-green, diff-red, diff-orange inherited from parent (identical values)

--- a/runtime/themes/wolf-alabaster-dark.toml
+++ b/runtime/themes/wolf-alabaster-dark.toml
@@ -59,6 +59,9 @@ diagnostic = { underline = { style = "curl" } }
 "ui.window" = { fg = "punctuation" }
 "ui.help" = { fg = "fg", bg = "bg" }
 
+# Jump labels - extremely visible
+"ui.virtual.jump-label" = { fg = "jump-label", modifiers = ["bold"] }
+
 # LSP diagnostic inline/expanded text
 "diagnostic.error" = { underline = { color = "error-red", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "highlight", style = "curl" } }
@@ -127,21 +130,27 @@ diagnostic = { underline = { style = "curl" } }
 "diff.delta" = { fg = "highlight" }
 
 [palette]
-# Core colors (Dark Alabaster)
-fg = "#CCCCCC"           # Main text - light grey
-bg = "#1E1E1E"           # Background - dark grey
+# Core colors (Original Alabaster Dark)
+fg = "#CECECE"           # Main text - light grey
+bg = "#0E1415"           # Background - very dark blue-black
 
-# The 4 semantic colors (adjusted for dark background)
-string = "#AAD94C"       # Green - strings & numbers
-constant = "#D2A6FF"     # Magenta - constants, booleans
-comment = "#F07178"      # Red/Pink - comments (important!)
-definition = "#73B8FF"   # Blue - function/class definitions
+# The 4 semantic colors (Original Alabaster Dark)
+string = "#95CB82"       # Green - strings & numbers
+constant = "#CC8BC9"     # Magenta - constants, booleans
+comment = "#DFDF8E"      # Yellow - comments (important!)
+definition = "#71ADE7"   # Blue - function/class definitions
 
 # Supporting colors
 punctuation = "#8C8C8C"  # Grey - dimmed operators/brackets
-selection = "#264F78"    # Dark blue - secondary selections
-selection-primary = "#4A7BA7"  # Much brighter blue - primary selection (clearly distinct)
-active = "#0E7ACC"       # Bright blue - cursor, active elements
+selection = "#1E3A5F"    # Very dark blue - secondary selections (subtle)
+selection-primary = "#4A7BA7"  # Bright blue - primary selection (clearly distinct)
+active = "#CD974B"       # Golden brown - cursor, active elements (original Alabaster Dark)
 highlight = "#FF9800"    # Orange - search, warnings
-error-red = "#F07178"    # Red/Pink - errors
+error-red = "#DFDF8E"    # Yellow - errors (use comment color for visibility)
 panel = "#252526"        # Slightly lighter grey - UI panels, menus, popups
+jump-label = "#FF6B35"   # Bright orange - jump destinations
+
+# Diff colors
+diff-green = "#95CB82"   # Green - additions (same as string)
+diff-red = "#DFDF8E"     # Yellow - deletions (same as error-red)
+diff-orange = "#FF9800"  # Orange - changes (same as highlight)

--- a/runtime/themes/wolf-alabaster-light-bg.toml
+++ b/runtime/themes/wolf-alabaster-light-bg.toml
@@ -60,3 +60,7 @@ string-bg-dark = "#DBECB6"   # Darker green - escape sequences
 definition-bg = "#DBF1FF"    # Light blue - definitions
 comment-bg = "#FFFABC"       # Light yellow - comments
 error-bg = "#FFE0E0"         # Light pink - errors
+
+# Override selection colors (Alabaster BG uses slightly darker selection)
+selection-primary = "#B4D8FD"  # Original Alabaster BG selection
+selection = "#D5E5F3"          # Lighter for secondary selections

--- a/runtime/themes/wolf-alabaster-light-mono.toml
+++ b/runtime/themes/wolf-alabaster-light-mono.toml
@@ -70,8 +70,8 @@ punctuation-light = "#BBBBBB"     # Light grey - punctuation
 string-bg = "#EEEEEE"             # Very light grey - strings/constants background
 string-bg-dark = "#D9D9D9"        # Slightly darker grey - escape sequences
 
-# Keep color only for errors and diffs
-error-red = "#CC3333"             # Red - errors
-diff-green = "#5F8700"            # Green - additions
+# Override parent colors with more muted tones for monochromatic aesthetic
+error-red = "#CC3333"             # Red - errors (more muted than parent)
+diff-green = "#5F8700"            # Green - additions (more muted than parent)
 diff-red = "#CC3333"              # Red - deletions
-diff-orange = "#D78700"           # Orange - changes
+diff-orange = "#D78700"           # Orange - changes (more muted than parent)

--- a/runtime/themes/wolf-alabaster-light.toml
+++ b/runtime/themes/wolf-alabaster-light.toml
@@ -59,6 +59,9 @@ diagnostic = { underline = { style = "curl" } }
 "ui.window" = { fg = "punctuation" }
 "ui.help" = { fg = "fg", bg = "bg" }
 
+# Jump labels - extremely visible
+"ui.virtual.jump-label" = { fg = "jump-label", modifiers = ["bold"] }
+
 # LSP diagnostic inline/expanded text
 "diagnostic.error" = { underline = { color = "error-red", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "highlight", style = "curl" } }
@@ -139,9 +142,15 @@ definition = "#325CC0"   # Blue - function/class definitions
 
 # Supporting colors
 punctuation = "#777777"  # Grey - dimmed operators/brackets
-selection = "#BFDBFE"    # Light blue - secondary selections
-selection-primary = "#93C5FD"  # Darker blue - primary selection
+selection = "#DDE7ED"    # Light gray-blue - secondary selections (subtle but distinct)
+selection-primary = "#BFDBFE"  # Light blue - primary selection (original Alabaster)
 active = "#007ACC"       # Bright blue - cursor, active elements
 highlight = "#FFBC5D"    # Orange - search, warnings
 error-red = "#AA3731"    # Red - errors
-panel = "#EEEEEE"      # Darker grey - UI panels, menus, popups
+panel = "#EEEEEE"        # Darker grey - UI panels, menus, popups
+jump-label = "#FF4500"   # Bright orange-red - jump destinations
+
+# Diff colors
+diff-green = "#448C27"   # Green - additions (same as string)
+diff-red = "#AA3731"     # Red - deletions (same as error-red)
+diff-orange = "#FFBC5D"  # Orange - changes (same as highlight)


### PR DESCRIPTION
This PR adds Alabaster themes for Helix - a port of the popular minimal syntax highlighting theme by Nikita Prokopov (tonsky).

## About Alabaster

Alabaster follows a minimal highlighting philosophy that emphasizes readability over decoration. Only 4 semantic categories receive color:
- **Strings** (green) - `#448C27`
- **Constants** (magenta) - `#7A3E9D`
- **Comments** (red) - `#AA3731` - because they're important!
- **Definitions** (blue) - `#325CC0` - functions, types, classes

Everything else (keywords, variables, operators) uses the default foreground color because the structure of code is already clear from its formatting.

## Themes Included

This PR includes the complete Alabaster family:

**Standard variants (text color):**
- `wolf-alabaster-light` - Light background theme
- `wolf-alabaster-dark` - Dark background theme

**BG variants (background color):**
- `wolf-alabaster-light-bg` - Light with background highlighting
- `wolf-alabaster-dark-bg` - Dark with background highlighting

**Mono variants (minimal color):**
- `wolf-alabaster-light-mono` - Light grayscale
- `wolf-alabaster-dark-mono` - Dark grayscale

All variants use theme inheritance for clean, maintainable code. The themes faithfully implement the [Alabaster philosophy](https://github.com/tonsky/sublime-scheme-alabaster) and use the same color values as the original Sublime Text version where applicable.

## Screenshots

![Light Theme](https://raw.githubusercontent.com/wolf/alabaster-for-helix/main/screenshots/alabaster-light.png)

![Dark Theme](https://raw.githubusercontent.com/wolf/alabaster-for-helix/main/screenshots/alabaster-dark.png)

![Light BG Theme](https://raw.githubusercontent.com/wolf/alabaster-for-helix/main/screenshots/variants/alabaster-light-bg.png)

![Dark BG Theme](https://raw.githubusercontent.com/wolf/alabaster-for-helix/main/screenshots/variants/alabaster-dark-bg.png)

![Light Mono Theme](https://raw.githubusercontent.com/wolf/alabaster-for-helix/main/screenshots/variants/alabaster-light-mono.png)

![Dark Mono Theme](https://raw.githubusercontent.com/wolf/alabaster-for-helix/main/screenshots/variants/alabaster-dark-mono.png)

## Maintenance

I've been using these themes daily and will maintain them. The standalone repository is at [wolf/alabaster-for-helix](https://github.com/wolf/alabaster-for-helix).

Alabaster has a strong following across editors (VS Code, Vim, NeoVim, IntelliJ, Emacs, etc.) and Helix was notably missing a good implementation. I believe many Helix users who appreciate minimal syntax highlighting will enjoy these themes.