### PR TITLE
feat: use yaml language for .bu files

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1587,7 +1587,8 @@ file-types = [
   { glob = ".kube/config" },
   { glob = ".kube/kuberc" },
   { glob = "yarn.lock" },
-  "sublime-syntax"
+  "sublime-syntax",
+  "bu"
 ]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Butane Configs are YAML, and the official documentation uses the .bu filename extensions.
https://coreos.github.io/butane/getting-started/