### PR TITLE
Fix some minor issues in the Adwaita themes

### DIFF
--- a/runtime/themes/adwaita-dark.toml
+++ b/runtime/themes/adwaita-dark.toml
@@ -69,12 +69,16 @@
 "ui.cursor.select" = { fg = "libadwaita_dark", bg = "light_5" }
 "ui.cursor.match" = { fg = "libadwaita_dark", bg = "blue_2" }
 "ui.cursor.primary" = { fg = "libadwaita_dark", bg = "light_7" }
+"ui.cursor.primary.normal" = { fg = "libadwaita_dark", bg = "light_7" }
+"ui.cursor.primary.insert" = { fg = "libadwaita_dark", bg = "teal_4" }
+"ui.cursor.primary.select" = { fg = "libadwaita_dark", bg = "blue_4" }
 "ui.linenr" = "dark_2"
 "ui.linenr.selected" = { fg = "light_7", modifiers = ["bold"] }
 "ui.statusline" = { fg = "light_4", bg = "libadwaita_dark_alt" }
-"ui.statusline.inactive" = { fg = "light_4", bg = "libadwaita_dark_alt" }
-"ui.statusline.insert" = { fg = "light_4", bg = "teal_4" }
-"ui.statusline.select" = { fg = "light_4", bg = "blue_4" }
+"ui.statusline.inactive" = { fg = "light_7", bg = "libadwaita_dark_alt" }
+"ui.statusline.normal" = { fg = "libadwaita_dark", bg = "light_7" }
+"ui.statusline.insert" = { fg = "libadwaita_dark", bg = "teal_4" }
+"ui.statusline.select" = { fg = "libadwaita_dark", bg = "blue_4" }
 "ui.popup" = { fg = "light_4", bg = "libadwaita_popup" }
 "ui.window" = "split_and_borders"
 "ui.help" = { fg = "light_4", bg = "libadwaita_dark_alt" }

--- a/runtime/themes/adwaita-light.toml
+++ b/runtime/themes/adwaita-light.toml
@@ -68,12 +68,16 @@ inherits="adwaita-dark"
 "ui.cursor.select" = { fg = "light_2", bg = "dark_5" }
 "ui.cursor.match" = { fg = "light_2", bg = "blue_1" }
 "ui.cursor.primary" = { fg = "light_2", bg = "dark_6" }
+"ui.cursor.primary.normal" = { fg = "light_2", bg = "dark_6" }
+"ui.cursor.primary.insert" = { fg = "light_2", bg = "teal_4" }
+"ui.cursor.primary.select" = { fg = "light_2", bg = "blue_4" }
 "ui.linenr" = "light_5"
 "ui.linenr.selected" = { fg = "dark_2", modifiers = ["bold"] }
 "ui.statusline" = { fg = "dark_4", bg = "light_4" }
-"ui.statusline.inactive" = { fg = "dark_4", bg = "light_4" }
-"ui.statusline.insert" = { fg = "light_4", bg = "teal_4" }
-"ui.statusline.select" = { fg = "light_4", bg = "blue_4" }
+"ui.statusline.inactive" = { fg = "light_7", bg = "light_4" }
+"ui.statusline.normal" = { fg = "light_2", bg = "dark_6" }
+"ui.statusline.insert" = { fg = "light_2", bg = "teal_4" }
+"ui.statusline.select" = { fg = "light_2", bg = "blue_4" }
 "ui.popup" = { fg = "dark_4", bg = "light_3" }
 "ui.window" = "split_and_borders"
 "ui.help" = { fg = "dark_4", bg = "light_3" }


### PR DESCRIPTION
I tried my best to catalog each change:
1. Changed 'libadwaita_dark' from #1d1d20 to #1c1c1f since that's what both Ptyxis and Gnome Console use as the background color.
2. 'variable.parameter' was changed to the value of 'variable' so that the color of function parameters will match the color of normal variables, as is done in some other themes.
3. Removed the background color from 'ui.linenr.selected' since it's not needed for the cursorline and looks distracting when the cursorline is disabled.
4. Added a foreground color to 'ui.help' and 'ui.popup'. If it's not set, the color will fall back to the terminal emulator's default foreground color which changes according to the theme set in the terminal. This makes it impossible to read the text in the tooltip whenever the terminal is set to a white theme and Helix is set to a dark theme or vice versa.
5. Copied 'ui.statusline.insert' and 'ui.statusline.select' from the dark variant to the light variant since the colors used aren't specific to either of the themes and the foreground color used in the light variant was way too dark.
6. In the light theme, I set 'ui.statusline.inactive' to the value of 'ui.statusline' because that is done in the dark theme as well.
7. Made the jump labels more readable by adding a background color.
8. Made the whitespace characters darker in the dark theme to make them less distracting.
9. Removed 'ui.cursor.primary.insert' from the light theme so that the cursor doesn't change its color just like is done in the dark theme.