### PR TITLE
Add scdoc syntax highlighting

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5126,6 +5126,28 @@ name = "scfg"
 source = { git = "https://github.com/rockorager/tree-sitter-scfg", rev = "d850fd470445d73de318a21d734d1e09e29b773c" }
 
 [[language]]
+name = "scdoc"
+scope = "text.scdoc"
+injection-regex = "scdoc"
+file-types = [
+  { glob = "*.1.scd" },
+  { glob = "*.2.scd" },
+  { glob = "*.3.scd" },
+  { glob = "*.4.scd" },
+  { glob = "*.5.scd" },
+  { glob = "*.6.scd" },
+  { glob = "*.7.scd" },
+  { glob = "*.8.scd" },
+]
+comment-token = "; "
+indent = { tab-width = 4, unit = "\t" }
+text-width = 80
+
+[[grammar]]
+name = "scdoc"
+source = { git = "https://github.com/EricGrill/tree-sitter-scdoc", rev = "51f6f0ab3bac372e95994d0e87bd73c0f3b7e486" }
+
+[[language]]
 name = "ripple"
 scope = "source.ripple"
 file-types = [ "ripple" ]

--- a/runtime/queries/scdoc/highlights.scm
+++ b/runtime/queries/scdoc/highlights.scm
@@ -1,0 +1,49 @@
+; Preamble
+(preamble
+  (title) @markup.heading.1
+  (section) @constant.numeric)
+
+(footer_text) @string
+
+; Headings
+(heading) @markup.heading.1
+
+(subheading) @markup.heading.2
+
+; Formatting
+(bold
+  "*" @punctuation.special
+  (bold_content) @markup.bold)
+
+(underline
+  "_" @punctuation.special
+  (underline_content) @markup.italic)
+
+(inline_code
+  "`" @punctuation.special
+  (code_content) @markup.raw.inline)
+
+; Code blocks
+(literal_block) @markup.raw.block
+
+(code_block_content) @markup.raw.block
+
+; Lists
+(list_item) @markup.list.unnumbered
+
+(numbered_list_item) @markup.list.numbered
+
+; Tables
+(table_row) @markup.raw
+
+; Comments
+(comment) @comment
+
+; Line break
+(line_break) @punctuation.special
+
+; Escape sequence
+(escape_sequence) @string.escape
+
+; Punctuation
+["(" ")" "\""] @punctuation.bracket


### PR DESCRIPTION
## Summary

- Add support for scdoc, a simple man page generator format
- Create tree-sitter-scdoc grammar (https://github.com/EricGrill/tree-sitter-scdoc)
- Add highlights.scm for syntax highlighting

### Features

The grammar and highlighting support:
- Preamble with title, section number, and footers
- Section headings (`# HEADING`) and subsection headings (`## SUBHEADING`)
- Bold (`*text*`) and underlined (`_text_`) formatting
- Inline code (`` `code` ``) and literal code blocks
- Bulleted (`- item`) and numbered (`. item`) lists
- Comments (`; comment`)
- Tables and escape sequences

### File Type Detection

Uses glob patterns for file detection (`*.1.scd` through `*.8.scd`) to avoid conflicts with SuperCollider which also uses the `.scd` extension. This follows the scdoc convention where man pages include their section number (e.g., `mycommand.1.scd` for section 1, `mycommand.5.scd` for section 5).

Closes #7707

## Test plan

- [x] Created tree-sitter grammar and verified it parses scdoc files correctly
- [x] Added highlights.scm with appropriate capture groups
- [x] Grammar handles preamble, headings, formatting, lists, code blocks, and comments
- [ ] Verify syntax highlighting works in helix editor

### Example scdoc file

```scdoc
mycommand(1) "My Project" "Manual"

# NAME

mycommand - description of my command

# SYNOPSIS

*mycommand* [OPTIONS] _file_

# DESCRIPTION

This is a description with *bold* and _underlined_ text.

## SUBSECTION

More content here.

; This is a comment

# SEE ALSO

man(1), groff(1)
```

---
Generated with [Claude Code](https://claude.com/claude-code)