### PR TITLE
Fix highlighting for new github-action language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -91,7 +91,7 @@
 | git-ignore | ✓ |  |  |  |  |  |
 | git-notes | ✓ |  |  |  |  |  |
 | git-rebase | ✓ |  |  |  |  |  |
-| github-action |  |  |  |  |  | `actions-languageserver`, `yaml-language-server` |
+| github-action | ✓ | ✓ | ✓ |  | ✓ | `actions-languageserver`, `yaml-language-server` |
 | gitlab-ci | ✓ | ✓ | ✓ | ✓ | ✓ | `yaml-language-server`, `gitlab-ci-ls` |
 | gjs | ✓ | ✓ | ✓ | ✓ |  | `typescript-language-server`, `vscode-eslint-language-server`, `ember-language-server` |
 | gleam | ✓ | ✓ |  |  | ✓ | `gleam` |

--- a/runtime/queries/github-action/highlights.scm
+++ b/runtime/queries/github-action/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/github-action/indents.scm
+++ b/runtime/queries/github-action/indents.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/github-action/injections.scm
+++ b/runtime/queries/github-action/injections.scm
@@ -1,0 +1,32 @@
+; inherits: yaml
+
+; JavaScript for workflow scripting (inline)
+(block_mapping
+  (block_mapping_pair
+    key: (flow_node) @_uses (#eq? @_uses "uses")
+    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
+  (block_mapping_pair
+    key: (flow_node) @_with (#eq? @_with "with")
+    value: (block_node
+             (block_mapping
+               (block_mapping_pair
+                 key: (flow_node) @_run (#eq? @_run "script")
+                 value: (flow_node
+                          (plain_scalar
+                            (string_scalar) @injection.content
+                            (#set! injection.language "javascript"))))))))
+
+; JavaScript for workflow scripting (block)
+(block_mapping
+  (block_mapping_pair
+    key: (flow_node) @_uses (#eq? @_uses "uses")
+    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
+  (block_mapping_pair
+    key: (flow_node) @_with (#any-of? @_with "with")
+    value: (block_node
+             (block_mapping
+               (block_mapping_pair
+                 key: (flow_node) @_run (#any-of? @_run "script")
+                 value: (block_node
+                          (block_scalar) @injection.content
+                          (#set! injection.language "javascript")))))))

--- a/runtime/queries/github-action/rainbows.scm
+++ b/runtime/queries/github-action/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/github-action/textobjects.scm
+++ b/runtime/queries/github-action/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: yaml

--- a/runtime/queries/yaml/injections.scm
+++ b/runtime/queries/yaml/injections.scm
@@ -55,35 +55,3 @@
                   (#set! injection.language "bash"))))))
 
 ;;; END nvim-treesitter LICENSED CODE
-
-; GitHub actions: JavaScript for workflow scripting (inline)
-(block_mapping
-  (block_mapping_pair
-    key: (flow_node) @_uses (#eq? @_uses "uses")
-    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
-  (block_mapping_pair
-    key: (flow_node) @_with (#eq? @_with "with")
-    value: (block_node
-             (block_mapping
-               (block_mapping_pair
-                 key: (flow_node) @_run (#eq? @_run "script")
-                 value: (flow_node
-                          (plain_scalar
-                            (string_scalar) @injection.content
-                            (#set! injection.language "javascript"))))))))
-
-; GitHub actions: JavaScript for workflow scripting (block)
-(block_mapping
-  (block_mapping_pair
-    key: (flow_node) @_uses (#eq? @_uses "uses")
-    value: (flow_node) @_actions_ghs (#match? @_actions_ghs "^actions/github-script"))
-  (block_mapping_pair
-    key: (flow_node) @_with (#any-of? @_with "with")
-    value: (block_node
-             (block_mapping
-               (block_mapping_pair
-                 key: (flow_node) @_run (#any-of? @_run "script")
-                 value: (block_node
-                          (block_scalar) @injection.content
-                          (#set! injection.language "javascript")))))))
-


### PR DESCRIPTION
https://github.com/helix-editor/helix/pull/15111 broke highlighting by splitting the `github-action` language off from `yaml` without inheriting queries. This adds the required files and moves purely GitHub-specific injections out of the queries for `yaml`.