### PR TITLE
Add missing docs anchor for new `[editor.file-explorer]` section

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -6,6 +6,7 @@
 - [`[editor.lsp]` Section](#editorlsp-section)
 - [`[editor.cursor-shape]` Section](#editorcursor-shape-section)
 - [`[editor.file-picker]` Section](#editorfile-picker-section)
+- [`[editor.file-explorer]` Section](#editorfile-explorer-section)
 - [`[editor.buffer-picker]` Section](#editorbuffer-picker-section)
 - [`[editor.auto-pairs]` Section](#editorauto-pairs-section)
 - [`[editor.auto-save]` Section](#editorauto-save-section)


### PR DESCRIPTION
The `[editor.file-explorer]` section of the docs is a nice addition but it seems the PR (#13888) missed the anchor at the top of the page. 

It's a bit nitpicky but also could lead to many people not finding the section once the docs are updated if left as-is, and given the confusion already happening (see https://github.com/helix-editor/helix/issues/15083#issuecomment-3722758718) due to different picker/explorer defaults, this seems like a good fix.