### PR TITLE
config(syntax): recognize (gnu) stow-styled dotfile paths

### DIFF
--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -169,6 +169,13 @@ impl<'de> Deserialize<'de> for FileType {
             {
                 match map.next_entry::<String, String>()? {
                     Some((key, mut glob)) if key == "glob" => {
+                        // If glob starts with a period, also match "dot-" as
+                        // an alternative prefix to support GNU stow --dotfiles
+                        // preprocessing.
+                        if let Some(rest) = glob.strip_prefix('.') {
+                            glob = format!("{{.,dot-}}{}", rest);
+                        }
+
                         // If the glob isn't an absolute path or already starts
                         // with a glob pattern, add a leading glob so we
                         // properly match relative paths.


### PR DESCRIPTION
This PR adds support for recognizing [stow](https://www.gnu.org/software/stow/)-styled dotfile paths.

Stow has a [`--dotfiles` flag](https://www.gnu.org/software/stow/manual/stow.html#index-dotfiles) to preprocess paths starting with `dot-` to be replaced with a literal dot character before linking. E.g. instead of `.zshrc` a source file would be named `dot-zshrc`.

My PR solves this by extending globs - beginning with a dot character - to also match the `dot-` variant.

Admittedly this change feels a bit invasive for a, presumably, uncommon use-case. So no hard feelings if this gets rejected :)