### PR TITLE
Add `.stylelintrc` and `.puppeteerrc` files to `yaml` language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1590,7 +1590,9 @@ file-types = [
   { glob = ".kube/kuberc" },
   { glob = "yarn.lock" },
   "sublime-syntax",
-  "bu"
+  "bu",
+  { glob = ".stylelintrc" },  # https://stylelint.io/user-guide/configure/
+  { glob = ".puppeteerrc" },  # https://pptr.dev/guides/configuration
 ]
 comment-token = "#"
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Both files can either be `yaml` or `json` when the config file has not set a file extension. From the docs of each it seems that they are parsed first as `yaml` and then `json` if the first fails. Looking at projects on GitHub most projects use `yaml` encoding for these files.