### PR TITLE
Revert "build(deps): bump `unicode-width` from `=0.1.12` to `=0.1.14`"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
  "tree-house",
  "unicode-general-category",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.1.12",
  "url",
 ]
 
@@ -2988,9 +2988,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-width"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -29,7 +29,7 @@ unicode-segmentation.workspace = true
 # width definitions in terminals, we need to replace it.
 # For now lets lock the version to avoid rendering glitches
 # when installing without `--locked`
-unicode-width = "=0.1.14"
+unicode-width = "=0.1.12"
 unicode-general-category = "1.1"
 slotmap.workspace = true
 tree-house.workspace = true

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -113,6 +113,8 @@ pub fn grapheme_width(g: &str) -> usize {
         // We use max(1) here because all grapeheme clusters--even illformed
         // ones--should have at least some width so they can be edited
         // properly.
+        // TODO properly handle unicode width for all codepoints
+        // example of where unicode width is currently wrong: 🤦🏼‍♂️ (taken from https://hsivonen.fi/string-length/)
         UnicodeWidthStr::width(g).max(1)
     }
 }


### PR DESCRIPTION
Reverts helix-editor/helix#14643

Leads to residual artifacts when render diffing for me.