### PR TITLE
theme(wolf-alabaster): Add missing UI scopes

### DIFF
--- a/runtime/themes/wolf-alabaster-dark-mono.toml
+++ b/runtime/themes/wolf-alabaster-dark-mono.toml
@@ -62,10 +62,15 @@ inherits = "wolf-alabaster-dark"
 error = { fg = "error-red", modifiers = ["bold"] }
 "diagnostic.error" = { underline = { color = "error-red", style = "curl" } }
 
+# Virtual text - grey in mono (no colored definitions)
+"ui.virtual" = { fg = "inlay-hint" }
+"ui.virtual.inlay-hint" = { fg = "inlay-hint" }
+
 [palette]
 # Dark monochromatic palette
 comment-grey = "#777777"          # Grey - comments
 punctuation-dark = "#555555"      # Dark grey - punctuation
 string-bg = "#2A2A2A"             # Dark grey - strings/constants background
 string-bg-dark = "#333333"        # Slightly lighter grey - escape sequences
+inlay-hint = "#555555"            # Dimmed grey - virtual text (type hints)
 # Note: error-red, diff-green, diff-red, diff-orange inherited from parent (identical values)

--- a/runtime/themes/wolf-alabaster-dark.toml
+++ b/runtime/themes/wolf-alabaster-dark.toml
@@ -36,6 +36,10 @@ diagnostic = { underline = { style = "curl" } }
 "ui.cursor" = { bg = "active", fg = "bg" }
 "ui.cursor.primary" = { bg = "active", fg = "bg" }
 "ui.cursor.match" = { bg = "highlight" }
+"ui.cursorline" = { bg = "cursorline" }
+"ui.cursorcolumn" = { bg = "cursorline" }
+
+"ui.gutter" = { bg = "bg" }
 
 "ui.selection" = { bg = "selection" }
 "ui.selection.primary" = { bg = "selection-primary" }
@@ -62,11 +66,17 @@ diagnostic = { underline = { style = "curl" } }
 # Jump labels - extremely visible
 "ui.virtual.jump-label" = { fg = "jump-label", modifiers = ["bold"] }
 
+# Virtual text (inlay hints, etc.) - dimmed type color
+"ui.virtual" = { fg = "inlay-hint" }
+"ui.virtual.inlay-hint" = { fg = "inlay-hint" }
+"ui.virtual.ruler" = { bg = "cursorline" }
+
 # LSP diagnostic inline/expanded text
 "diagnostic.error" = { underline = { color = "error-red", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "highlight", style = "curl" } }
 "diagnostic.info" = { underline = { color = "definition", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "punctuation", style = "curl" } }
+"diagnostic.deprecated" = { fg = "punctuation", modifiers = ["crossed_out"] }
 
 # SYNTAX HIGHLIGHTING - Following Alabaster's minimal approach
 # Only 4 categories get color: strings, constants, comments, definitions
@@ -110,6 +120,7 @@ diagnostic = { underline = { style = "curl" } }
 
 # Special cases
 "tag" = { fg = "definition" }
+"tag.error" = { fg = "error-red", underline = { style = "line" } }
 "attribute" = { fg = "fg" }
 "namespace" = { fg = "definition" }
 "label" = { fg = "constant" }
@@ -148,7 +159,9 @@ active = "#CD974B"       # Golden brown - cursor, active elements (original Alab
 highlight = "#FF9800"    # Orange - search, warnings
 error-red = "#DFDF8E"    # Yellow - errors (use comment color for visibility)
 panel = "#252526"        # Slightly lighter grey - UI panels, menus, popups
+cursorline = "#1A2022"   # Subtle highlight - cursorline, ruler
 jump-label = "#FF6B35"   # Bright orange - jump destinations
+inlay-hint = "#4A7090"   # Dimmed blue - virtual text (type hints)
 
 # Diff colors
 diff-green = "#95CB82"   # Green - additions (same as string)

--- a/runtime/themes/wolf-alabaster-light-mono.toml
+++ b/runtime/themes/wolf-alabaster-light-mono.toml
@@ -63,12 +63,17 @@ inherits = "wolf-alabaster-light"
 error = { fg = "error-red", modifiers = ["bold"] }
 "diagnostic.error" = { underline = { color = "error-red", style = "curl" } }
 
+# Virtual text - grey in mono (no colored definitions)
+"ui.virtual" = { fg = "inlay-hint" }
+"ui.virtual.inlay-hint" = { fg = "inlay-hint" }
+
 [palette]
 # Monochromatic palette
 comment-grey = "#999999"          # Grey - comments
 punctuation-light = "#BBBBBB"     # Light grey - punctuation
 string-bg = "#EEEEEE"             # Very light grey - strings/constants background
 string-bg-dark = "#D9D9D9"        # Slightly darker grey - escape sequences
+inlay-hint = "#AAAAAA"            # Dimmed grey - virtual text (type hints)
 
 # Override parent colors with more muted tones for monochromatic aesthetic
 error-red = "#CC3333"             # Red - errors (more muted than parent)

--- a/runtime/themes/wolf-alabaster-light.toml
+++ b/runtime/themes/wolf-alabaster-light.toml
@@ -36,6 +36,10 @@ diagnostic = { underline = { style = "curl" } }
 "ui.cursor" = { bg = "active", fg = "bg" }
 "ui.cursor.primary" = { bg = "active", fg = "bg" }
 "ui.cursor.match" = { bg = "highlight" }
+"ui.cursorline" = { bg = "cursorline" }
+"ui.cursorcolumn" = { bg = "cursorline" }
+
+"ui.gutter" = { bg = "bg" }
 
 "ui.selection" = { bg = "selection" }
 "ui.selection.primary" = { bg = "selection-primary" }
@@ -62,11 +66,17 @@ diagnostic = { underline = { style = "curl" } }
 # Jump labels - extremely visible
 "ui.virtual.jump-label" = { fg = "jump-label", modifiers = ["bold"] }
 
+# Virtual text (inlay hints, etc.) - dimmed type color
+"ui.virtual" = { fg = "inlay-hint" }
+"ui.virtual.inlay-hint" = { fg = "inlay-hint" }
+"ui.virtual.ruler" = { bg = "cursorline" }
+
 # LSP diagnostic inline/expanded text
 "diagnostic.error" = { underline = { color = "error-red", style = "curl" } }
 "diagnostic.warning" = { underline = { color = "highlight", style = "curl" } }
 "diagnostic.info" = { underline = { color = "definition", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "punctuation", style = "curl" } }
+"diagnostic.deprecated" = { fg = "punctuation", modifiers = ["crossed_out"] }
 
 # SYNTAX HIGHLIGHTING - Following Alabaster's minimal approach
 # Only 4 categories get color: strings, constants, comments, definitions
@@ -110,6 +120,7 @@ diagnostic = { underline = { style = "curl" } }
 
 # Special cases
 "tag" = { fg = "definition" }
+"tag.error" = { fg = "error-red", underline = { style = "line" } }
 "attribute" = { fg = "fg" }
 "namespace" = { fg = "definition" }
 "label" = { fg = "constant" }
@@ -148,7 +159,9 @@ active = "#007ACC"       # Bright blue - cursor, active elements
 highlight = "#FFBC5D"    # Orange - search, warnings
 error-red = "#AA3731"    # Red - errors
 panel = "#EEEEEE"        # Darker grey - UI panels, menus, popups
+cursorline = "#EFEFEF"   # Subtle highlight - cursorline, ruler
 jump-label = "#FF4500"   # Bright orange-red - jump destinations
+inlay-hint = "#8090B8"   # Dimmed blue - virtual text (type hints)
 
 # Diff colors
 diff-green = "#448C27"   # Green - additions (same as string)


### PR DESCRIPTION
## Summary

Addresses feedback from @Rudxain on #15102 regarding missing UI scopes in the wolf-alabaster themes.

Added scopes:
- `ui.virtual.inlay-hint`: dimmed blue (matches type color but muted)
- `ui.cursorline`, `ui.cursorcolumn`: subtle line highlighting
- `ui.virtual.ruler`: ruler column background
- `ui.gutter`: gutter background
- `diagnostic.deprecated`: crossed-out styling
- `tag.error`: error styling for malformed markup

## Test plan

- [x] Verified all 6 theme variants render correctly
- [x] Tested inlay hints with rust-analyzer
- [x] Tested cursorline, ruler visibility
- [x] Tested deprecated function styling
- [x] Tested tag.error with malformed HTML