### PR TITLE
Use space . to open current folder

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -101,7 +101,7 @@
 | `file_picker_in_current_buffer_directory` | Open file picker at current buffer's directory |  |
 | `file_picker_in_current_directory` | Open file picker at current working directory | normal: `` <space>F ``, select: `` <space>F `` |
 | `file_explorer` | Open file explorer in workspace root | normal: `` <space>e ``, select: `` <space>e `` |
-| `file_explorer_in_current_buffer_directory` | Open file explorer at current buffer's directory | normal: `` <space>E ``, select: `` <space>E `` |
+| `file_explorer_in_current_buffer_directory` | Open file explorer at current buffer's directory | normal: `` <space>. ``, select: `` <space>. `` |
 | `file_explorer_in_current_directory` | Open file explorer at current working directory |  |
 | `code_action` | Perform code action | normal: `` <space>a ``, select: `` <space>a `` |
 | `buffer_picker` | Open buffer picker | normal: `` <space>b ``, select: `` <space>b `` |

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -226,7 +226,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "f" => file_picker,
             "F" => file_picker_in_current_directory,
             "e" => file_explorer,
-            "E" => file_explorer_in_current_buffer_directory,
+            "." => file_explorer_in_current_buffer_directory,
             "b" => buffer_picker,
             "j" => jumplist_picker,
             "s" => lsp_or_syntax_symbol_picker,


### PR DESCRIPTION
File explorer was added in https://github.com/helix-editor/helix/pull/11285

Opening the current folder I often find it needed in a larger project which having it as a 2 key presses rather than 3 helps.

This changes <kbd>space</kbd> <kbd>E</kbd> to <kbd>space</kbd> <kbd>.</kbd>, one less shift press and clearer meaning.

## Prior Art

doom emacs have this on the first help in <kbd>space</kbd> <kbd>.</kbd>, and it aligns with `cd .`.

<img width="2417" height="549" alt="Screenshot_20260121_221501" src="https://github.com/user-attachments/assets/c35b9e1b-6140-40a4-a4ee-c7b3834288d7" />

https://github.com/nvim-telescope/telescope-file-browser.nvim have it as `<C-w>/w`, `w` is already taken and the meaning is less clear compared to `.` for current working directory.

I wonder if @drybalka have any thoughts on this since he was the creator of file explorer in helix.

---

After using it for quite some time, I was wondering if the UX could be improved:
- press backspace to go 1 folder backwards (if current prompt is empty)
- press tab to auto-complete the search (even though enter key works), I always seemed to tap on tab instead of enter since I want to auto complete directory (like in fish or any other auto completions)
- it would be better to show a version with the path in the prompt

Like in doom emacs, at least I find that UX straightforward even when I don't use it for long time.

---

Side note, lately our help box is growing, I am thinking to organize it to differentiate sub pickers (like space w) as seen in doom emacs.