### PR TITLE
don't mark all missing nodes as named

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1086,7 +1086,7 @@ pub fn pretty_print_tree<W: fmt::Write>(fmt: &mut W, node: Node) -> fmt::Result 
 }
 
 fn node_is_visible(node: &Node) -> bool {
-    node.is_missing() || (node.is_named() && node.grammar().node_kind_is_visible(node.kind_id()))
+    node.is_named() && node.grammar().node_kind_is_visible(node.kind_id())
 }
 
 fn format_anonymous_node_kind(kind: &str) -> Cow<'_, str> {


### PR DESCRIPTION
previously all nodes marked as missing were then printed like named nodes, i.e. `({name})`, which results in, for example, the following:

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/20867664-1700-40dc-87d8-7dafc8a26495" />

where the missing `";"` is treated as a named node `(;)`, which is not valid syntax, which causes the highlighting to die.

with this pr, the missing `";"` is correctly treated as an anonymous node:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/14cf2a50-4e02-44da-80b1-21a97759bd4e" />
