### PR TITLE
Add `regal` language server to `rego` language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -229,7 +229,7 @@
 | r | ✓ |  |  |  |  | `R` |
 | racket | ✓ |  | ✓ |  | ✓ | `racket` |
 | regex | ✓ |  |  |  | ✓ |  |
-| rego | ✓ |  |  |  |  | `regols` |
+| rego | ✓ |  |  |  |  | `regols`, `regal` |
 | rescript | ✓ | ✓ |  |  |  | `rescript-language-server` |
 | ripple | ✓ |  |  | ✓ | ✓ | `ripple-language-server` |
 | rmarkdown | ✓ |  | ✓ |  |  | `R` |

--- a/languages.toml
+++ b/languages.toml
@@ -207,6 +207,11 @@ command = "golangci-lint-langserver"
 [language-server.golangci-lint-lsp.config]
 command = ["golangci-lint", "run", "--output.json.path=stdout", "--show-stats=false", "--issues-exit-code=1"]
 
+[language-server.regal]
+command = "regal"
+args = ["language-server"]
+config = { provideFormatter = true }
+
 [language-server.rust-analyzer]
 command = "rust-analyzer"
 
@@ -3593,9 +3598,10 @@ name = "rego"
 scope = "source.rego"
 injection-regex = "rego"
 file-types = ["rego"]
+roots = [".regal/config.yaml", ".regal.yaml"]
 auto-format = true
 comment-token = "#"
-language-servers = [ "regols" ]
+language-servers = [ "regols", "regal" ]
 grammar = "rego"
 
 [[grammar]]


### PR DESCRIPTION
Configuration copied from the projects own documentation on integrating the tool with Helix
<https://www.openpolicyagent.org/projects/regal/editor-support#helix>