### PR TITLE
Update wolf-alabaster themes: distinguish definitions from usages

### DIFF
--- a/runtime/themes/wolf-alabaster-dark-bg.toml
+++ b/runtime/themes/wolf-alabaster-dark-bg.toml
@@ -38,7 +38,6 @@ inherits = "wolf-alabaster-dark"
 
 # Special cases
 "tag" = { fg = "fg", bg = "definition-bg" }
-"namespace" = { fg = "fg", bg = "definition-bg" }
 
 # MARKUP overrides
 "markup.heading" = { fg = "fg", bg = "definition-bg", modifiers = ["bold"] }

--- a/runtime/themes/wolf-alabaster-dark.toml
+++ b/runtime/themes/wolf-alabaster-dark.toml
@@ -35,7 +35,12 @@ diagnostic = { underline = { style = "curl" } }
 
 "ui.cursor" = { bg = "cursor-secondary", fg = "bg" }
 "ui.cursor.primary" = { bg = "active", fg = "bg" }
-"ui.cursor.match" = { bg = "highlight" }
+# Bracket matching: Helix only styles the *other* bracket via ui.match, not the one
+# under the cursor. ui.cursor.match affects cursor appearance, not the bracket itself.
+# Following tonsky's Sublime approach (blue + underline) as closely as Helix allows.
+"ui.cursor.match" = { fg = "active", underline = { style = "line" } }
+"ui.match" = { fg = "active", underline = { style = "line" } }
+"ui.cursorline.primary" = { bg = "cursorline-primary" }
 "ui.cursorline" = { bg = "cursorline" }
 "ui.cursorcolumn" = { bg = "cursorline" }
 
@@ -165,7 +170,8 @@ cursor-secondary = "#7A5B30"  # Dimmed gold - secondary cursors (multi-cursor)
 highlight = "#FF9800"    # Orange - search, warnings
 error-red = "#DFDF8E"    # Yellow - errors (use comment color for visibility)
 panel = "#252526"        # Slightly lighter grey - UI panels, menus, popups
-cursorline = "#1A2022"   # Subtle highlight - cursorline, ruler
+cursorline = "#141819"   # Subtle highlight - secondary cursorline
+cursorline-primary = "#1A2022"  # Primary cursorline (tonsky's original)
 jump-label = "#FF6B35"   # Bright orange - jump destinations
 inlay-hint = "#4A7090"   # Dimmed blue - virtual text (type hints)
 

--- a/runtime/themes/wolf-alabaster-dark.toml
+++ b/runtime/themes/wolf-alabaster-dark.toml
@@ -33,7 +33,7 @@ diagnostic = { underline = { style = "curl" } }
 "ui.text" = { fg = "fg" }
 "ui.text.focus" = { fg = "active", modifiers = ["bold"] }
 
-"ui.cursor" = { bg = "active", fg = "bg" }
+"ui.cursor" = { bg = "cursor-secondary", fg = "bg" }
 "ui.cursor.primary" = { bg = "active", fg = "bg" }
 "ui.cursor.match" = { bg = "highlight" }
 "ui.cursorline" = { bg = "cursorline" }
@@ -96,12 +96,17 @@ diagnostic = { underline = { style = "curl" } }
 "comment.block" = { fg = "comment" }
 
 "function" = { fg = "definition" }
-"function.builtin" = { fg = "definition" }
+# Helix uses function.builtin only at call sites (no builtin definitions exist),
+# so we treat it as a call—unhighlighted per tonsky's philosophy.
+"function.builtin" = { fg = "fg" }
 "function.method" = { fg = "definition" }
+"function.call" = { fg = "fg" }
+"function.method.call" = { fg = "fg" }
 
 "constructor" = { fg = "definition" }
-"type" = { fg = "definition" }
-"type.builtin" = { fg = "definition" }
+"type" = { fg = "fg" }
+"type.definition" = { fg = "definition" }
+"type.builtin" = { fg = "fg" }
 
 # These are NOT highlighted (Alabaster philosophy: keywords are obvious)
 "keyword" = { fg = "fg" }
@@ -122,7 +127,7 @@ diagnostic = { underline = { style = "curl" } }
 "tag" = { fg = "definition" }
 "tag.error" = { fg = "error-red", underline = { style = "line" } }
 "attribute" = { fg = "fg" }
-"namespace" = { fg = "definition" }
+"namespace" = { fg = "fg" }
 "label" = { fg = "constant" }
 
 # MARKUP - For markdown/documentation
@@ -156,6 +161,7 @@ punctuation = "#8C8C8C"  # Grey - dimmed operators/brackets
 selection = "#1E3A5F"    # Very dark blue - secondary selections (subtle)
 selection-primary = "#4A7BA7"  # Bright blue - primary selection (clearly distinct)
 active = "#CD974B"       # Golden brown - cursor, active elements (original Alabaster Dark)
+cursor-secondary = "#7A5B30"  # Dimmed gold - secondary cursors (multi-cursor)
 highlight = "#FF9800"    # Orange - search, warnings
 error-red = "#DFDF8E"    # Yellow - errors (use comment color for visibility)
 panel = "#252526"        # Slightly lighter grey - UI panels, menus, popups

--- a/runtime/themes/wolf-alabaster-light-bg.toml
+++ b/runtime/themes/wolf-alabaster-light-bg.toml
@@ -40,7 +40,6 @@ inherits = "wolf-alabaster-light"
 
 # Special cases
 "tag" = { fg = "fg", bg = "definition-bg" }
-"namespace" = { fg = "fg", bg = "definition-bg" }
 
 # MARKUP overrides
 "markup.heading" = { fg = "fg", bg = "definition-bg", modifiers = ["bold"] }

--- a/runtime/themes/wolf-alabaster-light.toml
+++ b/runtime/themes/wolf-alabaster-light.toml
@@ -35,7 +35,12 @@ diagnostic = { underline = { style = "curl" } }
 
 "ui.cursor" = { bg = "cursor-secondary", fg = "bg" }
 "ui.cursor.primary" = { bg = "active", fg = "bg" }
-"ui.cursor.match" = { bg = "highlight" }
+# Bracket matching: Helix only styles the *other* bracket via ui.match, not the one
+# under the cursor. ui.cursor.match affects cursor appearance, not the bracket itself.
+# Following tonsky's Sublime approach (blue + underline) as closely as Helix allows.
+"ui.cursor.match" = { fg = "active", underline = { style = "line" } }
+"ui.match" = { fg = "active", underline = { style = "line" } }
+"ui.cursorline.primary" = { bg = "cursorline-primary" }
 "ui.cursorline" = { bg = "cursorline" }
 "ui.cursorcolumn" = { bg = "cursorline" }
 
@@ -165,7 +170,8 @@ cursor-secondary = "#5A9DC4"  # Dimmed blue - secondary cursors (multi-cursor)
 highlight = "#FFBC5D"    # Orange - search, warnings
 error-red = "#AA3731"    # Red - errors
 panel = "#EEEEEE"        # Darker grey - UI panels, menus, popups
-cursorline = "#EFEFEF"   # Subtle highlight - cursorline, ruler
+cursorline = "#F3F3F3"   # Subtle highlight - secondary cursorline
+cursorline-primary = "#EFEFEF"  # Primary cursorline (tonsky's original)
 jump-label = "#FF4500"   # Bright orange-red - jump destinations
 inlay-hint = "#8090B8"   # Dimmed blue - virtual text (type hints)
 

--- a/runtime/themes/wolf-alabaster-light.toml
+++ b/runtime/themes/wolf-alabaster-light.toml
@@ -33,7 +33,7 @@ diagnostic = { underline = { style = "curl" } }
 "ui.text" = { fg = "fg" }
 "ui.text.focus" = { fg = "active", modifiers = ["bold"] }
 
-"ui.cursor" = { bg = "active", fg = "bg" }
+"ui.cursor" = { bg = "cursor-secondary", fg = "bg" }
 "ui.cursor.primary" = { bg = "active", fg = "bg" }
 "ui.cursor.match" = { bg = "highlight" }
 "ui.cursorline" = { bg = "cursorline" }
@@ -96,12 +96,17 @@ diagnostic = { underline = { style = "curl" } }
 "comment.block" = { fg = "comment" }
 
 "function" = { fg = "definition" }
-"function.builtin" = { fg = "definition" }
+# Helix uses function.builtin only at call sites (no builtin definitions exist),
+# so we treat it as a call—unhighlighted per tonsky's philosophy.
+"function.builtin" = { fg = "fg" }
 "function.method" = { fg = "definition" }
+"function.call" = { fg = "fg" }
+"function.method.call" = { fg = "fg" }
 
 "constructor" = { fg = "definition" }
-"type" = { fg = "definition" }
-"type.builtin" = { fg = "definition" }
+"type" = { fg = "fg" }
+"type.definition" = { fg = "definition" }
+"type.builtin" = { fg = "fg" }
 
 # These are NOT highlighted (Alabaster philosophy: keywords are obvious)
 "keyword" = { fg = "fg" }
@@ -122,7 +127,7 @@ diagnostic = { underline = { style = "curl" } }
 "tag" = { fg = "definition" }
 "tag.error" = { fg = "error-red", underline = { style = "line" } }
 "attribute" = { fg = "fg" }
-"namespace" = { fg = "definition" }
+"namespace" = { fg = "fg" }
 "label" = { fg = "constant" }
 
 # MARKUP - For markdown/documentation
@@ -156,6 +161,7 @@ punctuation = "#777777"  # Grey - dimmed operators/brackets
 selection = "#DDE7ED"    # Light gray-blue - secondary selections (subtle but distinct)
 selection-primary = "#BFDBFE"  # Light blue - primary selection (original Alabaster)
 active = "#007ACC"       # Bright blue - cursor, active elements
+cursor-secondary = "#5A9DC4"  # Dimmed blue - secondary cursors (multi-cursor)
 highlight = "#FFBC5D"    # Orange - search, warnings
 error-red = "#AA3731"    # Red - errors
 panel = "#EEEEEE"        # Darker grey - UI panels, menus, popups


### PR DESCRIPTION
## Summary

Updates the wolf-alabaster themes to better align with the [Alabaster philosophy](https://tonsky.me/blog/syntax-highlighting/): only definitions get color, not usages.

## Changes

- **Cursor**: Differentiate secondary cursors from primary (new `cursor-secondary` color)
- **Functions**: Don't highlight function calls (`function.call`, `function.method.call` = fg)
- **Builtins**: Don't highlight builtin function calls (`function.builtin` = fg)
- **Types**: Don't highlight type usages (`type` = fg), only definitions (`type.definition`)
- **Namespaces**: Don't highlight namespace usages (`namespace` = fg)

## Related

- Works best with query changes from #15185 (adds `@type.definition` and `@function.call` scopes)
- See #15184 for discussion on `@constructor` scope semantics

## Test plan

- [x] Tested with Rust, Python, JavaScript, and TypeScript files
- [x] Verified cursor differentiation in multi-cursor mode