### PR TITLE
goto_hover action

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -214,6 +214,7 @@
 | `remove_primary_selection` | Remove primary selection | normal: `` <A-,> ``, select: `` <A-,> `` |
 | `completion` | Invoke completion popup | insert: `` <C-x> `` |
 | `hover` | Show docs for item under cursor | normal: `` <space>k ``, select: `` <space>k `` |
+| `goto_hover` | Show docs for item under cursor in a buffer |  |
 | `toggle_comments` | Comment/uncomment selections | normal: `` <C-c> ``, `` <space>c ``, select: `` <C-c> ``, `` <space>c `` |
 | `toggle_line_comments` | Line comment/uncomment selections | normal: `` <space><A-c> ``, select: `` <space><A-c> `` |
 | `toggle_block_comments` | Block comment/uncomment selections | normal: `` <space>C ``, select: `` <space>C `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -517,6 +517,7 @@ impl MappableCommand {
         remove_primary_selection, "Remove primary selection",
         completion, "Invoke completion popup",
         hover, "Show docs for item under cursor",
+        goto_hover, "Show docs for item under cursor in a buffer",
         toggle_comments, "Comment/uncomment selections",
         toggle_line_comments, "Line comment/uncomment selections",
         toggle_block_comments, "Block comment/uncomment selections",

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -34,7 +34,6 @@ use crate::{
 };
 
 use std::{
-    cmp::Ordering,
     collections::{HashSet, VecDeque},
     fmt::Display,
     future::Future,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -15,7 +15,7 @@ use super::{align_view, push_jump, Align, Context, Editor};
 
 use helix_core::{
     diagnostic::DiagnosticProvider, syntax::config::LanguageServerFeature,
-    text_annotations::InlineAnnotation, Selection, Uri,
+    text_annotations::InlineAnnotation, Rope, Selection, Uri,
 };
 use helix_stdx::path;
 use helix_view::{
@@ -34,10 +34,12 @@ use crate::{
 };
 
 use std::{
+    cmp::Ordering,
     collections::{HashSet, VecDeque},
     fmt::Display,
     future::Future,
     path::Path,
+    sync::Arc,
 };
 
 /// Gets the first language server that is attached to a document which supports a specific feature.
@@ -1092,7 +1094,20 @@ pub fn signature_help(cx: &mut Context) {
         .trigger_signature_help(SignatureHelpInvoked::Manual, cx.editor)
 }
 
+enum HoverDisplay {
+    Popup,
+    File,
+}
+
 pub fn hover(cx: &mut Context) {
+    hover_impl(cx, HoverDisplay::Popup)
+}
+
+pub fn goto_hover(cx: &mut Context) {
+    hover_impl(cx, HoverDisplay::File)
+}
+
+fn hover_impl(cx: &mut Context, hover_action: HoverDisplay) {
     use ui::lsp::hover::Hover;
 
     let (view, doc) = current!(cx.editor);
@@ -1139,10 +1154,29 @@ pub fn hover(cx: &mut Context) {
                 return;
             }
 
-            // create new popup
-            let contents = Hover::new(hovers, editor.syn_loader.clone());
-            let popup = Popup::new(Hover::ID, contents).auto_close(true);
-            compositor.replace_or_push(Hover::ID, popup);
+            let hover = Hover::new(hovers, editor.syn_loader.clone());
+
+            match hover_action {
+                HoverDisplay::Popup => {
+                    let popup = Popup::new(Hover::ID, hover).auto_close(true);
+                    compositor.replace_or_push(Hover::ID, popup);
+                }
+                HoverDisplay::File => {
+                    editor.new_file_from_document(
+                        Action::Replace,
+                        Document::from(
+                            Rope::from(hover.content_string()),
+                            None,
+                            Arc::clone(&editor.config),
+                            Arc::clone(&editor.syn_loader),
+                        ),
+                    );
+                    let hover_doc = doc_mut!(editor);
+
+                    let _ = hover_doc
+                        .set_language_by_language_id("markdown", &editor.syn_loader.load());
+                }
+            }
         };
         Ok(Callback::EditorCompositor(Box::new(call)))
     });

--- a/helix-term/src/ui/lsp/hover.rs
+++ b/helix-term/src/ui/lsp/hover.rs
@@ -58,6 +58,22 @@ impl Hover {
         &self.contents[self.active_index]
     }
 
+    pub fn content_string(&self) -> String {
+        self.contents
+            .iter()
+            .map(|(header, body)| {
+                let header: String = header
+                    .iter()
+                    .map(|header| header.contents.clone())
+                    .collect();
+
+                format!("{}{}", header, body.contents)
+            })
+            .collect::<Vec<String>>()
+            .join("\n\n---\n\n")
+            + "\n"
+    }
+
     fn set_index(&mut self, index: usize) {
         assert!((0..self.contents.len()).contains(&index));
         self.active_index = index;

--- a/helix-term/src/ui/lsp/hover.rs
+++ b/helix-term/src/ui/lsp/hover.rs
@@ -62,12 +62,11 @@ impl Hover {
         self.contents
             .iter()
             .map(|(header, body)| {
-                let header: String = header
-                    .iter()
-                    .map(|header| header.contents.clone())
-                    .collect();
-
-                format!("{}{}", header, body.contents)
+                if let Some(header) = header {
+                    format!("{}\n{}", header.contents.trim(), body.contents.trim())
+                } else {
+                    body.contents.trim().to_owned()
+                }
             })
             .collect::<Vec<String>>()
             .join("\n\n---\n\n")

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -138,7 +138,7 @@ pub fn highlighted_code_block<'a>(
 }
 
 pub struct Markdown {
-    contents: String,
+    pub contents: String,
 
     config_loader: Arc<ArcSwap<syntax::Loader>>,
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1862,7 +1862,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2061,7 +2061,7 @@ impl Editor {
         id
     }
 
-    fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
+    pub fn new_file_from_document(&mut self, action: Action, doc: Document) -> DocumentId {
         let id = self.new_document(doc);
         self.switch(id, action);
         id


### PR DESCRIPTION
This is the reawakening of #12208 by @nik-rev.

I'd love to just cherry pick nik's commits, but because he was using a merge focused workflow, extracting his changes is a bit of a massive pain.

So I collected his code as best as I could, and made him the author of the commit. Because I needed to collect things around, I add myself as a co-author.

Commits that go after are *my* changes specifically. I'm the only author in those.

---

New `goto_hover` action, that opens `hover` in a new scratch buffer, for you to view.

I excluded adding *bindings* for the new `goto_hover` command like the initial pr *I think* does, because it makes this pr a harder sell to merge, for little benefit.
