### PR TITLE
enable-diagnostics option

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -192,19 +192,24 @@ impl EditorView {
                 primary_cursor,
             });
         }
-        let width = view.inner_width(doc);
         let config = doc.config.load();
-        let enable_cursor_line = view
-            .diagnostics_handler
-            .show_cursorline_diagnostics(doc, view.id);
-        let inline_diagnostic_config = config.inline_diagnostics.prepare(width, enable_cursor_line);
-        decorations.add_decoration(InlineDiagnostics::new(
-            doc,
-            theme,
-            primary_cursor,
-            inline_diagnostic_config,
-            config.end_of_line_diagnostics,
-        ));
+
+        if config.enable_diagnostics {
+            let width = view.inner_width(doc);
+            let enable_cursor_line = view
+                .diagnostics_handler
+                .show_cursorline_diagnostics(doc, view.id);
+            let inline_diagnostic_config =
+                config.inline_diagnostics.prepare(width, enable_cursor_line);
+            decorations.add_decoration(InlineDiagnostics::new(
+                doc,
+                theme,
+                primary_cursor,
+                inline_diagnostic_config,
+                config.end_of_line_diagnostics,
+            ));
+        }
+
         render_document(
             surface,
             inner,
@@ -229,7 +234,8 @@ impl EditorView {
             }
         }
 
-        if config.inline_diagnostics.disabled()
+        if config.enable_diagnostics
+            && config.inline_diagnostics.disabled()
             && config.end_of_line_diagnostics == DiagnosticFilter::Disable
         {
             Self::render_diagnostics(doc, view, inner, surface, theme);

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -194,19 +194,19 @@ impl EditorView {
         }
         let config = doc.config.load();
 
-        if config.enable_diagnostics {
+        if config.diagnostics.enable {
             let width = view.inner_width(doc);
             let enable_cursor_line = view
                 .diagnostics_handler
                 .show_cursorline_diagnostics(doc, view.id);
             let inline_diagnostic_config =
-                config.inline_diagnostics.prepare(width, enable_cursor_line);
+                config.diagnostics.inline.prepare(width, enable_cursor_line);
             decorations.add_decoration(InlineDiagnostics::new(
                 doc,
                 theme,
                 primary_cursor,
                 inline_diagnostic_config,
-                config.end_of_line_diagnostics,
+                config.diagnostics.end_of_line,
             ));
         }
 
@@ -234,9 +234,9 @@ impl EditorView {
             }
         }
 
-        if config.enable_diagnostics
-            && config.inline_diagnostics.disabled()
-            && config.end_of_line_diagnostics == DiagnosticFilter::Disable
+        if config.diagnostics.enable
+            && config.diagnostics.inline.disabled()
+            && config.diagnostics.end_of_line == DiagnosticFilter::Disable
         {
             Self::render_diagnostics(doc, view, inner, surface, theme);
         }

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -6,11 +6,35 @@ use serde::{Deserialize, Serialize};
 
 use crate::Document;
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DiagnosticsConfig {
+    pub enable: bool,
+    pub inline: InlineDiagnosticsConfig,
+    pub end_of_line: DiagnosticFilter,
+}
+
+impl Default for DiagnosticsConfig {
+    fn default() -> Self {
+        Self {
+            enable: true,
+            inline: InlineDiagnosticsConfig::default(),
+            end_of_line: DiagnosticFilter::default(),
+        }
+    }
+}
+
 /// Describes the severity level of a [`Diagnostic`].
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
 pub enum DiagnosticFilter {
     Disable,
     Enable(Severity),
+}
+
+impl Default for DiagnosticFilter {
+    fn default() -> Self {
+        Self::Enable(Severity::Hint)
+    }
 }
 
 impl<'de> Deserialize<'de> for DiagnosticFilter {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1,5 +1,5 @@
 use crate::{
-    annotations::diagnostics::{DiagnosticFilter, InlineDiagnosticsConfig},
+    annotations::diagnostics::DiagnosticsConfig,
     clipboard::ClipboardProvider,
     document::{
         DocumentOpenError, DocumentSavedEventFuture, DocumentSavedEventResult, Mode, SavePoint,
@@ -419,10 +419,7 @@ pub struct Config {
         deserialize_with = "deserialize_alphabet"
     )]
     pub jump_label_alphabet: Vec<char>,
-    pub enable_diagnostics: bool,
-    /// Display diagnostic below the line they occur.
-    pub inline_diagnostics: InlineDiagnosticsConfig,
-    pub end_of_line_diagnostics: DiagnosticFilter,
+    pub diagnostics: DiagnosticsConfig,
     // Set to override the default clipboard provider
     pub clipboard_provider: ClipboardProvider,
     /// Whether to read settings from [EditorConfig](https://editorconfig.org) files. Defaults to
@@ -1233,9 +1230,7 @@ impl Default for Config {
             popup_border: PopupBorderConfig::None,
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
-            enable_diagnostics: true,
-            inline_diagnostics: InlineDiagnosticsConfig::default(),
-            end_of_line_diagnostics: DiagnosticFilter::Enable(Severity::Hint),
+            diagnostics: DiagnosticsConfig::default(),
             clipboard_provider: ClipboardProvider::default(),
             editor_config: true,
             rainbow_brackets: false,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -419,6 +419,7 @@ pub struct Config {
         deserialize_with = "deserialize_alphabet"
     )]
     pub jump_label_alphabet: Vec<char>,
+    pub enable_diagnostics: bool,
     /// Display diagnostic below the line they occur.
     pub inline_diagnostics: InlineDiagnosticsConfig,
     pub end_of_line_diagnostics: DiagnosticFilter,
@@ -1232,6 +1233,7 @@ impl Default for Config {
             popup_border: PopupBorderConfig::None,
             indent_heuristic: IndentationHeuristic::default(),
             jump_label_alphabet: ('a'..='z').collect(),
+            enable_diagnostics: true,
             inline_diagnostics: InlineDiagnosticsConfig::default(),
             end_of_line_diagnostics: DiagnosticFilter::Enable(Severity::Hint),
             clipboard_provider: ClipboardProvider::default(),

--- a/helix-view/src/handlers/diagnostics.rs
+++ b/helix-view/src/handlers/diagnostics.rs
@@ -105,7 +105,7 @@ impl DiagnosticsHandler {
             .store(self.generation.get(), atomic::Ordering::Relaxed);
     }
     pub fn show_cursorline_diagnostics(&self, doc: &Document, view: ViewId) -> bool {
-        if !self.active {
+        if !self.active || !doc.config.load().enable_diagnostics {
             return false;
         }
         let cursor_line = doc

--- a/helix-view/src/handlers/diagnostics.rs
+++ b/helix-view/src/handlers/diagnostics.rs
@@ -105,7 +105,7 @@ impl DiagnosticsHandler {
             .store(self.generation.get(), atomic::Ordering::Relaxed);
     }
     pub fn show_cursorline_diagnostics(&self, doc: &Document, view: ViewId) -> bool {
-        if !self.active || !doc.config.load().enable_diagnostics {
+        if !self.active || !doc.config.load().diagnostics.enable {
             return false;
         }
         let cursor_line = doc

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -513,8 +513,10 @@ impl View {
         let enable_cursor_line = self
             .diagnostics_handler
             .show_cursorline_diagnostics(doc, self.id);
-        let config = config.inline_diagnostics.prepare(width, enable_cursor_line);
-        if !config.disabled() {
+        let enable_diagnostics = config.enable_diagnostics;
+        let inline_diagnotstics_config =
+            config.inline_diagnostics.prepare(width, enable_cursor_line);
+        if !inline_diagnotstics_config.disabled() && enable_diagnostics {
             let cursor = doc
                 .selection(self.id)
                 .primary()
@@ -524,7 +526,7 @@ impl View {
                 cursor,
                 width,
                 doc.view_offset(self.id).horizontal_offset,
-                config,
+                inline_diagnotstics_config,
             ));
         }
 

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -513,9 +513,9 @@ impl View {
         let enable_cursor_line = self
             .diagnostics_handler
             .show_cursorline_diagnostics(doc, self.id);
-        let enable_diagnostics = config.enable_diagnostics;
+        let enable_diagnostics = config.diagnostics.enable;
         let inline_diagnotstics_config =
-            config.inline_diagnostics.prepare(width, enable_cursor_line);
+            config.diagnostics.inline.prepare(width, enable_cursor_line);
         if !inline_diagnotstics_config.disabled() && enable_diagnostics {
             let cursor = doc
                 .selection(self.id)


### PR DESCRIPTION
Combine all diagnostics options into a struct.

Previously:
```
editor {
   inline-diagnostics: {
      …
   }
   end-of-line-diagnostics: …
}
```

Now:
```
editor {
   diagnostics {
      enable: bool
      inline: {
         …
      }
      end-of-line: …
   }
}
```

New `diagnostics.enable` option that allows you to toggle showing any diagnostics. Rather than having to individually change the two diagnostic variants.

# old pr body

Reopening #12203 by @nik-rev, taking on maintaining this pr.

I took the final form of the pr's diff into a single commit¹, and attributed nik as the author of it. I haven't needed to actually *change* any of the code.

¹ Easier this way so that I only need to solve merge conflicts with the latest diff of the pr, rather than every commit that comes before it.

---

`enable-diagnostics` option, that lets you easily toggle showing diagnostics globally. \
`true` by default.