### PR TITLE
goto_word does save_selection before making the jump

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6867,6 +6867,7 @@ fn jump_to_label(cx: &mut Context, labels: Vec<Range>, behaviour: Movement) {
                 } else {
                     range.with_direction(Direction::Forward)
                 };
+                save_selection(cx);
                 doc_mut!(cx.editor, &doc).set_selection(view, range.into());
             }
         });


### PR DESCRIPTION
Notably, `save_selection` doesn't happen if you cancel the jump with <kbd>Escape</kbd>. \
The userland hotkey of `gw = [save_selection, goto_word]` cannot achieve this: it will `save_selection` regardless of if you cancel the jump or not.