### PR TITLE
languages(js): recognize `.gs` as javascript file

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -909,7 +909,7 @@ name = "javascript"
 scope = "source.js"
 injection-regex = "(js|javascript)"
 language-id = "javascript"
-file-types = ["js", "mjs", "cjs", "rules", "es6", "pac", { glob = ".node_repl_history" }, { glob = "jakefile" }]
+file-types = ["js", "mjs", "cjs", "rules", "es6", "pac", "gs", { glob = ".node_repl_history" }, { glob = "jakefile" }]
 shebangs = ["node"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"


### PR DESCRIPTION
.gs is used by Google AppScripts.

> Apps Script is a cloud-based JavaScript platform powered by Google Drive that lets you integrate with and automate tasks across Google products.

quoted from the official website.