### PR TITLE
paste multiple selections at once

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -198,6 +198,8 @@
 | `replace_selections_with_primary_clipboard` | Replace selections by primary clipboard |  |
 | `paste_after` | Paste after selection | normal: `` p ``, select: `` p `` |
 | `paste_before` | Paste before selection | normal: `` P ``, select: `` P `` |
+| `paste_after_all` | Paste all after selection |  |
+| `paste_before_all` | Paste all before selection |  |
 | `paste_clipboard_after` | Paste clipboard after selections | normal: `` <space>p ``, select: `` <space>p `` |
 | `paste_clipboard_before` | Paste clipboard before selections | normal: `` <space>P ``, select: `` <space>P `` |
 | `paste_primary_clipboard_after` | Paste primary clipboard after selections |  |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -501,6 +501,8 @@ impl MappableCommand {
         replace_selections_with_primary_clipboard, "Replace selections by primary clipboard",
         paste_after, "Paste after selection",
         paste_before, "Paste before selection",
+        paste_after_all, "Paste all after selection",
+        paste_before_all, "Paste all before selection",
         paste_clipboard_after, "Paste clipboard after selections",
         paste_clipboard_before, "Paste clipboard before selections",
         paste_primary_clipboard_after, "Paste primary clipboard after selections",
@@ -4938,6 +4940,15 @@ pub(crate) enum Paste {
 
 static LINE_ENDING_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"\r\n|\r|\n").unwrap());
 
+/// Enumerates the possible ways to paste
+#[derive(Copy, Clone)]
+enum PasteType {
+    /// Paste one value in the register per selection
+    Default,
+    /// Paste every value in the register for every selection
+    All,
+}
+
 fn paste_impl(
     values: &[String],
     doc: &mut Document,
@@ -4945,6 +4956,7 @@ fn paste_impl(
     action: Paste,
     count: usize,
     mode: Mode,
+    paste_type: PasteType,
 ) {
     if values.is_empty() {
         return;
@@ -4973,13 +4985,26 @@ fn paste_impl(
         map_value(values.last().unwrap()),
     );
 
-    let mut values = values.iter().map(|value| map_value(value)).chain(repeat);
+    let mut values_iter = values.iter().map(|value| map_value(value)).chain(repeat);
 
     let text = doc.text();
     let selection = doc.selection(view.id);
 
     let mut offset = 0;
     let mut ranges = SmallVec::with_capacity(selection.len());
+
+    // Precompute the combined tendril value if we will be doing a PasteType::All
+    let combined_tendril_value = match paste_type {
+        PasteType::All => Some(
+            values
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join("\n")
+                .into(),
+        ),
+        PasteType::Default => None,
+    };
 
     let mut transaction = Transaction::change_by_selection(text, selection, |range| {
         let pos = match (action, linewise) {
@@ -4998,17 +5023,38 @@ fn paste_impl(
             (Paste::Cursor, _) => range.cursor(text.slice(..)),
         };
 
-        let value = values.next();
+        let value = match paste_type {
+            PasteType::All => {
+                // Iterate over every value and add its range
+                for value in values {
+                    let value_len = value.chars().count();
+                    let anchor = offset + pos;
 
-        let value_len = value
-            .as_ref()
-            .map(|content| content.chars().count())
-            .unwrap_or_default();
-        let anchor = offset + pos;
+                    let new_range =
+                        Range::new(anchor, anchor + value_len).with_direction(range.direction());
+                    ranges.push(new_range);
+                    offset += value_len + 1;
+                }
 
-        let new_range = Range::new(anchor, anchor + value_len).with_direction(range.direction());
-        ranges.push(new_range);
-        offset += value_len;
+                // Return the precomputed tendril value
+                combined_tendril_value.clone()
+            }
+            PasteType::Default => {
+                let value = values_iter.next();
+
+                let value_len = value
+                    .as_ref()
+                    .map(|content| content.chars().count())
+                    .unwrap_or_default();
+                let anchor = offset + pos;
+
+                let new_range =
+                    Range::new(anchor, anchor + value_len).with_direction(range.direction());
+                ranges.push(new_range);
+                offset += value_len;
+                value
+            }
+        };
 
         (pos, pos, value)
     });
@@ -5028,27 +5074,47 @@ pub(crate) fn paste_bracketed_value(cx: &mut Context, contents: String) {
         Mode::Normal => Paste::Before,
     };
     let (view, doc) = current!(cx.editor);
-    paste_impl(&[contents], doc, view, paste, count, cx.editor.mode);
+    paste_impl(
+        &[contents],
+        doc,
+        view,
+        paste,
+        count,
+        cx.editor.mode,
+        PasteType::Default,
+    );
     exit_select_mode(cx);
 }
 
 fn paste_clipboard_after(cx: &mut Context) {
-    paste(cx.editor, '+', Paste::After, cx.count());
+    paste(cx.editor, '+', Paste::After, cx.count(), PasteType::Default);
     exit_select_mode(cx);
 }
 
 fn paste_clipboard_before(cx: &mut Context) {
-    paste(cx.editor, '+', Paste::Before, cx.count());
+    paste(
+        cx.editor,
+        '+',
+        Paste::Before,
+        cx.count(),
+        PasteType::Default,
+    );
     exit_select_mode(cx);
 }
 
 fn paste_primary_clipboard_after(cx: &mut Context) {
-    paste(cx.editor, '*', Paste::After, cx.count());
+    paste(cx.editor, '*', Paste::After, cx.count(), PasteType::Default);
     exit_select_mode(cx);
 }
 
 fn paste_primary_clipboard_before(cx: &mut Context) {
-    paste(cx.editor, '*', Paste::Before, cx.count());
+    paste(
+        cx.editor,
+        '*',
+        Paste::Before,
+        cx.count(),
+        PasteType::Default,
+    );
     exit_select_mode(cx);
 }
 
@@ -5115,14 +5181,44 @@ fn replace_selections_with_primary_clipboard(cx: &mut Context) {
     exit_select_mode(cx);
 }
 
-pub(crate) fn paste(editor: &mut Editor, register: char, pos: Paste, count: usize) {
+pub(crate) fn paste(
+    editor: &mut Editor,
+    register: char,
+    pos: Paste,
+    count: usize,
+    paste_type: PasteType,
+) {
     let Some(values) = editor.registers.read(register, editor) else {
         return;
     };
     let values: Vec<_> = values.map(|value| value.to_string()).collect();
 
     let (view, doc) = current!(editor);
-    paste_impl(&values, doc, view, pos, count, editor.mode);
+    paste_impl(&values, doc, view, pos, count, editor.mode, paste_type);
+}
+
+fn paste_after_all(cx: &mut Context) {
+    paste(
+        cx.editor,
+        cx.register
+            .unwrap_or(cx.editor.config().default_yank_register),
+        Paste::After,
+        cx.count(),
+        PasteType::All,
+    );
+    exit_select_mode(cx);
+}
+
+fn paste_before_all(cx: &mut Context) {
+    paste(
+        cx.editor,
+        cx.register
+            .unwrap_or(cx.editor.config().default_yank_register),
+        Paste::Before,
+        cx.count(),
+        PasteType::All,
+    );
+    exit_select_mode(cx);
 }
 
 fn paste_after(cx: &mut Context) {
@@ -5132,6 +5228,7 @@ fn paste_after(cx: &mut Context) {
             .unwrap_or(cx.editor.config().default_yank_register),
         Paste::After,
         cx.count(),
+        PasteType::Default,
     );
     exit_select_mode(cx);
 }
@@ -5143,6 +5240,7 @@ fn paste_before(cx: &mut Context) {
             .unwrap_or(cx.editor.config().default_yank_register),
         Paste::Before,
         cx.count(),
+        PasteType::Default,
     );
     exit_select_mode(cx);
 }
@@ -6065,6 +6163,7 @@ fn insert_register(cx: &mut Context) {
                     .unwrap_or(cx.editor.config().default_yank_register),
                 Paste::Cursor,
                 count,
+                PasteType::Default,
             );
         }
     })

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1229,7 +1229,7 @@ fn paste_clipboard_after(
         return Ok(());
     }
 
-    paste(cx.editor, '+', Paste::After, 1);
+    paste(cx.editor, '+', Paste::After, 1, PasteType::Default);
     Ok(())
 }
 
@@ -1242,7 +1242,7 @@ fn paste_clipboard_before(
         return Ok(());
     }
 
-    paste(cx.editor, '+', Paste::Before, 1);
+    paste(cx.editor, '+', Paste::Before, 1, PasteType::Default);
     Ok(())
 }
 
@@ -1255,7 +1255,7 @@ fn paste_primary_clipboard_after(
         return Ok(());
     }
 
-    paste(cx.editor, '*', Paste::After, 1);
+    paste(cx.editor, '*', Paste::After, 1, PasteType::Default);
     Ok(())
 }
 
@@ -1268,7 +1268,7 @@ fn paste_primary_clipboard_before(
         return Ok(());
     }
 
-    paste(cx.editor, '*', Paste::Before, 1);
+    paste(cx.editor, '*', Paste::Before, 1, PasteType::Default);
     Ok(())
 }
 


### PR DESCRIPTION
Reawakening of #4694 by @stonewareslord

Say you have this text file, where `{`/`}` denotes a selection's head/cursor, and `[`/`]` denotes a selection's anchor/not-cursor.
```
here is [some} text
with selection [inside} of them
so [that} the example can be made better
```

If you `yank`, `keep_primary_selection`, and try to paste somewhere, only `some` will get pasted.

With the new `paste_before_all` and `paste_after_all` commands, `some`, `inside`, and `that` will all get pasted.

So let's open a scratch buffer and try to `paste_before_all`

```
[some}
[inside}
[that}
```

Note that your selection ranges are ***retained***. Unlike in the #13600 pr by @nik-rev, that merges the selections into one, which is like... what's even the point?

Retaining the selection ranges lets the feature handle mulitline selections correctly. Let's say I wanted to yank multiple selections, to then join them with commas in a scratch buffer.

```
here is [some text
with} selection [inside} of them
so [that} the example can be made better
```

If the pastation was merged, I'd be in a bit of a pickle:

```
[some text
with
inside
that}
```

If I want to end up with `some text with, inside, that`, I can't naively `split_selection_on_newline` — I would then end up adding a comma after `some text`. I can remove that specific selection to avoid the problem, but it becomes a bit of a massive pain once you scale up the example.

But if the selection ranges are *retained*, now there's no issue:

```
[some text
with}
[inside}
[that}
```

I can `remove_primary_selection` on the last selection, then `a,`,

```
[some text
with,}
[inside,}
that
```

And then `join_selections_space` the entire buffer.

```
some text with, inside, that
```

I hope you get my point: retaining selections' ranges makes it a lot easier to multiact on them, once you `paste_all` them. \
Helix is very good at caring about ranges more than lines, and the paste all feature should act no different.

As for why `paste_before_all` doesn't result in this:
```
[some text
with}[inside}[that}
```

That is because helix will collapse the multiple selections into one, if you do `a`. Curiously, it won't do it with `i`. \
The selections need to be separated with *something* to fight against helix's selection merging behavior, and I thought that a newline is a pretty reasonable choice. Note that this joining newline is *not* included in your selections, so you won't need to `trim_selections` first or anything of that nature.

`join_selections_space` plays pretty well with selections pasted this way, even if you make a paste in the middle of some line, rather than a blank line. You can first `paste_before_all`, do the transformations you might wanna do on the selections, then if you wanted to join them with spaces rather than newlines, you just `join_selections_space` and you're done. Surprisingly less edgecasey than I thought it would be.

---

Since the code is mostly by @stonewareslord, I set them as the author of the commit. Because it was a massive pain to update their pr on latest master, I added myself as a co-author :p
