### PR TITLE
Make spacebones info colour more visually distinct

### DIFF
--- a/runtime/themes/spacebones_light.toml
+++ b/runtime/themes/spacebones_light.toml
@@ -77,7 +77,7 @@
 
 "diagnostic.warning" = { underline = { style = "curl", color = "meta" } }
 "diagnostic.error" = { underline = { style = "curl", color = "#e0211d" } }
-"diagnostic.info" = { underline = { style = "curl", color = "theme_yellow" } }
+"diagnostic.info" = { underline = { style = "curl", color = "theme_blue" } }
 "diagnostic.hint" = { underline = { style = "curl", color = "bg2" } }
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }


### PR DESCRIPTION
The current `info` severity colour, `#b1951d`, a dark yellow, I find to be too similar to the warning colour, `#da8b55`, an orange.
