### PR TITLE
languages.toml: Add RobotCode language server for robot

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -119,6 +119,7 @@ racket = { command = "racket", args = ["-l", "racket-langserver"] }
 regols = { command = "regols" }
 rescript-language-server = { command = "rescript-language-server", args = ["--stdio"] }
 ripple-lsp = { command = "ripple-language-server", args = ["--stdio"] }
+robotcode = { command = "robotcode", args = ["language-server", "--stdio"] }
 robotframework_ls = { command = "robotframework_ls" }
 ron-lsp = { command = "ron-lsp" }
 ruff = { command = "ruff", args = ["server"] }
@@ -2388,7 +2389,7 @@ injection-regex = "robot"
 file-types = ["robot", "resource"]
 comment-token = "#"
 indent = { tab-width = 4, unit = " " }
-language-servers = [ "robotframework_ls" ]
+language-servers = [ "robotcode", "robotframework_ls" ]
 
 [[grammar]]
 name = "robot"


### PR DESCRIPTION
This adds the [RobotCode](https://robotcode.io) language server for the Robot Framework language.

This is my first contribution - since I don't have a new enough rust toolchain on my distro, I could not re-generate the book - please let me know if this is required!

Thanks for your great work on Helix!