### PR TITLE
Treat symlinks to dirs as dirs when relevant

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2581,11 +2581,9 @@ fn global_search(cx: &mut Context) {
                             Err(_) => return WalkState::Continue,
                         };
 
-                        match entry.file_type() {
-                            Some(entry) if entry.is_file() => {}
-                            // skip everything else
-                            _ => return WalkState::Continue,
-                        };
+                        if !entry.path().is_file() {
+                            return WalkState::Continue;
+                        }
 
                         let mut stop = false;
                         let sink = sinks::UTF8(|line_num, _line_content| {

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -338,11 +338,9 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
                         Ok(entry) => entry,
                         Err(_) => return WalkState::Continue,
                     };
-                    match entry.file_type() {
-                        Some(entry) if entry.is_file() => {}
-                        // skip everything else
-                        _ => return WalkState::Continue,
-                    };
+                    if !entry.path().is_file() {
+                        return WalkState::Continue;
+                    }
                     let path = entry.path();
                     // If this document is open, skip it because we've already processed it above.
                     if documents.contains(path) {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -244,7 +244,7 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         .build()
         .filter_map(|entry| {
             let entry = entry.ok()?;
-            if !entry.file_type()?.is_file() {
+            if !entry.path().is_file() {
                 return None;
             }
             Some(entry.into_path())
@@ -379,10 +379,9 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
         .filter_map(|entry| {
             entry
                 .map(|entry| {
-                    let is_dir = entry
-                        .file_type()
-                        .is_some_and(|file_type| file_type.is_dir());
-                    let mut path = entry.path().to_path_buf();
+                    let path = entry.path();
+                    let is_dir = path.is_dir();
+                    let mut path = path.to_path_buf();
                     if is_dir && path != root && config.file_explorer.flatten_dirs {
                         while let Some(single_child_directory) = get_child_if_single_dir(&path) {
                             path = single_child_directory;
@@ -407,8 +406,9 @@ fn directory_content(root: &Path, editor: &Editor) -> Result<Vec<(PathBuf, bool)
 fn get_child_if_single_dir(path: &Path) -> Option<PathBuf> {
     let mut entries = path.read_dir().ok()?;
     let entry = entries.next()?.ok()?;
-    if entries.next().is_none() && entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
-        Some(entry.path())
+    let entry_path = entry.path();
+    if entries.next().is_none() && entry_path.is_dir() {
+        Some(entry_path)
     } else {
         None
     }


### PR DESCRIPTION
# What ?

Symlinks to directories is sometimes not a relevant distinction of file_type for the end user.

# Why ?

#15201 

# How ?

In the code, this kind of case was often handled with `path.file_type().is_some_and(|ft| ft.is_dir())`, but file_type returns different categories for symlinks and directories. Calling `is_dir()` directly on the path follows symlink by default.

# Notes

3ddf07d addresses just the issue linked, 876355b find other places in the code where this pattern was found when sementically, the distinction between symlink to dirs and dirs was not relevant.

Fixes #15201 