### PR TITLE
Fix panic when deleting a long prompt line

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -517,6 +517,7 @@ impl Prompt {
             .clip_right(2);
 
         if self.line.is_empty() {
+            self.anchor = 0;
             // Show the most recently entered value as a suggestion.
             if let Some(suggestion) = self.first_history_completion(cx.editor) {
                 surface.set_string(

--- a/helix-term/tests/test/command_line.rs
+++ b/helix-term/tests/test/command_line.rs
@@ -17,6 +17,21 @@ async fn history_completion() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn prompt_reset_anchor() -> anyhow::Result<()> {
+    test_key_sequence(
+        &mut AppBuilder::new().build()?,
+        Some(":string wider than the terminal window causing the anchor location to be non zero which would panic when the line is deleted<C-u>"),
+        Some(&|app| {
+            assert!(!app.editor.is_err());
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
 async fn test_statusline(
     line: &str,
     expected_status: &str,


### PR DESCRIPTION
Description
-----------

When deleting to the start of a long prompt line, one that exceeds the width of the terminal, the anchor is not properly reset on an empty line and Helix will panic.

Steps To Reproduce
------------------

1. : # open a command prompt
1. type text exceeding the width of the terminal until you see the ... at the begining of the prompt line
1. &lt;C-u&gt; # delete to the start of the line

Debug and Release
-----------------

```
thread 'main' panicked at helix-term/src/ui/prompt.rs:769:55:
byte index 7 is out of bounds of ``
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```