### PR TITLE
feat(helix-tui): use compact string to dramatically increase performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,15 +117,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
-name = "castaway"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,20 +168,6 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
-
-[[package]]
-name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
 
 [[package]]
 name = "content_inspector"
@@ -1612,9 +1589,9 @@ dependencies = [
 name = "helix-tui"
 version = "25.7.1"
 dependencies = [
+ "arrayvec",
  "bitflags",
  "cassowary",
- "compact_str",
  "crossterm",
  "helix-core",
  "helix-view",
@@ -2521,12 +2498,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,20 @@ name = "clru"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbd0f76e066e64fdc5631e3bb46381254deab9ef1158292f27c8c57e3bf3fe59"
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "content_inspector"
@@ -1591,6 +1614,7 @@ version = "25.7.1"
 dependencies = [
  "bitflags",
  "cassowary",
+ "compact_str",
  "crossterm",
  "helix-core",
  "helix-view",
@@ -2497,6 +2521,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ sonic-rs = "0.5"
 globset = "0.4"
 etcetera = "0.11"
 arc-swap = "1.9"
+compact_str = "0.8"
 
 [workspace.package]
 version = "25.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ sonic-rs = "0.5"
 globset = "0.4"
 etcetera = "0.11"
 arc-swap = "1.9"
-compact_str = "0.8"
+arrayvec = "0.7"
 
 [workspace.package]
 version = "25.7.1"

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -20,6 +20,7 @@ helix-core = { path = "../helix-core" }
 
 bitflags.workspace = true
 cassowary = "0.3"
+compact_str.workspace = true
 unicode-segmentation.workspace = true
 termina = { workspace = true, optional = true }
 termini = "1.0"

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -20,7 +20,7 @@ helix-core = { path = "../helix-core" }
 
 bitflags.workspace = true
 cassowary = "0.3"
-compact_str.workspace = true
+arrayvec.workspace = true
 unicode-segmentation.workspace = true
 termina = { workspace = true, optional = true }
 termini = "1.0"

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -26,10 +26,10 @@ impl Cell {
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Cell {
         self.symbol.clear();
         if self.symbol.try_push_str(symbol).is_err() {
-            log::warn!(
+            log::error!(
                 "Grapheme exceeded Symbol capacity ({} bytes, max 28): {:?}",
                 symbol.len(),
-                symbol.chars().collect::<String>()
+                symbol
             );
             self.symbol.push(REPLACEMENT_CHARACTER);
         }
@@ -39,10 +39,7 @@ impl Cell {
     /// Set the cell's grapheme to a [char]
     pub fn set_char(&mut self, ch: char) -> &mut Cell {
         self.symbol.clear();
-        if self.symbol.try_push(ch).is_err() {
-            // Should never happen (chars are max 4 bytes)
-            self.symbol.push(REPLACEMENT_CHARACTER);
-        }
+        self.symbol.try_push(ch).unwrap();
         self
     }
 
@@ -1233,7 +1230,7 @@ mod tests {
         buffer.set_string(0, 0, &extreme, Style::default());
 
         // Should use replacement character
-        assert_eq!(&*buffer[(0, 0)].symbol, "\u{FFFD}");
+        assert_eq!(&*buffer[(0, 0)].symbol, REPLACEMENT_CHARACTER.to_string());
     }
 
     #[test]
@@ -1254,7 +1251,7 @@ mod tests {
         buffer.set_string(0, 0, &absurd, Style::default());
 
         // Should use replacement character
-        assert_eq!(&*buffer[(0, 0)].symbol, "\u{FFFD}");
+        assert_eq!(&*buffer[(0, 0)].symbol, REPLACEMENT_CHARACTER.to_string());
     }
 
     #[test]
@@ -1269,6 +1266,6 @@ mod tests {
         buffer.set_string(0, 0, &chain, Style::default());
 
         // Should use replacement character
-        assert_eq!(&*buffer[(0, 0)].symbol, "\u{FFFD}");
+        assert_eq!(&*buffer[(0, 0)].symbol, REPLACEMENT_CHARACTER.to_string());
     }
 }

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -28,6 +28,12 @@ impl Cell {
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Cell {
         self.symbol.clear();
         if self.symbol.try_push_str(symbol).is_err() {
+            debug_assert!(
+                symbol.len() > 28,
+                "Symbols can't exceed 28 bytes.\nTried to push {} (size in bytes: {})",
+                symbol,
+                symbol.len()
+            );
             SIZE_EXCEEDED_LOG.call_once(|| {
                 log::error!(
                     "Grapheme exceeded Symbol capacity ({} bytes, max 28): {:?}",

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -1,17 +1,16 @@
 //! Contents of a terminal screen. A [Buffer] is made up of [Cell]s.
 use crate::text::{Span, Spans};
 use helix_core::unicode::width::UnicodeWidthStr;
+use helix_view::graphics::{Color, Modifier, Rect, Style, UnderlineStyle};
 use std::cmp::min;
 use unicode_segmentation::UnicodeSegmentation;
 
-pub use compact_str::CompactString;
-
-use helix_view::graphics::{Color, Modifier, Rect, Style, UnderlineStyle};
+pub type Symbol = arrayvec::ArrayString<28>;
 
 /// One cell of the terminal. Contains one stylized grapheme.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Cell {
-    pub symbol: CompactString,
+    pub symbol: Symbol,
     pub fg: Color,
     pub bg: Color,
     pub underline_color: Color,
@@ -22,15 +21,15 @@ pub struct Cell {
 impl Cell {
     /// Set the cell's grapheme
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Cell {
-        self.symbol = CompactString::from(symbol);
+        self.symbol.clear();
+        self.symbol.push_str(symbol);
         self
     }
 
     /// Set the cell's grapheme to a [char]
     pub fn set_char(&mut self, ch: char) -> &mut Cell {
-        let mut buf = [0u8; 4];
-        let s = ch.encode_utf8(&mut buf);
-        self.symbol = CompactString::new(s);
+        self.symbol.clear();
+        self.symbol.push(ch);
         self
     }
 
@@ -85,7 +84,7 @@ impl Cell {
 impl Default for Cell {
     fn default() -> Cell {
         Cell {
-            symbol: CompactString::const_new(" "),
+            symbol: Symbol::from(" ").unwrap(),
             fg: Color::Reset,
             bg: Color::Reset,
             underline_color: Color::Reset,
@@ -105,7 +104,7 @@ impl Default for Cell {
 /// # Examples:
 ///
 /// ```
-/// use helix_tui::buffer::{Buffer, Cell, CompactString};
+/// use helix_tui::buffer::{Buffer, Cell, Symbol};
 /// use helix_view::graphics::{Rect, Color, UnderlineStyle, Style, Modifier};
 ///
 /// let mut buf = Buffer::empty(Rect{x: 0, y: 0, width: 10, height: 5});
@@ -113,7 +112,7 @@ impl Default for Cell {
 /// assert_eq!(&*buf[(0, 2)].symbol, "x");
 /// buf.set_string(3, 0, "string", Style::default().fg(Color::Red).bg(Color::White));
 /// assert_eq!(buf[(5, 0)], Cell{
-///     symbol: CompactString::from("r"),
+///     symbol: Symbol::from("r").unwrap(),
 ///     fg: Color::Red,
 ///     bg: Color::White,
 ///     underline_color: Color::Reset,

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -1129,6 +1129,9 @@ mod tests {
 
         // Zero-width chars shouldn't take space
         assert_eq!(&*buffer[(0, 0)].symbol, "a");
+        // ZWJ attaches to the preceding character
+        assert_eq!(&*buffer[(1, 0)].symbol, "b\u{200D}");
+        assert_eq!(&*buffer[(2, 0)].symbol, "c");
     }
 
     #[test]


### PR DESCRIPTION
# What ?

Replace `String` with `ArrayString` for `Cell.symbol` in `helix-tui`.

# Why ?

Buffer creation allocates thousands of `Cells`, each with a heap-allocated `String` for the symbol field. For a typical terminal (say, 120×40), that's about 10k allocations per buffer, so 20k for Helix has double-buffering.

`ArrayString` stores strings up to N (currently, 28) bytes inline on the stack. This eliminates all those wasteful small heap allocations.

# How ?

Swapped `String` -> `ArrayString::<28>` in `Cell`. The API is very similar so pretty much everything else is as is.


# Benchmark

Refer to https://github.com/helix-editor/helix/pull/15210#issuecomment-3838019936