### PR TITLE
feat: Mode based theming

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2480,12 +2480,18 @@ fn global_search(cx: &mut Context) {
     let config = GlobalSearchConfig {
         smart_case: config.search.smart_case,
         file_picker_config: config.file_picker.clone(),
-        directory_style: cx.editor.theme.get(cx.editor.mode, "ui.text.directory"),
+        directory_style: cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.text.directory"),
         number_style: cx
             .editor
             .theme
-            .get(cx.editor.mode, "constant.numeric.integer"),
-        colon_style: cx.editor.theme.get(cx.editor.mode, "punctuation"),
+            .get(cx.editor.theme_context(), "constant.numeric.integer"),
+        colon_style: cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "punctuation"),
     };
 
     let columns = [
@@ -3349,11 +3355,17 @@ fn changed_file_picker(cx: &mut Context) {
         return;
     }
 
-    let added = cx.editor.theme.get(cx.editor.mode, "diff.plus");
-    let modified = cx.editor.theme.get(cx.editor.mode, "diff.delta");
-    let conflict = cx.editor.theme.get(cx.editor.mode, "diff.delta.conflict");
-    let deleted = cx.editor.theme.get(cx.editor.mode, "diff.minus");
-    let renamed = cx.editor.theme.get(cx.editor.mode, "diff.delta.moved");
+    let added = cx.editor.theme.get(cx.editor.theme_context(), "diff.plus");
+    let modified = cx.editor.theme.get(cx.editor.theme_context(), "diff.delta");
+    let conflict = cx
+        .editor
+        .theme
+        .get(cx.editor.theme_context(), "diff.delta.conflict");
+    let deleted = cx.editor.theme.get(cx.editor.theme_context(), "diff.minus");
+    let renamed = cx
+        .editor
+        .theme
+        .get(cx.editor.theme_context(), "diff.delta.moved");
 
     let columns = [
         PickerColumn::new("change", |change: &FileChange, data: &FileChangeData| {

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -502,6 +502,10 @@ pub fn dap_next(cx: &mut Context) {
 }
 
 pub fn dap_variables(cx: &mut Context) {
+    // debugger takes cx.editor as a &mut borrow so this needs to be first
+    // to satisfy the borrow checker.
+    let theme_context = cx.editor.theme_context();
+
     let debugger = debugger!(cx.editor);
 
     if debugger.thread_id.is_none() {
@@ -549,9 +553,9 @@ pub fn dap_variables(cx: &mut Context) {
     let mut variables = Vec::new();
 
     let theme = &cx.editor.theme;
-    let scope_style = theme.get(cx.editor.mode, "ui.linenr.selected");
-    let type_style = theme.get(cx.editor.mode, "ui.text");
-    let text_style = theme.get(cx.editor.mode, "ui.text.focus");
+    let scope_style = theme.get(theme_context, "ui.linenr.selected");
+    let type_style = theme.get(theme_context, "ui.text");
+    let text_style = theme.get(theme_context, "ui.text.focus");
 
     for scope in scopes.iter() {
         // use helix_view::graphics::Style;

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -239,10 +239,10 @@ fn diag_picker(
     });
 
     let styles = DiagnosticStyles {
-        hint: cx.editor.theme.get(cx.editor.mode, "hint"),
-        info: cx.editor.theme.get(cx.editor.mode, "info"),
-        warning: cx.editor.theme.get(cx.editor.mode, "warning"),
-        error: cx.editor.theme.get(cx.editor.mode, "error"),
+        hint: cx.editor.theme.get(cx.editor.theme_context(), "hint"),
+        info: cx.editor.theme.get(cx.editor.theme_context(), "info"),
+        warning: cx.editor.theme.get(cx.editor.theme_context(), "warning"),
+        error: cx.editor.theme.get(cx.editor.theme_context(), "error"),
     };
 
     let mut columns = vec![

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -133,7 +133,9 @@ impl Completion {
         let preview_completion_insert = editor.config().preview_completion_insert;
         let replace_mode = editor.config().completion_replace;
 
-        let dir_style = editor.theme.get(editor.mode, "ui.text.directory");
+        let dir_style = editor
+            .theme
+            .get(editor.theme_context(), "ui.text.directory");
 
         // Then create the menu
         let menu = Menu::new(items, dir_style, move |editor: &mut Editor, item, event| {
@@ -568,7 +570,7 @@ impl Component for Completion {
         };
 
         // clear area
-        let background = cx.editor.theme.get(cx.editor.mode, "ui.popup");
+        let background = cx.editor.theme.get(cx.editor.theme_context(), "ui.popup");
         surface.clear_with(doc_area, background);
 
         if cx.editor.popup_border() {

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -245,7 +245,7 @@ impl<'a> TextRenderer<'a> {
             " ".to_owned()
         };
 
-        let text_style = theme.get(editor.mode, "ui.text");
+        let text_style = theme.get(editor.theme_context(), "ui.text");
 
         let indent_width = doc.indent_style.indent_width(tab_width) as u16;
 
@@ -258,15 +258,15 @@ impl<'a> TextRenderer<'a> {
             space,
             tab,
             virtual_tab,
-            whitespace_style: theme.get(editor.mode, "ui.virtual.whitespace"),
+            whitespace_style: theme.get(editor.theme_context(), "ui.virtual.whitespace"),
             indent_width,
             starting_indent: offset.col / indent_width as usize
                 + !offset.col.is_multiple_of(indent_width as usize) as usize
                 + editor_config.indent_guides.skip_levels as usize,
             indent_guide_style: text_style.patch(
                 theme
-                    .try_get(editor.mode, "ui.virtual.indent-guide")
-                    .unwrap_or_else(|| theme.get(editor.mode, "ui.virtual.whitespace")),
+                    .try_get(editor.theme_context(), "ui.virtual.indent-guide")
+                    .unwrap_or_else(|| theme.get(editor.theme_context(), "ui.virtual.whitespace")),
             ),
             text_style,
             draw_indent_guides: editor_config.indent_guides.render,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -113,7 +113,7 @@ impl EditorView {
         // Set DAP highlights, if needed.
         if let Some(frame) = editor.current_stack_frame() {
             let dap_line = frame.line.saturating_sub(1);
-            let style = theme.get(editor.mode, "ui.highlight.frameline");
+            let style = theme.get(editor.theme_context(), "ui.highlight.frameline");
             let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
                 if pos.doc_line != dap_line {
                     return;
@@ -200,7 +200,7 @@ impl EditorView {
         decorations.add_decoration(InlineDiagnostics::new(
             doc,
             theme,
-            editor.mode,
+            editor.theme_context(),
             primary_cursor,
             inline_diagnostic_config,
             config.end_of_line_diagnostics,
@@ -221,7 +221,7 @@ impl EditorView {
         // if we're not at the edge of the screen, draw a right border
         if viewport.right() != view.area.right() {
             let x = area.right();
-            let border_style = theme.get(editor.mode, "ui.window");
+            let border_style = theme.get(editor.theme_context(), "ui.window");
             for y in area.top()..area.bottom() {
                 surface[(x, y)]
                     .set_symbol(tui::symbols::line::VERTICAL)
@@ -257,7 +257,7 @@ impl EditorView {
     ) {
         let editor_rulers = &editor.config().rulers;
         let ruler_theme = theme
-            .try_get(editor.mode, "ui.virtual.ruler")
+            .try_get(editor.theme_context(), "ui.virtual.ruler")
             .unwrap_or_else(|| Style::default().bg(Color::Red));
 
         let rulers = doc
@@ -608,19 +608,27 @@ impl EditorView {
             viewport,
             editor
                 .theme
-                .try_get(editor.mode, "ui.bufferline.background")
-                .unwrap_or_else(|| editor.theme.get(editor.mode, "ui.statusline")),
+                .try_get(editor.theme_context(), "ui.bufferline.background")
+                .unwrap_or_else(|| editor.theme.get(editor.theme_context(), "ui.statusline")),
         );
 
         let bufferline_active = editor
             .theme
-            .try_get(editor.mode, "ui.bufferline.active")
-            .unwrap_or_else(|| editor.theme.get(editor.mode, "ui.statusline.active"));
+            .try_get(editor.theme_context(), "ui.bufferline.active")
+            .unwrap_or_else(|| {
+                editor
+                    .theme
+                    .get(editor.theme_context(), "ui.statusline.active")
+            });
 
         let bufferline_inactive = editor
             .theme
-            .try_get(editor.mode, "ui.bufferline")
-            .unwrap_or_else(|| editor.theme.get(editor.mode, "ui.statusline.inactive"));
+            .try_get(editor.theme_context(), "ui.bufferline")
+            .unwrap_or_else(|| {
+                editor
+                    .theme
+                    .get(editor.theme_context(), "ui.statusline.inactive")
+            });
 
         let mut x = viewport.x;
         let current_doc = view!(editor).doc;
@@ -672,10 +680,11 @@ impl EditorView {
 
         let mut offset = 0;
 
-        let gutter_style = theme.get(editor.mode, "ui.gutter");
-        let gutter_selected_style = theme.get(editor.mode, "ui.gutter.selected");
-        let gutter_style_virtual = theme.get(editor.mode, "ui.gutter.virtual");
-        let gutter_selected_style_virtual = theme.get(editor.mode, "ui.gutter.selected.virtual");
+        let gutter_style = theme.get(editor.theme_context(), "ui.gutter");
+        let gutter_selected_style = theme.get(editor.theme_context(), "ui.gutter.selected");
+        let gutter_style_virtual = theme.get(editor.theme_context(), "ui.gutter.virtual");
+        let gutter_selected_style_virtual =
+            theme.get(editor.theme_context(), "ui.gutter.selected.virtual");
 
         for gutter_type in view.gutters() {
             let mut gutter = gutter_type.style(editor, doc, view, theme, is_focused);
@@ -743,13 +752,13 @@ impl EditorView {
             diagnostic.range.start <= cursor && diagnostic.range.end >= cursor
         });
 
-        let warning = theme.get(editor.mode, "warning");
-        let error = theme.get(editor.mode, "error");
-        let info = theme.get(editor.mode, "info");
-        let hint = theme.get(editor.mode, "hint");
+        let warning = theme.get(editor.theme_context(), "warning");
+        let error = theme.get(editor.theme_context(), "error");
+        let info = theme.get(editor.theme_context(), "info");
+        let hint = theme.get(editor.theme_context(), "hint");
 
         let mut lines = Vec::new();
-        let background_style = theme.get(editor.mode, "ui.background");
+        let background_style = theme.get(editor.theme_context(), "ui.background");
         for diagnostic in diagnostics {
             let style = Style::reset()
                 .patch(background_style)
@@ -806,8 +815,8 @@ impl EditorView {
             .map(|range| range.cursor_line(text))
             .collect();
 
-        let primary_style = theme.get(editor.mode, "ui.cursorline.primary");
-        let secondary_style = theme.get(editor.mode, "ui.cursorline.secondary");
+        let primary_style = theme.get(editor.theme_context(), "ui.cursorline.primary");
+        let secondary_style = theme.get(editor.theme_context(), "ui.cursorline.secondary");
         let viewport = view.area;
 
         move |renderer: &mut TextRenderer, pos: LinePos| {
@@ -835,13 +844,13 @@ impl EditorView {
         // Manual fallback behaviour:
         // ui.cursorcolumn.{p/s} -> ui.cursorcolumn -> ui.cursorline.{p/s}
         let primary_style = theme
-            .try_get_exact(editor.mode, "ui.cursorcolumn.primary")
-            .or_else(|| theme.try_get_exact(editor.mode, "ui.cursorcolumn"))
-            .unwrap_or_else(|| theme.get(editor.mode, "ui.cursorline.primary"));
+            .try_get_exact(editor.theme_context(), "ui.cursorcolumn.primary")
+            .or_else(|| theme.try_get_exact(editor.theme_context(), "ui.cursorcolumn"))
+            .unwrap_or_else(|| theme.get(editor.theme_context(), "ui.cursorline.primary"));
         let secondary_style = theme
-            .try_get_exact(editor.mode, "ui.cursorcolumn.secondary")
-            .or_else(|| theme.try_get_exact(editor.mode, "ui.cursorcolumn"))
-            .unwrap_or_else(|| theme.get(editor.mode, "ui.cursorline.secondary"));
+            .try_get_exact(editor.theme_context(), "ui.cursorcolumn.secondary")
+            .or_else(|| theme.try_get_exact(editor.theme_context(), "ui.cursorcolumn"))
+            .unwrap_or_else(|| theme.get(editor.theme_context(), "ui.cursorline.secondary"));
 
         let inner_area = view.inner_area(doc);
 
@@ -1541,7 +1550,12 @@ impl Component for EditorView {
 
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         // clear with background color
-        surface.set_style(area, cx.editor.theme.get(cx.editor.mode, "ui.background"));
+        surface.set_style(
+            area,
+            cx.editor
+                .theme
+                .get(cx.editor.theme_context(), "ui.background"),
+        );
         let config = cx.editor.config();
 
         // check if bufferline should be rendered
@@ -1585,9 +1599,9 @@ impl Component for EditorView {
             status_msg_width = status_msg.width();
             use helix_view::editor::Severity;
             let style = if *severity == Severity::Error {
-                cx.editor.theme.get(cx.editor.mode, "error")
+                cx.editor.theme.get(cx.editor.theme_context(), "error")
             } else {
-                cx.editor.theme.get(cx.editor.mode, "ui.text")
+                cx.editor.theme.get(cx.editor.theme_context(), "ui.text")
             };
 
             surface.set_string(
@@ -1609,7 +1623,7 @@ impl Component for EditorView {
             for key in &self.pseudo_pending {
                 disp.push_str(&key.key_sequence_format());
             }
-            let style = cx.editor.theme.get(cx.editor.mode, "ui.text");
+            let style = cx.editor.theme.get(cx.editor.theme_context(), "ui.text");
             let macro_width = if cx.editor.macro_recording.is_some() {
                 3
             } else {

--- a/helix-term/src/ui/info.rs
+++ b/helix-term/src/ui/info.rs
@@ -7,8 +7,14 @@ use tui::widgets::{Block, Paragraph, Widget};
 
 impl Component for Info {
     fn render(&mut self, viewport: Rect, surface: &mut Surface, cx: &mut Context) {
-        let text_style = cx.editor.theme.get(cx.editor.mode, "ui.text.info");
-        let popup_style = cx.editor.theme.get(cx.editor.mode, "ui.popup.info");
+        let text_style = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.text.info");
+        let popup_style = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.popup.info");
 
         // Calculate the area of the terminal to modify. Because we want to
         // render at the bottom right, we use the viewport's width and height

--- a/helix-term/src/ui/lsp/hover.rs
+++ b/helix-term/src/ui/lsp/hover.rs
@@ -80,7 +80,7 @@ impl Component for Hover {
         // show header and border only when more than one results
         if let Some(header) = header {
             // header LSP Name
-            let header = header.parse(Some((&cx.editor.theme, cx.editor.mode)));
+            let header = header.parse(Some((&cx.editor.theme, cx.editor.theme_context())));
             let header = Paragraph::new(&header);
             header.render(area.with_height(HEADER_HEIGHT), surface);
 
@@ -95,7 +95,7 @@ impl Component for Hover {
         }
 
         // hover content
-        let contents = contents.parse(Some((&cx.editor.theme, cx.editor.mode)));
+        let contents = contents.parse(Some((&cx.editor.theme, cx.editor.theme_context())));
         let contents_area = area.clip_top(if self.has_header() {
             HEADER_HEIGHT + SEPARATOR_HEIGHT
         } else {

--- a/helix-term/src/ui/lsp/signature_help.rs
+++ b/helix-term/src/ui/lsp/signature_help.rs
@@ -119,7 +119,7 @@ impl Component for SignatureHelp {
         let sig_text = crate::ui::markdown::highlighted_code_block(
             signature.signature.as_str(),
             &self.language,
-            Some((&cx.editor.theme, cx.editor.mode)),
+            Some((&cx.editor.theme, cx.editor.theme_context())),
             &self.config_loader.load(),
             active_param_span,
         );
@@ -155,7 +155,7 @@ impl Component for SignatureHelp {
             None => return,
             Some(doc) => Markdown::new(doc.clone(), Arc::clone(&self.config_loader)),
         };
-        let sig_doc = sig_doc.parse(Some((&cx.editor.theme, cx.editor.mode)));
+        let sig_doc = sig_doc.parse(Some((&cx.editor.theme, cx.editor.theme_context())));
         let sig_doc_area = area
             .clip_top(sig_text_area.height + 2)
             .clip_bottom(u16::from(cx.editor.popup_border()));

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -332,9 +332,9 @@ impl<T: Item + 'static> Component for Menu<T> {
     fn render(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let theme = &cx.editor.theme;
         let style = theme
-            .try_get(cx.editor.mode, "ui.menu")
-            .unwrap_or_else(|| theme.get(cx.editor.mode, "ui.text"));
-        let selected = theme.get(cx.editor.mode, "ui.menu.selected");
+            .try_get(cx.editor.theme_context(), "ui.menu")
+            .unwrap_or_else(|| theme.get(cx.editor.theme_context(), "ui.text"));
+        let selected = theme.get(cx.editor.theme_context(), "ui.menu.selected");
 
         surface.clear_with(area, style);
 
@@ -391,7 +391,7 @@ impl<T: Item + 'static> Component for Menu<T> {
 
         let fits = len <= win_height;
 
-        let scroll_style = theme.get(cx.editor.mode, "ui.menu.scroll");
+        let scroll_style = theme.get(cx.editor.theme_context(), "ui.menu.scroll");
         if !fits {
             let scroll_height = win_height.pow(2).div_ceil(len).min(win_height);
             let scroll_line = (win_height - scroll_height) * scroll

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -218,7 +218,9 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
     let config = editor.config();
     let data = FilePickerData {
         root: root.clone(),
-        directory_style: editor.theme.get(editor.mode, "ui.text.directory"),
+        directory_style: editor
+            .theme
+            .get(editor.theme_context(), "ui.text.directory"),
     };
 
     let now = Instant::now();
@@ -310,7 +312,9 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
 type FileExplorer = Picker<(PathBuf, bool), (PathBuf, Style)>;
 
 pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std::io::Error> {
-    let directory_style = editor.theme.get(editor.mode, "ui.text.directory");
+    let directory_style = editor
+        .theme
+        .get(editor.theme_context(), "ui.text.directory");
     let directory_content = directory_content(&root, editor)?;
 
     let columns = [PickerColumn::new(
@@ -686,8 +690,10 @@ pub mod completers {
             }) // TODO: unwrap or skip
             .filter(|path| !path.path.is_empty());
 
-        let directory_color = editor.theme.get(editor.mode, "ui.text.directory");
-        let symlink_color = editor.theme.get(editor.mode, "ui.text.symlink");
+        let directory_color = editor
+            .theme
+            .get(editor.theme_context(), "ui.text.directory");
+        let symlink_color = editor.theme.get(editor.theme_context(), "ui.text.symlink");
 
         let style_from_file = |file: Utf8PathBuf| {
             if file.is_symlink {

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -689,17 +689,23 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 .min(snapshot.matched_item_count().saturating_sub(1))
         }
 
-        let text_style = cx.editor.theme.get(cx.editor.mode, "ui.text");
-        let selected = cx.editor.theme.get(cx.editor.mode, "ui.text.focus");
+        let text_style = cx.editor.theme.get(cx.editor.theme_context(), "ui.text");
+        let selected = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.text.focus");
         let highlight_style = cx
             .editor
             .theme
-            .get(cx.editor.mode, "special")
+            .get(cx.editor.theme_context(), "special")
             .add_modifier(Modifier::BOLD);
 
         // -- Render the frame:
         // clear area
-        let background = cx.editor.theme.get(cx.editor.mode, "ui.background");
+        let background = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.background");
         surface.clear_with(area, background);
 
         const BLOCK: Block<'_> = Block::bordered();
@@ -740,7 +746,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let sep_style = cx
             .editor
             .theme
-            .get(cx.editor.mode, "ui.background.separator");
+            .get(cx.editor.theme_context(), "ui.background.separator");
         let borders = BorderType::line_symbols(BorderType::Plain);
         for x in inner.left()..inner.right() {
             if let Some(cell) = surface.get_mut(x, inner.y + 1) {
@@ -851,25 +857,29 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         // -- Header
         if self.columns.len() > 1 {
             let active_column = self.query.active_column(self.prompt.position());
-            let header_style = cx.editor.theme.get(cx.editor.mode, "ui.picker.header");
+            let header_style = cx
+                .editor
+                .theme
+                .get(cx.editor.theme_context(), "ui.picker.header");
             let header_column_style = cx
                 .editor
                 .theme
-                .get(cx.editor.mode, "ui.picker.header.column");
+                .get(cx.editor.theme_context(), "ui.picker.header.column");
 
             table = table.header(
                 Row::new(self.columns.iter().map(|column| {
                     if column.hidden {
                         Cell::default()
                     } else {
-                        let style =
-                            if active_column.is_some_and(|name| Arc::ptr_eq(name, &column.name)) {
-                                cx.editor
-                                    .theme
-                                    .get(cx.editor.mode, "ui.picker.header.column.active")
-                            } else {
-                                header_column_style
-                            };
+                        let style = if active_column
+                            .is_some_and(|name| Arc::ptr_eq(name, &column.name))
+                        {
+                            cx.editor
+                                .theme
+                                .get(cx.editor.theme_context(), "ui.picker.header.column.active")
+                        } else {
+                            header_column_style
+                        };
 
                         Cell::from(Span::styled(Cow::from(&*column.name), style))
                     }
@@ -894,9 +904,15 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     fn render_preview(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         // -- Render the frame:
         // clear area
-        let background = cx.editor.theme.get(cx.editor.mode, "ui.background");
-        let text = cx.editor.theme.get(cx.editor.mode, "ui.text");
-        let directory = cx.editor.theme.get(cx.editor.mode, "ui.text.directory");
+        let background = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.background");
+        let text = cx.editor.theme.get(cx.editor.theme_context(), "ui.text");
+        let directory = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.text.directory");
         surface.clear_with(area, background);
 
         const BLOCK: Block<'_> = Block::bordered();
@@ -987,8 +1003,12 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 let style = cx
                     .editor
                     .theme
-                    .try_get(cx.editor.mode, "ui.highlight")
-                    .unwrap_or_else(|| cx.editor.theme.get(cx.editor.mode, "ui.selection"));
+                    .try_get(cx.editor.theme_context(), "ui.highlight")
+                    .unwrap_or_else(|| {
+                        cx.editor
+                            .theme
+                            .get(cx.editor.theme_context(), "ui.selection")
+                    });
                 let draw_highlight = move |renderer: &mut TextRenderer, pos: LinePos| {
                     if (start..=end).contains(&pos.doc_line) {
                         let area = Rect::new(

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -328,10 +328,10 @@ impl<T: Component> Component for Popup<T> {
             // TODO: consistently style menu
             cx.editor
                 .theme
-                .try_get(cx.editor.mode, "ui.menu")
-                .unwrap_or_else(|| cx.editor.theme.get(cx.editor.mode, "ui.text"))
+                .try_get(cx.editor.theme_context(), "ui.menu")
+                .unwrap_or_else(|| cx.editor.theme.get(cx.editor.theme_context(), "ui.text"))
         } else {
-            cx.editor.theme.get(cx.editor.mode, "ui.popup")
+            cx.editor.theme.get(cx.editor.theme_context(), "ui.popup")
         };
         surface.clear_with(area, background);
 
@@ -356,7 +356,10 @@ impl<T: Component> Component for Popup<T> {
             let win_height = inner.height as usize;
             let len = child_height as usize;
             let fits = len <= win_height;
-            let scroll_style = cx.editor.theme.get(cx.editor.mode, "ui.menu.scroll");
+            let scroll_style = cx
+                .editor
+                .theme
+                .get(cx.editor.theme_context(), "ui.menu.scroll");
 
             if !fits {
                 let scroll_height = win_height.pow(2).div_ceil(len).min(win_height);

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -403,11 +403,11 @@ const BASE_WIDTH: u16 = 30;
 impl Prompt {
     pub fn render_prompt(&mut self, area: Rect, surface: &mut Surface, cx: &mut Context) {
         let theme = &cx.editor.theme;
-        let prompt_color = theme.get(cx.editor.mode, "ui.text");
-        let completion_color = theme.get(cx.editor.mode, "ui.menu");
-        let selected_color = theme.get(cx.editor.mode, "ui.menu.selected");
-        let suggestion_color = theme.get(cx.editor.mode, "ui.text.inactive");
-        let background = theme.get(cx.editor.mode, "ui.background");
+        let prompt_color = theme.get(cx.editor.theme_context(), "ui.text");
+        let completion_color = theme.get(cx.editor.theme_context(), "ui.menu");
+        let selected_color = theme.get(cx.editor.theme_context(), "ui.menu.selected");
+        let suggestion_color = theme.get(cx.editor.theme_context(), "ui.text.inactive");
+        let background = theme.get(cx.editor.theme_context(), "ui.background");
         // completion
 
         let max_len = self
@@ -435,7 +435,7 @@ impl Prompt {
 
         if completion_area.height > 0 && !self.completion.is_empty() {
             let area = completion_area;
-            let background = theme.get(cx.editor.mode, "ui.menu");
+            let background = theme.get(cx.editor.theme_context(), "ui.menu");
 
             let items = height as usize * cols as usize;
 
@@ -493,7 +493,7 @@ impl Prompt {
                 height + padding * 2,
             ));
 
-            let background = theme.get(cx.editor.mode, "ui.help");
+            let background = theme.get(cx.editor.theme_context(), "ui.help");
             surface.clear_with(area, background);
 
             let block = Block::bordered()
@@ -531,7 +531,7 @@ impl Prompt {
             let mut text: ui::text::Text = crate::ui::markdown::highlighted_code_block(
                 &self.line,
                 language,
-                Some((&cx.editor.theme, cx.editor.mode)),
+                Some((&cx.editor.theme, cx.editor.theme_context())),
                 &loader.load(),
                 None,
             )

--- a/helix-term/src/ui/select.rs
+++ b/helix-term/src/ui/select.rs
@@ -86,8 +86,11 @@ impl<T: Item> Component for Select<T> {
         };
 
         // Message
-        let background = cx.editor.theme.get(cx.editor.mode, "ui.background");
-        let text = cx.editor.theme.get(cx.editor.mode, "ui.text");
+        let background = cx
+            .editor
+            .theme
+            .get(cx.editor.theme_context(), "ui.background");
+        let text = cx.editor.theme.get(cx.editor.theme_context(), "ui.text");
         let message_box = area.with_height(message_height + 2);
         surface.clear_with(message_box, background.patch(text));
         BLOCK.render(message_box, surface);

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -55,12 +55,12 @@ pub fn render(context: &mut RenderContext, viewport: Rect, surface: &mut Surface
         context
             .editor
             .theme
-            .get(context.editor.mode, "ui.statusline")
+            .get(context.editor.theme_context(), "ui.statusline")
     } else {
         context
             .editor
             .theme
-            .get(context.editor.mode, "ui.statusline.inactive")
+            .get(context.editor.theme_context(), "ui.statusline.inactive")
     };
 
     surface.set_style(viewport.with_height(1), base_style);
@@ -184,10 +184,14 @@ where
         // If not focused, explicitly leave an empty space instead of returning None.
         " ".repeat(mode_str.width() + 2)
     };
-    let style = context
-        .editor
-        .theme
-        .get(context.editor.mode, "ui.statusline");
+    let style = if visible {
+        context
+            .editor
+            .theme
+            .get(context.editor.theme_context(), "ui.statusline")
+    } else {
+        Style::default()
+    };
     write(context, Span::styled(content, style));
 }
 
@@ -237,14 +241,26 @@ where
             Severity::Hint if hints > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get(context.editor.mode, "hint")),
+                    Span::styled(
+                        "●",
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "hint"),
+                    ),
                 );
                 write(context, format!(" {} ", hints).into());
             }
             Severity::Info if info > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get(context.editor.mode, "info")),
+                    Span::styled(
+                        "●",
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "info"),
+                    ),
                 );
                 write(context, format!(" {} ", info).into());
             }
@@ -253,7 +269,10 @@ where
                     context,
                     Span::styled(
                         "●",
-                        context.editor.theme.get(context.editor.mode, "warning"),
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "warning"),
                     ),
                 );
                 write(context, format!(" {} ", warnings).into());
@@ -261,7 +280,13 @@ where
             Severity::Error if errors > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get(context.editor.mode, "error")),
+                    Span::styled(
+                        "●",
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "error"),
+                    ),
                 );
                 write(context, format!(" {} ", errors).into());
             }
@@ -313,14 +338,26 @@ where
             Severity::Hint if hints > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get(context.editor.mode, "hint")),
+                    Span::styled(
+                        "●",
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "hint"),
+                    ),
                 );
                 write(context, format!(" {} ", hints).into());
             }
             Severity::Info if info > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get(context.editor.mode, "info")),
+                    Span::styled(
+                        "●",
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "info"),
+                    ),
                 );
                 write(context, format!(" {} ", info).into());
             }
@@ -329,7 +366,10 @@ where
                     context,
                     Span::styled(
                         "●",
-                        context.editor.theme.get(context.editor.mode, "warning"),
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "warning"),
                     ),
                 );
                 write(context, format!(" {} ", warnings).into());
@@ -337,7 +377,13 @@ where
             Severity::Error if errors > 0 => {
                 write(
                     context,
-                    Span::styled("●", context.editor.theme.get(context.editor.mode, "error")),
+                    Span::styled(
+                        "●",
+                        context
+                            .editor
+                            .theme
+                            .get(context.editor.theme_context(), "error"),
+                    ),
                 );
                 write(context, format!(" {} ", errors).into());
             }
@@ -542,7 +588,7 @@ where
     let style = context
         .editor
         .theme
-        .get(context.editor.mode, "ui.statusline.separator");
+        .get(context.editor.theme_context(), "ui.statusline.separator");
 
     write(context, Span::styled(sep.to_string(), style));
 }

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -11,9 +11,8 @@ use helix_view::annotations::diagnostics::{
 
 use crate::ui::document::{LinePos, TextRenderer};
 use crate::ui::text_decorations::Decoration;
-use helix_view::document::Mode;
-use helix_view::theme::Style;
-use helix_view::{document, Document, Theme};
+use helix_view::theme::{Style, ThemeContext};
+use helix_view::{Document, Theme};
 
 #[derive(Debug)]
 struct Styles {
@@ -24,12 +23,12 @@ struct Styles {
 }
 
 impl Styles {
-    fn new(theme: &Theme, mode: document::Mode) -> Styles {
+    fn new(theme: &Theme, tc: ThemeContext) -> Styles {
         Styles {
-            hint: theme.get(mode, "hint"),
-            info: theme.get(mode, "info"),
-            warning: theme.get(mode, "warning"),
-            error: theme.get(mode, "error"),
+            hint: theme.get(tc, "hint"),
+            info: theme.get(tc, "info"),
+            warning: theme.get(tc, "warning"),
+            error: theme.get(tc, "error"),
         }
     }
 
@@ -53,14 +52,14 @@ impl<'a> InlineDiagnostics<'a> {
     pub fn new(
         doc: &'a Document,
         theme: &Theme,
-        mode: Mode,
+        tc: ThemeContext,
         cursor: usize,
         config: InlineDiagnosticsConfig,
         eol_diagnostics: DiagnosticFilter,
     ) -> Self {
         InlineDiagnostics {
             state: InlineDiagnosticAccumulator::new(cursor, doc, config),
-            styles: Styles::new(theme, mode),
+            styles: Styles::new(theme, tc),
             eol_diagnostics,
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1172,6 +1172,7 @@ pub struct Breakpoint {
     pub log_message: Option<String>,
 }
 
+use crate::theme::ThemeContext;
 use futures_util::stream::{Flatten, Once};
 
 type Diagnostics = BTreeMap<Uri, Vec<(lsp::Diagnostic, DiagnosticProvider)>>;
@@ -2422,6 +2423,13 @@ impl Editor {
         let (view, doc) = current!(self);
         doc.set_selection(view_id, selection);
         view.ensure_cursor_in_view_center(doc, self.config.load().scrolloff);
+    }
+
+    pub fn theme_context(&self) -> ThemeContext {
+        ThemeContext {
+            mode: self.mode,
+            color_modes: self.config().color_modes,
+        }
     }
 }
 

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -52,10 +52,10 @@ pub fn diagnostic<'doc>(
     theme: &Theme,
     _is_focused: bool,
 ) -> GutterFn<'doc> {
-    let warning = theme.get(editor.mode, "warning");
-    let error = theme.get(editor.mode, "error");
-    let info = theme.get(editor.mode, "info");
-    let hint = theme.get(editor.mode, "hint");
+    let warning = theme.get(editor.theme_context(), "warning");
+    let error = theme.get(editor.theme_context(), "error");
+    let info = theme.get(editor.theme_context(), "info");
+    let hint = theme.get(editor.theme_context(), "hint");
     let diagnostics = &doc.diagnostics;
 
     Box::new(
@@ -94,9 +94,9 @@ pub fn diff<'doc>(
     theme: &Theme,
     _is_focused: bool,
 ) -> GutterFn<'doc> {
-    let added = theme.get(editor.mode, "diff.plus.gutter");
-    let deleted = theme.get(editor.mode, "diff.minus.gutter");
-    let modified = theme.get(editor.mode, "diff.delta.gutter");
+    let added = theme.get(editor.theme_context(), "diff.plus.gutter");
+    let deleted = theme.get(editor.theme_context(), "diff.minus.gutter");
+    let modified = theme.get(editor.theme_context(), "diff.delta.gutter");
     if let Some(diff_handle) = doc.diff_handle() {
         let hunks = diff_handle.load();
         let mut hunk_i = 0;
@@ -155,8 +155,8 @@ pub fn line_numbers<'doc>(
     // document or not.  We only draw it if it's not an empty line.
     let draw_last = text.line_to_byte(last_line_in_view) < text.len_bytes();
 
-    let linenr = theme.get(editor.mode, "ui.linenr");
-    let linenr_select = theme.get(editor.mode, "ui.linenr.selected");
+    let linenr = theme.get(editor.theme_context(), "ui.linenr");
+    let linenr_select = theme.get(editor.theme_context(), "ui.linenr.selected");
 
     let current_line = doc
         .text()
@@ -234,9 +234,9 @@ pub fn breakpoints<'doc>(
     theme: &Theme,
     _is_focused: bool,
 ) -> GutterFn<'doc> {
-    let error = theme.get(editor.mode, "error");
-    let info = theme.get(editor.mode, "info");
-    let breakpoint_style = theme.get(editor.mode, "ui.debug.breakpoint");
+    let error = theme.get(editor.theme_context(), "error");
+    let info = theme.get(editor.theme_context(), "info");
+    let breakpoint_style = theme.get(editor.theme_context(), "ui.debug.breakpoint");
 
     let breakpoints = doc.path().and_then(|path| editor.breakpoints.get(path));
 
@@ -277,7 +277,7 @@ fn execution_pause_indicator<'doc>(
     theme: &Theme,
     is_focused: bool,
 ) -> GutterFn<'doc> {
-    let style = theme.get(editor.mode, "ui.debug.active");
+    let style = theme.get(editor.theme_context(), "ui.debug.active");
     let current_stack_frame = editor.current_stack_frame();
     let frame_line = current_stack_frame.map(|frame| frame.line.saturating_sub(1));
     let frame_source_path = current_stack_frame.map(|frame| {


### PR DESCRIPTION
![mode-based-themes](https://github.com/user-attachments/assets/1a5cdc30-2077-4de2-b10b-0170be82c96e)

This commit adds a generic way of changing the color based on mode from the theme struct. This saves us from having to implement a match statement under every render function and makes the code rather readable whilst adding a lot more customisation to the user.

All theme options now support adding ".insert", ".select" and ".normal" to the key, and will apply those color/style choices directly. Specifying the theme key without those suffixes will be used as a fallback. So current themes should still work as expected.