### PR TITLE
feat(lsp): add call hierarchy picker

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -138,6 +138,8 @@
 | `goto_file_hsplit` | Goto files in selections (hsplit) | normal: `` <C-w>f ``, `` <space>wf ``, select: `` <C-w>f ``, `` <space>wf `` |
 | `goto_file_vsplit` | Goto files in selections (vsplit) | normal: `` <C-w>F ``, `` <space>wF ``, select: `` <C-w>F ``, `` <space>wF `` |
 | `goto_reference` | Goto references | normal: `` gr ``, select: `` gr `` |
+| `call_hierarchy_incoming` | Show incoming call hierarchy |  |
+| `call_hierarchy_outgoing` | Show outgoing call hierarchy |  |
 | `goto_window_top` | Goto window top | normal: `` gt ``, select: `` gt `` |
 | `goto_window_center` | Goto window center | normal: `` gc ``, select: `` gc `` |
 | `goto_window_bottom` | Goto window bottom | normal: `` gb ``, select: `` gb `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -441,6 +441,8 @@ impl MappableCommand {
         goto_file_hsplit, "Goto files in selections (hsplit)",
         goto_file_vsplit, "Goto files in selections (vsplit)",
         goto_reference, "Goto references",
+        call_hierarchy_incoming, "Show incoming call hierarchy",
+        call_hierarchy_outgoing, "Show outgoing call hierarchy",
         goto_window_top, "Goto window top",
         goto_window_center, "Goto window center",
         goto_window_bottom, "Goto window bottom",

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1,4 +1,7 @@
-use futures_util::{stream::FuturesUnordered, FutureExt};
+use futures_util::{
+    stream::{FuturesOrdered, FuturesUnordered},
+    FutureExt,
+};
 use helix_lsp::{
     block_on,
     lsp::{
@@ -9,7 +12,10 @@ use helix_lsp::{
     Client, LanguageServerId, OffsetEncoding,
 };
 use tokio_stream::StreamExt;
-use tui::{text::Span, widgets::Row};
+use tui::{
+    text::Span,
+    widgets::{Block, Row, Tree, TreeItem, TreeState},
+};
 
 use super::{align_view, push_jump, Align, Context, Editor};
 
@@ -28,8 +34,11 @@ use helix_view::{
 };
 
 use crate::{
-    compositor::{self, Compositor},
+    alt,
+    compositor::{self, Component, Compositor, Event, EventResult},
+    ctrl,
     job::{Callback, Job},
+    key, shift,
     ui::{self, overlay::overlaid, FileLocation, Picker, Popup, PromptEvent},
 };
 
@@ -89,9 +98,72 @@ fn lsp_location_to_location(
     })
 }
 
+fn call_hierarchy_item_to_location(
+    item: &lsp::CallHierarchyItem,
+    offset_encoding: OffsetEncoding,
+) -> Option<Location> {
+    call_hierarchy_uri_to_location(&item.uri, item.selection_range, offset_encoding)
+}
+
+fn call_hierarchy_uri_to_location(
+    uri: &lsp::Url,
+    range: lsp::Range,
+    offset_encoding: OffsetEncoding,
+) -> Option<Location> {
+    let uri = match Uri::try_from(uri) {
+        Ok(uri) => uri,
+        Err(err) => {
+            log::warn!("discarding call hierarchy item with invalid URI: {err}");
+            return None;
+        }
+    };
+    Some(Location {
+        uri,
+        range,
+        offset_encoding,
+    })
+}
+
 struct SymbolInformationItem {
     location: Location,
     symbol: lsp::SymbolInformation,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum CallHierarchyDirection {
+    Incoming,
+    Outgoing,
+}
+
+#[derive(Debug, Clone)]
+struct CallHierarchyEntry {
+    id: usize,
+    item: lsp::CallHierarchyItem,
+    location: Location,
+    preview_location: Location,
+    server_id: LanguageServerId,
+    has_children: bool,
+    children: Vec<CallHierarchyEntry>,
+}
+
+impl CallHierarchyEntry {
+    fn new(
+        id: usize,
+        item: lsp::CallHierarchyItem,
+        location: Location,
+        preview_location: Location,
+        server_id: LanguageServerId,
+    ) -> Self {
+        Self {
+            id,
+            item,
+            location,
+            preview_location,
+            server_id,
+            has_children: true,
+            children: Vec::new(),
+        }
+    }
 }
 
 struct DiagnosticStyles {
@@ -197,6 +269,473 @@ fn display_symbol_kind(kind: lsp::SymbolKind) -> &'static str {
             log::warn!("Unknown symbol kind: {:?}", kind);
             ""
         }
+    }
+}
+
+fn call_hierarchy_direction_label(direction: CallHierarchyDirection) -> &'static str {
+    match direction {
+        CallHierarchyDirection::Incoming => "incoming",
+        CallHierarchyDirection::Outgoing => "outgoing",
+    }
+}
+
+fn call_hierarchy_preview_location(
+    uri: &lsp::Url,
+    ranges: &[lsp::Range],
+    offset_encoding: OffsetEncoding,
+    fallback: &Location,
+) -> Location {
+    ranges
+        .first()
+        .and_then(|range| call_hierarchy_uri_to_location(uri, *range, offset_encoding))
+        .unwrap_or_else(|| fallback.clone())
+}
+
+fn incoming_call_hierarchy_entry(
+    id: usize,
+    call: lsp::CallHierarchyIncomingCall,
+    offset_encoding: OffsetEncoding,
+    server_id: LanguageServerId,
+) -> Option<CallHierarchyEntry> {
+    let item = call.from;
+    let location = call_hierarchy_item_to_location(&item, offset_encoding)?;
+    let preview_location =
+        call_hierarchy_preview_location(&item.uri, &call.from_ranges, offset_encoding, &location);
+    Some(CallHierarchyEntry::new(
+        id,
+        item,
+        location,
+        preview_location,
+        server_id,
+    ))
+}
+
+fn outgoing_call_hierarchy_entry(
+    id: usize,
+    call: lsp::CallHierarchyOutgoingCall,
+    caller_uri: &lsp::Url,
+    offset_encoding: OffsetEncoding,
+    server_id: LanguageServerId,
+) -> Option<CallHierarchyEntry> {
+    let item = call.to;
+    let location = call_hierarchy_item_to_location(&item, offset_encoding)?;
+    let preview_location =
+        call_hierarchy_preview_location(caller_uri, &call.from_ranges, offset_encoding, &location);
+    Some(CallHierarchyEntry::new(
+        id,
+        item,
+        location,
+        preview_location,
+        server_id,
+    ))
+}
+
+struct CallHierarchyPicker {
+    direction: CallHierarchyDirection,
+    entries: Vec<CallHierarchyEntry>,
+    state: TreeState<usize>,
+    preview: ui::picker::FilePreview,
+}
+
+impl CallHierarchyPicker {
+    fn new(direction: CallHierarchyDirection, entries: Vec<CallHierarchyEntry>) -> Self {
+        let mut state = TreeState::default();
+        if let Some(first) = entries.first() {
+            state.select(vec![first.id]);
+        }
+        Self {
+            direction,
+            entries,
+            state,
+            preview: ui::picker::FilePreview::default(),
+        }
+    }
+
+    fn with_state(
+        direction: CallHierarchyDirection,
+        entries: Vec<CallHierarchyEntry>,
+        opened: HashSet<Vec<usize>>,
+        selected: Vec<usize>,
+    ) -> Self {
+        let mut state = TreeState::default();
+        for identifier in opened {
+            state.open(identifier);
+        }
+        state.select(selected);
+        Self {
+            direction,
+            entries,
+            state,
+            preview: ui::picker::FilePreview::default(),
+        }
+    }
+
+    fn selected_entry(&self) -> Option<&CallHierarchyEntry> {
+        let selected = self.state.selected();
+        if selected.is_empty() {
+            None
+        } else {
+            find_call_hierarchy_entry(&self.entries, selected)
+        }
+    }
+
+    fn jump_selected(&self, editor: &mut Editor, action: Action) {
+        if let Some(entry) = self.selected_entry() {
+            jump_to_location(editor, &entry.location, action);
+        }
+    }
+
+    fn render_tree(
+        &mut self,
+        area: helix_view::graphics::Rect,
+        surface: &mut tui::buffer::Buffer,
+        cx: &mut compositor::Context,
+    ) {
+        let background = cx.editor.theme.get("ui.background");
+        surface.clear_with(area, background);
+
+        let title = format!(
+            "{} call hierarchy",
+            call_hierarchy_direction_label(self.direction)
+        );
+        let block = Block::bordered().title(title);
+        let text_style = cx.editor.theme.get("ui.text");
+        let selected_style = cx.editor.theme.get("ui.text.focus");
+        let items = call_hierarchy_tree_items(&self.entries);
+        let Ok(tree) = Tree::new(&items) else {
+            return;
+        };
+        tree.block(block)
+            .style(text_style)
+            .highlight_style(selected_style)
+            .highlight_symbol(" > ")
+            .render_tree(area, surface, &mut self.state);
+    }
+
+    fn toggle_selected(&mut self, cx: &mut compositor::Context) {
+        let selected = self.state.selected().to_vec();
+        if selected.is_empty() {
+            return;
+        }
+
+        let Some(entry) = find_call_hierarchy_entry(&self.entries, &selected) else {
+            return;
+        };
+
+        if !entry.has_children {
+            cx.editor.set_status(format!(
+                "No {} calls.",
+                call_hierarchy_direction_label(self.direction)
+            ));
+            return;
+        }
+
+        if !entry.children.is_empty() {
+            self.state.toggle(selected);
+            return;
+        }
+
+        let Some(client) = cx
+            .editor
+            .language_servers
+            .get_by_id(entry.server_id)
+            .cloned()
+        else {
+            cx.editor
+                .set_error("Language server is no longer available");
+            return;
+        };
+
+        let item = entry.item.clone();
+        let parent_uri = item.uri.clone();
+        let direction = self.direction;
+        let server_id = entry.server_id;
+        let next_id = next_call_hierarchy_id(&self.entries);
+        let selected_path = selected.clone();
+        let opened = self.state.opened().clone();
+        let mut entries = self.entries.clone();
+
+        match direction {
+            CallHierarchyDirection::Incoming => {
+                let Some(request) = client.call_hierarchy_incoming(item) else {
+                    cx.editor
+                        .set_error("Language server does not support call hierarchy");
+                    return;
+                };
+                cx.jobs.callback(async move {
+                    let response = request.await?;
+                    let calls = response.unwrap_or_default();
+                    let offset_encoding = client.offset_encoding();
+                    let children = calls
+                        .into_iter()
+                        .enumerate()
+                        .filter_map(|(offset, call)| {
+                            incoming_call_hierarchy_entry(
+                                next_id + offset,
+                                call,
+                                offset_encoding,
+                                server_id,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+
+                    let call = move |editor: &mut Editor, compositor: &mut Compositor| {
+                        replace_call_hierarchy_children(
+                            editor,
+                            compositor,
+                            direction,
+                            &mut entries,
+                            selected_path,
+                            opened,
+                            children,
+                        );
+                    };
+
+                    Ok(Callback::EditorCompositor(Box::new(call)))
+                });
+            }
+            CallHierarchyDirection::Outgoing => {
+                let Some(request) = client.call_hierarchy_outgoing(item) else {
+                    cx.editor
+                        .set_error("Language server does not support call hierarchy");
+                    return;
+                };
+                cx.jobs.callback(async move {
+                    let response = request.await?;
+                    let calls = response.unwrap_or_default();
+                    let offset_encoding = client.offset_encoding();
+                    let children = calls
+                        .into_iter()
+                        .enumerate()
+                        .filter_map(|(offset, call)| {
+                            outgoing_call_hierarchy_entry(
+                                next_id + offset,
+                                call,
+                                &parent_uri,
+                                offset_encoding,
+                                server_id,
+                            )
+                        })
+                        .collect::<Vec<_>>();
+
+                    let call = move |editor: &mut Editor, compositor: &mut Compositor| {
+                        replace_call_hierarchy_children(
+                            editor,
+                            compositor,
+                            direction,
+                            &mut entries,
+                            selected_path,
+                            opened,
+                            children,
+                        );
+                    };
+
+                    Ok(Callback::EditorCompositor(Box::new(call)))
+                });
+            }
+        }
+    }
+}
+
+fn call_hierarchy_tree_items(entries: &[CallHierarchyEntry]) -> Vec<TreeItem<'static, usize>> {
+    entries.iter().map(call_hierarchy_tree_item).collect()
+}
+
+fn call_hierarchy_tree_item(entry: &CallHierarchyEntry) -> TreeItem<'static, usize> {
+    let text = call_hierarchy_entry_text(entry);
+    if entry.children.is_empty() {
+        if entry.has_children {
+            TreeItem::new(entry.id, text, vec![TreeItem::new_leaf(usize::MAX, "")])
+                .expect("placeholder identifier is unique")
+        } else {
+            TreeItem::new_leaf(entry.id, text)
+        }
+    } else {
+        TreeItem::new(entry.id, text, call_hierarchy_tree_items(&entry.children))
+            .expect("call hierarchy identifiers are unique")
+    }
+}
+
+fn call_hierarchy_entry_text(entry: &CallHierarchyEntry) -> String {
+    let detail = entry.item.detail.as_deref().unwrap_or_default();
+    let preview_line = entry.preview_location.range.start.line + 1;
+    format!(
+        "{:<9} {} {} {}:{}",
+        display_symbol_kind(entry.item.kind),
+        entry.item.name,
+        detail,
+        entry.location.uri,
+        preview_line,
+    )
+}
+
+fn find_call_hierarchy_entry<'a>(
+    entries: &'a [CallHierarchyEntry],
+    path: &[usize],
+) -> Option<&'a CallHierarchyEntry> {
+    let (id, rest) = path.split_first()?;
+    let entry = entries.iter().find(|entry| entry.id == *id)?;
+    if rest.is_empty() {
+        Some(entry)
+    } else {
+        find_call_hierarchy_entry(&entry.children, rest)
+    }
+}
+
+fn find_call_hierarchy_entry_mut<'a>(
+    entries: &'a mut [CallHierarchyEntry],
+    path: &[usize],
+) -> Option<&'a mut CallHierarchyEntry> {
+    let (id, rest) = path.split_first()?;
+    let entry = entries.iter_mut().find(|entry| entry.id == *id)?;
+    if rest.is_empty() {
+        Some(entry)
+    } else {
+        find_call_hierarchy_entry_mut(&mut entry.children, rest)
+    }
+}
+
+fn next_call_hierarchy_id(entries: &[CallHierarchyEntry]) -> usize {
+    fn max_id(entries: &[CallHierarchyEntry]) -> Option<usize> {
+        entries
+            .iter()
+            .map(|entry| {
+                max_id(&entry.children)
+                    .map(|child_id| child_id.max(entry.id))
+                    .unwrap_or(entry.id)
+            })
+            .max()
+    }
+
+    max_id(entries).unwrap_or(0) + 1
+}
+
+fn replace_call_hierarchy_children(
+    editor: &mut Editor,
+    compositor: &mut Compositor,
+    direction: CallHierarchyDirection,
+    entries: &mut [CallHierarchyEntry],
+    selected_path: Vec<usize>,
+    mut opened: HashSet<Vec<usize>>,
+    children: Vec<CallHierarchyEntry>,
+) {
+    let Some(entry) = find_call_hierarchy_entry_mut(entries, &selected_path) else {
+        return;
+    };
+    if children.is_empty() {
+        editor.set_status(format!(
+            "No {} calls.",
+            call_hierarchy_direction_label(direction)
+        ));
+        entry.has_children = false;
+    } else {
+        entry.children = children;
+        opened.insert(selected_path.clone());
+    }
+
+    let picker =
+        CallHierarchyPicker::with_state(direction, entries.to_vec(), opened, selected_path);
+    compositor.replace_or_push(ui::picker::ID, overlaid(picker));
+}
+
+impl Component for CallHierarchyPicker {
+    fn render(
+        &mut self,
+        area: helix_view::graphics::Rect,
+        surface: &mut tui::buffer::Buffer,
+        cx: &mut compositor::Context,
+    ) {
+        let render_preview =
+            self.selected_entry().is_some() && area.width > ui::picker::MIN_AREA_WIDTH_FOR_PREVIEW;
+
+        let tree_width = if render_preview {
+            area.width / 2
+        } else {
+            area.width
+        };
+
+        let tree_area = area.with_width(tree_width);
+        self.render_tree(tree_area, surface, cx);
+
+        if render_preview {
+            let preview_area = area.clip_left(tree_width);
+            let location = self.selected_entry().and_then(|entry| {
+                let path = entry.preview_location.uri.as_path()?.to_path_buf();
+                let line = Some((
+                    entry.preview_location.range.start.line as usize,
+                    entry.preview_location.range.end.line as usize,
+                ));
+                Some((path, line))
+            });
+            if let Some((path, range)) = &location {
+                self.preview.render(
+                    preview_area,
+                    surface,
+                    cx,
+                    Some((ui::picker::PathOrId::Path(path.as_path()), *range)),
+                );
+            } else {
+                self.preview.render(preview_area, surface, cx, None);
+            }
+        }
+    }
+
+    fn handle_event(&mut self, event: &Event, ctx: &mut compositor::Context) -> EventResult {
+        let key_event = match event {
+            Event::Key(event) => *event,
+            Event::Resize(..) | Event::Mouse(_) => return EventResult::Consumed(None),
+            _ => return EventResult::Ignored(None),
+        };
+
+        let close: compositor::Callback = Box::new(|compositor: &mut Compositor, _ctx| {
+            compositor.pop();
+        });
+
+        match key_event {
+            key!(Up) | shift!(Tab) | ctrl!('p') => {
+                self.state.key_up();
+            }
+            key!(Down) | key!(Tab) | ctrl!('n') => {
+                self.state.key_down();
+            }
+            key!(PageUp) | ctrl!('u') => {
+                self.state.scroll_up(10);
+            }
+            key!(PageDown) | ctrl!('d') => {
+                self.state.scroll_down(10);
+            }
+            key!(Home) => {
+                self.state.select_first();
+            }
+            key!(End) => {
+                self.state.select_last();
+            }
+            key!(Left) => {
+                self.state.key_left();
+            }
+            key!(Right) | key!(Enter) => {
+                self.toggle_selected(ctx);
+            }
+            alt!(Enter) => {
+                self.jump_selected(ctx.editor, Action::Replace);
+            }
+            ctrl!('s') => {
+                self.jump_selected(ctx.editor, Action::HorizontalSplit);
+                return EventResult::Consumed(Some(close));
+            }
+            ctrl!('v') => {
+                self.jump_selected(ctx.editor, Action::VerticalSplit);
+                return EventResult::Consumed(Some(close));
+            }
+            key!(Esc) | ctrl!('c') => return EventResult::Consumed(Some(close)),
+            _ => {}
+        }
+
+        EventResult::Consumed(None)
+    }
+
+    fn id(&self) -> Option<&'static str> {
+        Some(ui::picker::ID)
     }
 }
 
@@ -1082,6 +1621,115 @@ pub fn goto_reference(cx: &mut Context) {
                 goto_impl(editor, compositor, locations);
             }
         };
+        Ok(Callback::EditorCompositor(Box::new(call)))
+    });
+}
+
+pub fn call_hierarchy_incoming(cx: &mut Context) {
+    call_hierarchy(cx, CallHierarchyDirection::Incoming);
+}
+
+pub fn call_hierarchy_outgoing(cx: &mut Context) {
+    call_hierarchy(cx, CallHierarchyDirection::Outgoing);
+}
+
+fn call_hierarchy(cx: &mut Context, direction: CallHierarchyDirection) {
+    let (view, doc) = current_ref!(cx.editor);
+
+    let mut seen_language_servers = HashSet::new();
+    let mut futures: FuturesOrdered<_> = doc
+        .language_servers_with_feature(LanguageServerFeature::CallHierarchy)
+        .filter(|ls| seen_language_servers.insert(ls.id()))
+        .map(|language_server| {
+            let server_id = language_server.id();
+            let client = cx.editor.language_servers.get_by_id(server_id).cloned();
+            let offset_encoding = language_server.offset_encoding();
+            let pos = doc.position(view.id, offset_encoding);
+            let request = language_server
+                .prepare_call_hierarchy(doc.identifier(), pos)
+                .unwrap();
+            async move {
+                let Some(client) = client else {
+                    return anyhow::Ok(Vec::new());
+                };
+                let items = request.await?.unwrap_or_default();
+                let mut entries = Vec::new();
+                for item in items {
+                    match direction {
+                        CallHierarchyDirection::Incoming => {
+                            let Some(request) = client.call_hierarchy_incoming(item) else {
+                                continue;
+                            };
+                            let calls = request.await?.unwrap_or_default();
+                            let offset_encoding = client.offset_encoding();
+                            for call in calls {
+                                if let Some(entry) = incoming_call_hierarchy_entry(
+                                    entries.len(),
+                                    call,
+                                    offset_encoding,
+                                    server_id,
+                                ) {
+                                    entries.push(entry);
+                                }
+                            }
+                        }
+                        CallHierarchyDirection::Outgoing => {
+                            let parent_uri = item.uri.clone();
+                            let Some(request) = client.call_hierarchy_outgoing(item) else {
+                                continue;
+                            };
+                            let calls = request.await?.unwrap_or_default();
+                            let offset_encoding = client.offset_encoding();
+                            for call in calls {
+                                if let Some(entry) = outgoing_call_hierarchy_entry(
+                                    entries.len(),
+                                    call,
+                                    &parent_uri,
+                                    offset_encoding,
+                                    server_id,
+                                ) {
+                                    entries.push(entry);
+                                }
+                            }
+                        }
+                    }
+                }
+                anyhow::Ok(entries)
+            }
+        })
+        .collect();
+
+    if futures.is_empty() {
+        cx.editor
+            .set_error("No configured language server supports call hierarchy");
+        return;
+    }
+
+    cx.jobs.callback(async move {
+        let mut entries = Vec::new();
+        while let Some(response) = futures.next().await {
+            match response {
+                Ok(mut items) => entries.append(&mut items),
+                Err(err) => log::error!("Error requesting call hierarchy: {err}"),
+            }
+        }
+        for (id, entry) in entries.iter_mut().enumerate() {
+            entry.id = id;
+        }
+
+        let call = move |editor: &mut Editor, compositor: &mut Compositor| {
+            if entries.is_empty() {
+                editor.set_status(format!(
+                    "No {} calls.",
+                    call_hierarchy_direction_label(direction)
+                ));
+                return;
+            }
+
+            let picker = CallHierarchyPicker::new(direction, entries);
+            compositor.push(Box::new(overlaid(picker)));
+        };
+
         Ok(Callback::EditorCompositor(Box::new(call)))
     });
 }

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -24,7 +24,7 @@ use helix_stdx::rope;
 use helix_view::theme::Style;
 pub use markdown::Markdown;
 pub use menu::Menu;
-pub use picker::{Column as PickerColumn, FileLocation, Picker};
+pub use picker::{tree_picker, Column as PickerColumn, FileLocation, Picker, TreeItem, TreePicker};
 pub use popup::Popup;
 pub use prompt::{Prompt, PromptEvent};
 pub use select::Select;

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -129,6 +129,251 @@ impl Preview<'_, '_> {
     }
 }
 
+#[derive(Default)]
+pub(crate) struct FilePreview {
+    preview_cache: HashMap<Arc<Path>, CachedPreview>,
+    read_buffer: Vec<u8>,
+}
+
+impl FilePreview {
+    /// Render a file preview for a location using the same layout as picker previews.
+    pub(crate) fn render(
+        &mut self,
+        area: Rect,
+        surface: &mut Surface,
+        cx: &Context,
+        location: Option<FileLocation<'_>>,
+    ) {
+        let background = cx.editor.theme.get("ui.background");
+        let text = cx.editor.theme.get("ui.text");
+        let directory = cx.editor.theme.get("ui.text.directory");
+        surface.clear_with(area, background);
+
+        const BLOCK: Block<'_> = Block::bordered();
+
+        let inner = BLOCK.inner(area);
+        let inner = inner.inner(Margin::horizontal(1));
+        BLOCK.render(area, surface);
+
+        let Some(location) = location else {
+            return;
+        };
+        let Some((preview, range)) = self.get(cx.editor, location) else {
+            return;
+        };
+
+        let doc = match preview.document() {
+            Some(doc)
+                if range
+                    .is_none_or(|(start, end)| start <= end && end <= doc.text().len_lines()) =>
+            {
+                doc
+            }
+            _ => {
+                if let Some(dir_content) = preview.dir_content() {
+                    for (i, (path, is_dir)) in
+                        dir_content.iter().take(inner.height as usize).enumerate()
+                    {
+                        let style = if *is_dir { directory } else { text };
+                        surface.set_stringn(
+                            inner.x,
+                            inner.y + i as u16,
+                            path,
+                            inner.width as usize,
+                            style,
+                        );
+                    }
+                    return;
+                }
+
+                let alt_text = preview.placeholder();
+                let x = inner.x + inner.width.saturating_sub(alt_text.len() as u16) / 2;
+                let y = inner.y + inner.height / 2;
+                surface.set_stringn(x, y, alt_text, inner.width as usize, text);
+                return;
+            }
+        };
+
+        render_preview_document(surface, inner, area, cx, doc, range);
+    }
+
+    fn get<'preview, 'editor>(
+        &'preview mut self,
+        editor: &'editor Editor,
+        (path_or_id, range): FileLocation<'_>,
+    ) -> Option<(Preview<'preview, 'editor>, Option<(usize, usize)>)> {
+        match path_or_id {
+            PathOrId::Path(path) => {
+                if let Some(doc) = editor.document_by_path(path) {
+                    return Some((Preview::EditorDocument(doc), range));
+                }
+
+                if self.preview_cache.contains_key(path) {
+                    return Some((Preview::Cached(&self.preview_cache[path]), range));
+                }
+
+                let path: Arc<Path> = path.into();
+                let preview = std::fs::metadata(&path)
+                    .and_then(|metadata| {
+                        if metadata.is_dir() {
+                            let files = super::directory_content(&path, editor)?;
+                            let file_names: Vec<_> = files
+                                .iter()
+                                .filter_map(|(file_path, is_dir)| {
+                                    let name = file_path
+                                        .strip_prefix(&path)
+                                        .map(|p| Some(p.as_os_str()))
+                                        .unwrap_or_else(|_| file_path.file_name())?
+                                        .to_string_lossy();
+                                    if *is_dir {
+                                        Some((format!("{name}/"), true))
+                                    } else {
+                                        Some((name.into_owned(), false))
+                                    }
+                                })
+                                .collect();
+                            Ok(CachedPreview::Directory(file_names))
+                        } else if metadata.is_file() {
+                            if metadata.len() > MAX_FILE_SIZE_FOR_PREVIEW {
+                                return Ok(CachedPreview::LargeFile);
+                            }
+                            let is_binary = std::fs::File::open(&path).and_then(|file| {
+                                let n = file.take(1024).read_to_end(&mut self.read_buffer)?;
+                                let is_binary = crate::is_binary(&self.read_buffer[..n]);
+                                self.read_buffer.clear();
+                                Ok(is_binary)
+                            })?;
+                            if is_binary {
+                                return Ok(CachedPreview::Binary);
+                            }
+                            let mut doc = Document::open(
+                                &path,
+                                None,
+                                false,
+                                editor.config.clone(),
+                                editor.syn_loader.clone(),
+                            )
+                            .or(Err(std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "Cannot open document",
+                            )))?;
+                            let loader = editor.syn_loader.load();
+                            if let Some(language_config) = doc.detect_language_config(&loader) {
+                                doc.set_language(Some(language_config), &loader);
+                            }
+                            Ok(CachedPreview::Document(Box::new(doc)))
+                        } else {
+                            Err(std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "Neither a dir, nor a file",
+                            ))
+                        }
+                    })
+                    .unwrap_or(CachedPreview::NotFound);
+                self.preview_cache.insert(path.clone(), preview);
+                Some((Preview::Cached(&self.preview_cache[&path]), range))
+            }
+            PathOrId::Id(id) => {
+                let doc = editor.documents.get(&id).unwrap();
+                Some((Preview::EditorDocument(doc), range))
+            }
+        }
+    }
+}
+
+fn render_preview_document(
+    surface: &mut Surface,
+    inner: Rect,
+    area: Rect,
+    cx: &Context,
+    doc: &Document,
+    range: Option<(usize, usize)>,
+) {
+    let mut offset = ViewPosition::default();
+    if let Some((start_line, end_line)) = range {
+        let height = end_line - start_line;
+        let text = doc.text().slice(..);
+        let start = text.line_to_char(start_line);
+        let middle = text.line_to_char(start_line + height / 2);
+        if height < inner.height as usize {
+            let text_fmt = doc.text_format(inner.width, None);
+            let annotations = TextAnnotations::default();
+            (offset.anchor, offset.vertical_offset) = char_idx_at_visual_offset(
+                text,
+                middle,
+                -(inner.height as isize / 2),
+                0,
+                &text_fmt,
+                &annotations,
+            );
+            if start < offset.anchor {
+                offset.anchor = start;
+                offset.vertical_offset = 0;
+            }
+        } else {
+            offset.anchor = start;
+        }
+    }
+
+    let loader = cx.editor.syn_loader.load();
+    let config = cx.editor.config();
+
+    let syntax_highlighter =
+        EditorView::doc_syntax_highlighter(doc, offset.anchor, area.height, &loader);
+    let mut overlay_highlights = Vec::new();
+    if doc
+        .language_config()
+        .and_then(|config| config.rainbow_brackets)
+        .unwrap_or(config.rainbow_brackets)
+    {
+        if let Some(overlay) = EditorView::doc_rainbow_highlights(
+            doc,
+            offset.anchor,
+            area.height,
+            &cx.editor.theme,
+            &loader,
+        ) {
+            overlay_highlights.push(overlay);
+        }
+    }
+
+    EditorView::doc_diagnostics_highlights_into(doc, &cx.editor.theme, &mut overlay_highlights);
+
+    let mut decorations = DecorationManager::default();
+
+    if let Some((start, end)) = range {
+        let style = cx
+            .editor
+            .theme
+            .try_get("ui.highlight")
+            .unwrap_or_else(|| cx.editor.theme.get("ui.selection"));
+        let draw_highlight = move |renderer: &mut TextRenderer, pos: LinePos| {
+            if (start..=end).contains(&pos.doc_line) {
+                let area = Rect::new(
+                    renderer.viewport.x,
+                    pos.visual_line,
+                    renderer.viewport.width,
+                    1,
+                );
+                renderer.set_style(area, style)
+            }
+        };
+        decorations.add_decoration(draw_highlight);
+    }
+
+    render_document(
+        surface,
+        inner,
+        doc,
+        offset,
+        &TextAnnotations::default(),
+        syntax_highlighter,
+        overlay_highlights,
+        &cx.editor.theme,
+        decorations,
+    );
+}
+
 fn inject_nucleo_item<T, D>(
     injector: &nucleo::Injector<T>,
     columns: &[Column<T, D>],
@@ -233,6 +478,67 @@ impl<T, D> Column<T, D> {
     }
 }
 
+pub struct TreeItem<T> {
+    item: T,
+    depth: usize,
+    expanded: bool,
+    has_children: bool,
+}
+
+impl<T> TreeItem<T> {
+    pub fn new(item: T, depth: usize, expanded: bool, has_children: bool) -> Self {
+        Self {
+            item,
+            depth,
+            expanded,
+            has_children,
+        }
+    }
+
+    pub fn item(&self) -> &T {
+        &self.item
+    }
+
+    pub fn marker(&self) -> String {
+        tree_marker(self.depth, self.expanded, self.has_children)
+    }
+}
+
+pub type TreePicker<T, D> = Picker<TreeItem<T>, D>;
+
+pub fn tree_picker<T, D, C, O, F>(
+    columns: C,
+    primary_column: usize,
+    options: O,
+    editor_data: D,
+    callback_fn: F,
+) -> TreePicker<T, D>
+where
+    T: 'static + Send + Sync,
+    D: 'static + Send + Sync,
+    C: IntoIterator<Item = Column<TreeItem<T>, D>>,
+    O: IntoIterator<Item = TreeItem<T>>,
+    F: Fn(&mut Context, &T, Action) + 'static,
+{
+    Picker::new(
+        columns,
+        primary_column,
+        options,
+        editor_data,
+        move |cx, row, action| callback_fn(cx, &row.item, action),
+    )
+}
+
+fn tree_marker(depth: usize, expanded: bool, has_children: bool) -> String {
+    let mut prefix = "  ".repeat(depth);
+    if has_children {
+        prefix.push(if expanded { '▼' } else { '▶' });
+    } else {
+        prefix.push(' ');
+    }
+    prefix
+}
+
 /// Returns a new list of options to replace the contents of the picker
 /// when called with the current picker query,
 type DynQueryCallback<T, D> =
@@ -259,6 +565,7 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
 
     callback_fn: PickerCallback<T>,
     default_action: Action,
+    close_on_accept: bool,
 
     pub truncate_start: bool,
     /// Caches paths to documents
@@ -387,6 +694,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             show_preview: true,
             callback_fn: Box::new(callback_fn),
             default_action: Action::Replace,
+            close_on_accept: true,
             completion_height: 0,
             widths,
             preview_cache: HashMap::new(),
@@ -452,6 +760,11 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
 
     pub fn with_default_action(mut self, action: Action) -> Self {
         self.default_action = action;
+        self
+    }
+
+    pub fn close_on_accept(mut self, close_on_accept: bool) -> Self {
+        self.close_on_accept = close_on_accept;
         self
     }
 
@@ -1143,7 +1456,9 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                             ctx.editor.set_error(err.to_string());
                         }
                     }
-                    return close_fn(self);
+                    if self.close_on_accept {
+                        return close_fn(self);
+                    }
                 }
             }
             ctrl!('s') => {

--- a/helix-tui/src/widgets/mod.rs
+++ b/helix-tui/src/widgets/mod.rs
@@ -8,17 +8,20 @@
 // //! - [`List`]
 // //! - [`Table`]
 //! - [`Paragraph`]
+//! - [`Tree`]
 
 mod block;
 // mod list;
 mod paragraph;
 mod reflow;
 mod table;
+mod tree;
 
 pub use self::block::{Block, BorderType};
 // pub use self::list::{List, ListItem, ListState};
 pub use self::paragraph::{Paragraph, Wrap};
 pub use self::table::{Cell, Row, Table, TableState};
+pub use self::tree::{Flattened, Tree, TreeItem, TreeState};
 
 use crate::buffer::Buffer;
 use bitflags::bitflags;

--- a/helix-tui/src/widgets/tree.rs
+++ b/helix-tui/src/widgets/tree.rs
@@ -1,0 +1,810 @@
+//! Tree widget for hierarchical data.
+//!
+//! Ported from `tui-tree-widget` 0.24.0 and adapted to Helix's local TUI
+//! types and widget conventions.
+
+use crate::{
+    buffer::Buffer,
+    text::Text,
+    widgets::{Block, Widget},
+};
+use helix_core::unicode::width::UnicodeWidthStr;
+use helix_view::graphics::{Rect, Style};
+use std::collections::{hash_set, HashSet};
+
+/// One item inside a [`Tree`].
+///
+/// The identifier is used by [`TreeState`] to keep track of selected and open
+/// nodes. Identifiers only need to be unique among siblings.
+#[derive(Debug, Clone)]
+pub struct TreeItem<'text, Identifier> {
+    identifier: Identifier,
+    text: Text<'text>,
+    children: Vec<Self>,
+}
+
+impl<'text, Identifier> TreeItem<'text, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    /// Create a new `TreeItem` without children.
+    pub fn new_leaf<T>(identifier: Identifier, text: T) -> Self
+    where
+        T: Into<Text<'text>>,
+    {
+        Self {
+            identifier,
+            text: text.into(),
+            children: Vec::new(),
+        }
+    }
+
+    /// Create a new `TreeItem` with children.
+    ///
+    /// Returns an error when any child identifiers are duplicated.
+    pub fn new<T>(identifier: Identifier, text: T, children: Vec<Self>) -> std::io::Result<Self>
+    where
+        T: Into<Text<'text>>,
+    {
+        let identifiers = children
+            .iter()
+            .map(|item| &item.identifier)
+            .collect::<HashSet<_>>();
+        if identifiers.len() != children.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "The children contain duplicate identifiers",
+            ));
+        }
+
+        Ok(Self {
+            identifier,
+            text: text.into(),
+            children,
+        })
+    }
+
+    pub const fn identifier(&self) -> &Identifier {
+        &self.identifier
+    }
+
+    pub fn text(&self) -> &Text<'text> {
+        &self.text
+    }
+
+    pub fn children(&self) -> &[Self] {
+        &self.children
+    }
+
+    pub fn child(&self, index: usize) -> Option<&Self> {
+        self.children.get(index)
+    }
+
+    /// Get a mutable reference to a child by index.
+    ///
+    /// Changing identifiers after rendering can make existing [`TreeState`]
+    /// selections point at stale nodes.
+    pub fn child_mut(&mut self, index: usize) -> Option<&mut Self> {
+        self.children.get_mut(index)
+    }
+
+    pub fn height(&self) -> usize {
+        self.text.height()
+    }
+
+    /// Add a child.
+    ///
+    /// Returns an error when the child's identifier already exists among this
+    /// node's children.
+    pub fn add_child(&mut self, child: Self) -> std::io::Result<()> {
+        let existing = self
+            .children
+            .iter()
+            .map(|item| &item.identifier)
+            .collect::<HashSet<_>>();
+        if existing.contains(&child.identifier) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "identifier already exists in the children",
+            ));
+        }
+
+        self.children.push(child);
+        Ok(())
+    }
+}
+
+impl TreeItem<'static, &'static str> {
+    #[cfg(test)]
+    fn example() -> Vec<Self> {
+        vec![
+            Self::new_leaf("a", "Alfa"),
+            Self::new(
+                "b",
+                "Bravo",
+                vec![
+                    Self::new_leaf("c", "Charlie"),
+                    Self::new(
+                        "d",
+                        "Delta",
+                        vec![Self::new_leaf("e", "Echo"), Self::new_leaf("f", "Foxtrot")],
+                    )
+                    .expect("all item identifiers are unique"),
+                    Self::new_leaf("g", "Golf"),
+                ],
+            )
+            .expect("all item identifiers are unique"),
+            Self::new_leaf("h", "Hotel"),
+        ]
+    }
+}
+
+/// A flattened visible tree item.
+pub struct Flattened<'text, Identifier> {
+    pub identifier: Vec<Identifier>,
+    pub item: &'text TreeItem<'text, Identifier>,
+}
+
+impl<Identifier> Flattened<'_, Identifier> {
+    /// Zero-based depth. Depth 0 means top-level with no indentation.
+    pub fn depth(&self) -> usize {
+        self.identifier.len() - 1
+    }
+}
+
+fn flatten<'text, Identifier>(
+    open_identifiers: &HashSet<Vec<Identifier>>,
+    items: &'text [TreeItem<'text, Identifier>],
+    current: &[Identifier],
+) -> Vec<Flattened<'text, Identifier>>
+where
+    Identifier: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    let mut result = Vec::new();
+    for item in items {
+        let mut child_identifier = current.to_vec();
+        child_identifier.push(item.identifier.clone());
+
+        let child_result = open_identifiers
+            .contains(&child_identifier)
+            .then(|| flatten(open_identifiers, &item.children, &child_identifier));
+
+        result.push(Flattened {
+            identifier: child_identifier,
+            item,
+        });
+
+        if let Some(mut child_result) = child_result {
+            result.append(&mut child_result);
+        }
+    }
+    result
+}
+
+/// State for selected, open, and scrolled tree nodes.
+#[derive(Debug)]
+pub struct TreeState<Identifier> {
+    offset: usize,
+    opened: HashSet<Vec<Identifier>>,
+    selected: Vec<Identifier>,
+    ensure_selected_in_view_on_next_render: bool,
+
+    last_area: Rect,
+    last_biggest_index: usize,
+    last_identifiers: Vec<Vec<Identifier>>,
+    last_rendered_identifiers: Vec<(u16, Vec<Identifier>)>,
+}
+
+impl<Identifier> Default for TreeState<Identifier> {
+    fn default() -> Self {
+        Self {
+            offset: 0,
+            opened: HashSet::new(),
+            selected: Vec::new(),
+            ensure_selected_in_view_on_next_render: false,
+
+            last_area: Rect::default(),
+            last_biggest_index: 0,
+            last_identifiers: Vec::new(),
+            last_rendered_identifiers: Vec::new(),
+        }
+    }
+}
+
+impl<Identifier> TreeState<Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    pub const fn offset(&self) -> usize {
+        self.offset
+    }
+
+    pub const fn opened(&self) -> &HashSet<Vec<Identifier>> {
+        &self.opened
+    }
+
+    pub fn opened_mut(&mut self) -> &mut HashSet<Vec<Identifier>> {
+        &mut self.opened
+    }
+
+    pub fn opened_iter(&self) -> hash_set::Iter<'_, Vec<Identifier>> {
+        self.opened.iter()
+    }
+
+    pub fn selected(&self) -> &[Identifier] {
+        &self.selected
+    }
+
+    /// Get all currently visible tree items.
+    pub fn flatten<'text>(
+        &self,
+        items: &'text [TreeItem<'text, Identifier>],
+    ) -> Vec<Flattened<'text, Identifier>> {
+        flatten(&self.opened, items, &[])
+    }
+
+    /// Select the given identifier. Pass an empty vector to clear selection.
+    ///
+    /// Returns `true` when the selection changed.
+    pub fn select(&mut self, identifier: Vec<Identifier>) -> bool {
+        self.ensure_selected_in_view_on_next_render = true;
+        let changed = self.selected != identifier;
+        self.selected = identifier;
+        changed
+    }
+
+    /// Open a tree node.
+    ///
+    /// Returns `true` when the node was previously closed.
+    pub fn open(&mut self, identifier: Vec<Identifier>) -> bool {
+        if identifier.is_empty() {
+            false
+        } else {
+            self.opened.insert(identifier)
+        }
+    }
+
+    /// Close a tree node.
+    ///
+    /// Returns `true` when the node was previously open.
+    pub fn close(&mut self, identifier: &[Identifier]) -> bool {
+        self.opened.remove(identifier)
+    }
+
+    /// Toggle a tree node open or closed.
+    pub fn toggle(&mut self, identifier: Vec<Identifier>) -> bool {
+        if identifier.is_empty() {
+            false
+        } else if self.opened.contains(&identifier) {
+            self.close(&identifier)
+        } else {
+            self.open(identifier)
+        }
+    }
+
+    /// Toggle the selected node open or closed.
+    pub fn toggle_selected(&mut self) -> bool {
+        if self.selected.is_empty() {
+            return false;
+        }
+
+        self.ensure_selected_in_view_on_next_render = true;
+
+        let was_open = self.opened.remove(&self.selected);
+        if was_open {
+            return true;
+        }
+
+        self.open(self.selected.clone())
+    }
+
+    /// Close all open nodes.
+    pub fn close_all(&mut self) -> bool {
+        if self.opened.is_empty() {
+            false
+        } else {
+            self.opened.clear();
+            true
+        }
+    }
+
+    pub fn select_first(&mut self) -> bool {
+        let identifier = self.last_identifiers.first().cloned().unwrap_or_default();
+        self.select(identifier)
+    }
+
+    pub fn select_last(&mut self) -> bool {
+        let identifier = self.last_identifiers.last().cloned().unwrap_or_default();
+        self.select(identifier)
+    }
+
+    pub fn select_relative<F>(&mut self, change_function: F) -> bool
+    where
+        F: FnOnce(Option<usize>) -> usize,
+    {
+        let current_index = self
+            .last_identifiers
+            .iter()
+            .position(|identifier| identifier == &self.selected);
+        let new_index = change_function(current_index).min(self.last_biggest_index);
+        let new_identifier = self
+            .last_identifiers
+            .get(new_index)
+            .cloned()
+            .unwrap_or_default();
+        self.select(new_identifier)
+    }
+
+    /// Get the identifier rendered at the given coordinates during the last render.
+    pub fn rendered_at(&self, x: u16, y: u16) -> Option<&[Identifier]> {
+        if !rect_contains(self.last_area, x, y) {
+            return None;
+        }
+
+        self.last_rendered_identifiers
+            .iter()
+            .rev()
+            .find(|(rendered_y, _)| y >= *rendered_y)
+            .map(|(_, identifier)| identifier.as_ref())
+    }
+
+    /// Select what was rendered at the given coordinates. If it is already
+    /// selected, toggle it.
+    pub fn click_at(&mut self, x: u16, y: u16) -> bool {
+        if let Some(identifier) = self.rendered_at(x, y) {
+            if identifier == self.selected {
+                self.toggle_selected()
+            } else {
+                self.select(identifier.to_vec())
+            }
+        } else {
+            false
+        }
+    }
+
+    pub const fn scroll_selected_into_view(&mut self) {
+        self.ensure_selected_in_view_on_next_render = true;
+    }
+
+    pub const fn scroll_up(&mut self, lines: usize) -> bool {
+        let before = self.offset;
+        self.offset = self.offset.saturating_sub(lines);
+        before != self.offset
+    }
+
+    pub fn scroll_down(&mut self, lines: usize) -> bool {
+        let before = self.offset;
+        self.offset = self
+            .offset
+            .saturating_add(lines)
+            .min(self.last_biggest_index);
+        before != self.offset
+    }
+
+    pub fn key_up(&mut self) -> bool {
+        self.select_relative(|current| {
+            current.map_or(usize::MAX, |current| current.saturating_sub(1))
+        })
+    }
+
+    pub fn key_down(&mut self) -> bool {
+        self.select_relative(|current| current.map_or(0, |current| current.saturating_add(1)))
+    }
+
+    pub fn key_left(&mut self) -> bool {
+        self.ensure_selected_in_view_on_next_render = true;
+        let mut changed = self.opened.remove(&self.selected);
+        if !changed {
+            changed = self.selected.pop().is_some();
+        }
+        changed
+    }
+
+    pub fn key_right(&mut self) -> bool {
+        if self.selected.is_empty() {
+            false
+        } else {
+            self.ensure_selected_in_view_on_next_render = true;
+            self.open(self.selected.clone())
+        }
+    }
+}
+
+/// A renderable tree.
+#[derive(Debug, Clone)]
+pub struct Tree<'a, Identifier> {
+    items: &'a [TreeItem<'a, Identifier>],
+
+    block: Option<Block<'a>>,
+    style: Style,
+    highlight_style: Style,
+    highlight_symbol: &'a str,
+
+    node_closed_symbol: &'a str,
+    node_open_symbol: &'a str,
+    node_no_children_symbol: &'a str,
+}
+
+impl<'a, Identifier> Tree<'a, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    /// Create a new `Tree`.
+    ///
+    /// Returns an error when top-level identifiers are duplicated.
+    pub fn new(items: &'a [TreeItem<'a, Identifier>]) -> std::io::Result<Self> {
+        let identifiers = items
+            .iter()
+            .map(|item| &item.identifier)
+            .collect::<HashSet<_>>();
+        if identifiers.len() != items.len() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "The items contain duplicate identifiers",
+            ));
+        }
+
+        Ok(Self {
+            items,
+            block: None,
+            style: Style::default(),
+            highlight_style: Style::default(),
+            highlight_symbol: "",
+            node_closed_symbol: "\u{25b6} ",
+            node_open_symbol: "\u{25bc} ",
+            node_no_children_symbol: "  ",
+        })
+    }
+
+    pub fn block(mut self, block: Block<'a>) -> Self {
+        self.block = Some(block);
+        self
+    }
+
+    pub const fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    pub const fn highlight_style(mut self, style: Style) -> Self {
+        self.highlight_style = style;
+        self
+    }
+
+    pub const fn highlight_symbol(mut self, highlight_symbol: &'a str) -> Self {
+        self.highlight_symbol = highlight_symbol;
+        self
+    }
+
+    pub const fn node_closed_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_closed_symbol = symbol;
+        self
+    }
+
+    pub const fn node_open_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_open_symbol = symbol;
+        self
+    }
+
+    pub const fn node_no_children_symbol(mut self, symbol: &'a str) -> Self {
+        self.node_no_children_symbol = symbol;
+        self
+    }
+
+    pub fn render_tree(
+        mut self,
+        full_area: Rect,
+        buf: &mut Buffer,
+        state: &mut TreeState<Identifier>,
+    ) {
+        buf.set_style(full_area, self.style);
+
+        let area = match self.block.take() {
+            Some(block) => {
+                let inner_area = block.inner(full_area);
+                block.render(full_area, buf);
+                inner_area
+            }
+            None => full_area,
+        };
+
+        state.last_area = area;
+        state.last_rendered_identifiers.clear();
+        if area.width < 1 || area.height < 1 {
+            return;
+        }
+
+        let visible = state.flatten(self.items);
+        state.last_biggest_index = visible.len().saturating_sub(1);
+        if visible.is_empty() {
+            return;
+        }
+        let available_height = area.height as usize;
+
+        let ensure_index_in_view =
+            if state.ensure_selected_in_view_on_next_render && !state.selected.is_empty() {
+                visible
+                    .iter()
+                    .position(|flattened| flattened.identifier == state.selected)
+            } else {
+                None
+            };
+
+        let mut start = state.offset.min(state.last_biggest_index);
+        if let Some(ensure_index_in_view) = ensure_index_in_view {
+            start = start.min(ensure_index_in_view);
+        }
+
+        let mut end = start;
+        let mut height = 0;
+        for item_height in visible
+            .iter()
+            .skip(start)
+            .map(|flattened| flattened.item.height())
+        {
+            if height + item_height > available_height {
+                break;
+            }
+            height += item_height;
+            end += 1;
+        }
+
+        if let Some(ensure_index_in_view) = ensure_index_in_view {
+            while ensure_index_in_view >= end {
+                height += visible[end].item.height();
+                end += 1;
+                while height > available_height {
+                    height = height.saturating_sub(visible[start].item.height());
+                    start += 1;
+                }
+            }
+        }
+
+        state.offset = start;
+        state.ensure_selected_in_view_on_next_render = false;
+
+        let blank_symbol = " ".repeat(self.highlight_symbol.width());
+
+        let mut current_height = 0;
+        let has_selection = !state.selected.is_empty();
+        for flattened in visible.iter().skip(state.offset).take(end - start) {
+            let Flattened { identifier, item } = flattened;
+
+            let x = area.x;
+            let y = area.y + current_height;
+            let height = item.height() as u16;
+            current_height += height;
+
+            let row_area = Rect {
+                x,
+                y,
+                width: area.width,
+                height,
+            };
+
+            let is_selected = state.selected == *identifier;
+            let after_highlight_symbol_x = if has_selection {
+                let symbol = if is_selected {
+                    self.highlight_symbol
+                } else {
+                    &blank_symbol
+                };
+                let (x, _) = buf.set_stringn(x, y, symbol, row_area.width as usize, self.style);
+                x
+            } else {
+                x
+            };
+
+            let after_depth_x = {
+                let indent_width = flattened.depth() * 2;
+                let (after_indent_x, _) = buf.set_stringn(
+                    after_highlight_symbol_x,
+                    y,
+                    &" ".repeat(indent_width),
+                    indent_width,
+                    self.style,
+                );
+                let symbol = if item.children.is_empty() {
+                    self.node_no_children_symbol
+                } else if state.opened.contains(identifier) {
+                    self.node_open_symbol
+                } else {
+                    self.node_closed_symbol
+                };
+                let max_width = row_area.width.saturating_sub(after_indent_x - x);
+                let (x, _) =
+                    buf.set_stringn(after_indent_x, y, symbol, max_width as usize, self.style);
+                x
+            };
+
+            let text_area = Rect {
+                x: after_depth_x,
+                width: row_area.width.saturating_sub(after_depth_x - x),
+                ..row_area
+            };
+            render_text(buf, item.text(), text_area);
+
+            if is_selected {
+                buf.set_style(row_area, self.highlight_style);
+            }
+
+            state
+                .last_rendered_identifiers
+                .push((row_area.y, identifier.clone()));
+        }
+        state.last_identifiers = visible
+            .into_iter()
+            .map(|flattened| flattened.identifier)
+            .collect();
+    }
+}
+
+impl<Identifier> Widget for Tree<'_, Identifier>
+where
+    Identifier: Clone + PartialEq + Eq + std::hash::Hash,
+{
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let mut state = TreeState::default();
+        self.render_tree(area, buf, &mut state);
+    }
+}
+
+fn rect_contains(area: Rect, x: u16, y: u16) -> bool {
+    x >= area.x && x < area.right() && y >= area.y && y < area.bottom()
+}
+
+fn render_text(buf: &mut Buffer, text: &Text, area: Rect) {
+    for (i, spans) in text.lines.iter().enumerate() {
+        if i as u16 >= area.height {
+            break;
+        }
+        buf.set_spans(area.x, area.y + i as u16, spans, area.width);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(width: u16, height: u16, state: &mut TreeState<&'static str>) -> Buffer {
+        let items = TreeItem::example();
+        let tree = Tree::new(&items).unwrap();
+        let area = Rect::new(0, 0, width, height);
+        let mut buffer = Buffer::empty(area);
+        tree.render_tree(area, &mut buffer, state);
+        buffer
+    }
+
+    #[test]
+    #[should_panic = "duplicate identifiers"]
+    fn tree_new_errors_with_duplicate_identifiers() {
+        let item = TreeItem::new_leaf("same", "text");
+        let another = item.clone();
+        let _: Tree<_> = Tree::new(&[item, another]).unwrap();
+    }
+
+    #[test]
+    #[should_panic = "duplicate identifiers"]
+    fn tree_item_new_errors_with_duplicate_identifiers() {
+        let item = TreeItem::new_leaf("same", "text");
+        let another = item.clone();
+        TreeItem::new("root", "Root", vec![item, another]).unwrap();
+    }
+
+    #[test]
+    #[should_panic = "identifier already exists"]
+    fn tree_item_add_child_errors_with_duplicate_identifiers() {
+        let item = TreeItem::new_leaf("same", "text");
+        let another = item.clone();
+        let mut root = TreeItem::new("root", "Root", vec![item]).unwrap();
+        root.add_child(another).unwrap();
+    }
+
+    #[test]
+    fn flatten_nothing_open_is_top_level() {
+        let open = HashSet::new();
+        let actual = flatten(&open, &TreeItem::example(), &[])
+            .into_iter()
+            .map(|flattened| flattened.identifier.into_iter().next_back().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, ["a", "b", "h"]);
+    }
+
+    #[test]
+    fn flatten_all_open() {
+        let mut open = HashSet::new();
+        open.insert(vec!["b"]);
+        open.insert(vec!["b", "d"]);
+        let actual = flatten(&open, &TreeItem::example(), &[])
+            .into_iter()
+            .map(|flattened| flattened.identifier.into_iter().next_back().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(actual, ["a", "b", "c", "d", "e", "f", "g", "h"]);
+    }
+
+    #[test]
+    fn does_not_panic() {
+        _ = render(0, 0, &mut TreeState::default());
+        _ = render(10, 0, &mut TreeState::default());
+        _ = render(0, 10, &mut TreeState::default());
+        _ = render(10, 10, &mut TreeState::default());
+    }
+
+    #[test]
+    fn nothing_open() {
+        let buffer = render(10, 4, &mut TreeState::default());
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines(vec![
+            "  Alfa    ",
+            "▶ Bravo   ",
+            "  Hotel   ",
+            "          ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn depth_one() {
+        let mut state = TreeState::default();
+        state.open(vec!["b"]);
+        let buffer = render(13, 7, &mut state);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines(vec![
+            "  Alfa       ",
+            "▼ Bravo      ",
+            "    Charlie  ",
+            "  ▶ Delta    ",
+            "    Golf     ",
+            "  Hotel      ",
+            "             ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn depth_two() {
+        let mut state = TreeState::default();
+        state.open(vec!["b"]);
+        state.open(vec!["b", "d"]);
+        let buffer = render(15, 9, &mut state);
+        #[rustfmt::skip]
+        let expected = Buffer::with_lines(vec![
+            "  Alfa         ",
+            "▼ Bravo        ",
+            "    Charlie    ",
+            "  ▼ Delta      ",
+            "      Echo     ",
+            "      Foxtrot  ",
+            "    Golf       ",
+            "  Hotel        ",
+            "               ",
+        ]);
+        assert_eq!(buffer, expected);
+    }
+
+    #[test]
+    fn key_navigation_uses_last_rendered_items() {
+        let mut state = TreeState::default();
+        _ = render(10, 4, &mut state);
+
+        assert!(state.key_down());
+        assert_eq!(state.selected(), &["a"]);
+        assert!(state.key_down());
+        assert_eq!(state.selected(), &["b"]);
+        assert!(state.key_right());
+        _ = render(10, 4, &mut state);
+        assert!(state.key_down());
+        assert_eq!(state.selected(), &["b", "c"]);
+    }
+
+    #[test]
+    fn click_at_selects_rendered_item() {
+        let mut state = TreeState::default();
+        _ = render(10, 4, &mut state);
+
+        assert!(state.click_at(0, 1));
+        assert_eq!(state.selected(), &["b"]);
+        assert!(state.click_at(0, 1));
+        assert!(state.opened().contains(&vec!["b"]));
+    }
+}


### PR DESCRIPTION
Implements LSP call hierarchy with a drill-down picker[^ref]. The initial picker shows incoming/outgoing calls immediately (instead of the prepared item), and selecting an entry jumps directly to the call site.

This implementation is limited, I think ideally we would render this as a tree, allowing users to go up / down the tree of calls or callees but as far as I am aware we don't have the UI primitives for that and adding those would significantly bloat this PR. Thus, I am keeping this minimal as an initial version.

![ScreenRecording2026-03-15at22 32 02-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/ef115ac8-dc94-4188-b0d9-7c324a7780c3)

[^ref]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/