### PR TITLE
Add `tilt` language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -286,6 +286,7 @@
 | textproto | ✓ | ✓ | ✓ |  |  |  |
 | tfvars | ✓ |  | ✓ |  |  | `terraform-ls` |
 | thrift | ✓ |  |  |  |  |  |
+| tilt | ✓ | ✓ | ✓ |  | ✓ | `tilt` |
 | tlaplus | ✓ |  |  |  |  |  |
 | todotxt | ✓ |  |  |  |  |  |
 | toml | ✓ | ✓ |  |  | ✓ | `taplo`, `tombi` |

--- a/languages.toml
+++ b/languages.toml
@@ -145,6 +145,7 @@ taplo = { command = "taplo", args = ["lsp", "stdio"] }
 templ = { command = "templ", args = ["lsp"] }
 terraform-ls = { command = "terraform-ls", args = ["serve"] }
 texlab = { command = "texlab" }
+tilt = { command = "tilt", args = ["lsp", "start"] }
 tombi = { command = "tombi", args = ["lsp"] }
 ty = { command = "ty", args = ["server"] }
 typespec = { command = "tsp-server", args = ["--stdio"] }
@@ -2878,7 +2879,7 @@ source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e57c569
 name = "starlark"
 scope = "source.starlark"
 injection-regex = "(starlark|bzl|bazel|buck)"
-file-types = ["bzl", "bazel", "star", { glob = "BUILD" }, { glob = "BUCK" }, { glob = "BUILD.*" }, { glob = "Tiltfile" }, { glob = "WORKSPACE" }, { glob = "WORKSPACE.bzlmod" }, { glob = "PACKAGE" }]
+file-types = ["bzl", "bazel", "star", { glob = "BUILD" }, { glob = "BUCK" }, { glob = "BUILD.*" }, { glob = "WORKSPACE" }, { glob = "WORKSPACE.bzlmod" }, { glob = "PACKAGE" }]
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 language-servers = [ "starpls" ]
@@ -5291,3 +5292,17 @@ indent = { tab-width = 4, unit="    "}
 [[grammar]]
 name = "klog"
 source = { git = "https://github.com/Ansimorph/tree-sitter-klog/", rev = "0b215fe75bdeb8368546e3cee36aca8c19212d06" }
+
+
+# https://docs.tilt.dev/editor.html
+[[language]]
+name = "tilt"
+scope = "source.tilt"
+injection-regex = "[Tt]ilt(file)?"
+file-types = [{ glob = "Tiltfile" }, "tiltfile"]
+comment-token = "#"
+grammar = "python" # Uses starlark as grammar
+indent = { tab-width = 4, unit = "    " }
+language-servers = ["tilt"]
+formatter = {command = "buildifier"} # Official formatter tool for starlark/bazel
+auto-format = true

--- a/runtime/queries/tilt/highlights.scm
+++ b/runtime/queries/tilt/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/runtime/queries/tilt/indents.scm
+++ b/runtime/queries/tilt/indents.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/runtime/queries/tilt/injections.scm
+++ b/runtime/queries/tilt/injections.scm
@@ -1,0 +1,53 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))
+
+; https://docs.tilt.dev/api.html#api.local
+; https://docs.tilt.dev/api.html#api.run
+; e.g. `local("git rev-parse --show-toplevel")`
+(call
+  function: (identifier) @_function (#any-of? @_function "local" "run")
+  arguments: (argument_list . (string (string_content) @injection.content))
+  (#set! injection.language "bash"))
+
+; https://docs.tilt.dev/api.html#api.local_resource
+; https://docs.tilt.dev/api.html#api.custom_build
+; e.g.
+; ```
+; custom_build(
+;   'gcr.io/my-project/frontend-server',
+;   'docker build -t $EXPECTED_REF .',
+;   ['.'],
+; )
+; ```
+(call
+  function: (identifier) @_function (#any-of? @_function "custom_build" "local_resource")
+  arguments: (argument_list . (string) (string (string_content) @injection.content))
+  (#set! injection.language "bash"))
+
+; https://docs.tilt.dev/api.html#api.k8s_custom_deploy
+; e.g.
+; ```
+; local_resource(
+;   'local-myserver',
+;   cmd='go build ./cmd/myserver',
+;   serve_cmd='./myserver --port=8001',
+;   deps=['cmd/myserver']
+; )
+; ```
+(call
+  arguments: (argument_list
+    (keyword_argument
+      name: (identifier) @_keyword_arg (#any-of? @_keyword_arg
+        "cmd"
+        "serve_cmd"
+        "apply_cmd"
+        "delete_cmd"
+        "cmd_bat"
+        "apply_cmd_bat"
+        "serve_cmd_bat"
+        "delete_cmd_bat"
+        "command"
+        "command_bat"
+        "entrypoint")
+      value: (string (string_content) @injection.content)))
+  (#set! injection.language "bash"))

--- a/runtime/queries/tilt/rainbows.scm
+++ b/runtime/queries/tilt/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: python

--- a/runtime/queries/tilt/textobjects.scm
+++ b/runtime/queries/tilt/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: python


### PR DESCRIPTION
The file format is `starlark` and is used by <https://tilt.dev/> Moved into its own language to add support for its LSP and to add injection queries for command strings executed by a shell interpreter like `bash`.

## Showcase

<img width="804" height="1026" alt="image" src="https://github.com/user-attachments/assets/937a2b61-31f1-4835-ae3f-2532d6385523" />
