### PR TITLE
Add `direnvrc` to `bash` file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1306,6 +1306,7 @@ file-types = [
   { glob = "xinitrc" }, # /etc/X11/xinit/xinitrc
   { glob = ".xserverrc" }, # ~/.xserverrc
   { glob = "xserverrc" }, # /etc/X11/xinit/xserverrc
+  { glob = "direnvrc" }, # ~/.config/direnv/direnvrc
 ]
 shebangs = ["sh", "bash", "dash", "zsh"]
 comment-token = "#"


### PR DESCRIPTION
The location of this file is documented in this
[section](https://direnv.net/#faq) of the `direnv` project.