### PR TITLE
dev(helix-tui): add benchmarking for `Buffer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1678,6 +1678,7 @@ dependencies = [
  "arrayvec",
  "bitflags",
  "cassowary",
+ "criterion",
  "crossterm",
  "helix-core",
  "helix-view",

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -29,3 +29,13 @@ log = "~0.4"
 
 [target.'cfg(windows)'.dependencies]
 crossterm = { version = "0.28", optional = true }
+
+[dev-dependencies]
+criterion.workspace = true
+
+[lib]
+bench = false
+
+[[bench]]
+name = "tui"
+harness = false

--- a/helix-tui/benches/tui.rs
+++ b/helix-tui/benches/tui.rs
@@ -1,0 +1,6 @@
+pub mod tui {
+    pub mod buffer;
+}
+pub use tui::*;
+
+criterion::criterion_main!(buffer::benches);

--- a/helix-tui/benches/tui/buffer.rs
+++ b/helix-tui/benches/tui/buffer.rs
@@ -1,0 +1,172 @@
+use criterion::{BenchmarkId, Criterion};
+use helix_tui::buffer::{Buffer, Cell};
+use helix_view::{graphics::Rect, theme::Style};
+use std::hint::black_box;
+
+criterion::criterion_group!(
+    benches,
+    empty,
+    filled,
+    diff_no_change,
+    diff_partial_change,
+    diff_full_change,
+    diff_multi_width,
+    diff_emoji,
+);
+
+const fn rect(size: u16) -> Rect {
+    Rect::new(0, 0, size, size)
+}
+
+fn empty(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/empty");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        group.bench_with_input(BenchmarkId::from_parameter(size), &area, |b, &area| {
+            b.iter(|| {
+                let _buffer = Buffer::empty(black_box(area));
+            });
+        });
+    }
+    group.finish();
+}
+
+/// This likely should have the same performance as `empty`, but it's here for completeness
+/// and to catch any potential performance regressions.
+fn filled(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/filled");
+    for size in [16, 64, 255] {
+        let area = rect(size);
+        let cell = Cell::new("AAAA"); // simulate a multi-byte character
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(area, cell),
+            |b, (area, cell)| {
+                b.iter(|| {
+                    let _buffer = Buffer::filled(black_box(*area), cell);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn diff_no_change(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_no_change");
+    for size in [16, 64, 128] {
+        let area = rect(size);
+        let buffer = Buffer::filled(area, &Cell::new("x"));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &buffer, |b, buffer| {
+            b.iter(|| {
+                let diff = black_box(buffer).diff(black_box(buffer));
+                black_box(diff);
+            });
+        });
+    }
+    group.finish();
+}
+
+/// This tests maximum update cost with every cell needing an update
+fn diff_full_change(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_full_change");
+    for size in [16, 64, 128] {
+        let area = rect(size);
+        let prev = Buffer::filled(area, &Cell::new("a"));
+        let next = Buffer::filled(area, &Cell::new("b"));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// This simulates typical incremental updates in a TUI
+fn diff_partial_change(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_partial_change");
+    for size in [16, 64, 128] {
+        let area = rect(size);
+        let prev = Buffer::filled(area, &Cell::new("a"));
+        let mut next = Buffer::filled(area, &Cell::new("a"));
+
+        let total_cells = (size as usize) * (size as usize);
+        for i in (0..total_cells).step_by(10) {
+            if i < next.content.len() {
+                next.content[i].set_symbol("b");
+            }
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+fn diff_multi_width(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_multi_width");
+    for size in [16, 64] {
+        let area = rect(size);
+        let prev = Buffer::with_lines(vec!["a".repeat(size as usize); size as usize]);
+        let mut next = Buffer::filled(area, &Cell::new(" "));
+
+        for y in 0..size {
+            next.set_string(
+                0,
+                y,
+                &"日本語中文한국어".repeat(size as usize / 6),
+                Style::default(),
+            );
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+/// Tests the emoji-specific VS16 clearing path for complex emoji sequences
+fn diff_emoji(c: &mut Criterion) {
+    let mut group = c.benchmark_group("buffer/diff_emoji");
+    for size in [16, 64] {
+        let area = rect(size);
+        let prev = Buffer::filled(area, &Cell::new("a"));
+        let mut next = Buffer::filled(area, &Cell::new(" "));
+
+        for y in 0..size {
+            next.set_string(0, y, &"⌨️👁️‍🗨️🐻‍❄️".repeat(size as usize / 6), Style::default());
+        }
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(size),
+            &(prev, next),
+            |b, (prev, next)| {
+                b.iter(|| {
+                    let diff = black_box(prev).diff(black_box(next));
+                    black_box(diff);
+                });
+            },
+        );
+    }
+    group.finish();
+}

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -25,6 +25,17 @@ pub struct Cell {
 const REPLACEMENT_CHARACTER: char = '\u{FFFD}';
 
 impl Cell {
+    #[inline]
+    #[must_use]
+    pub fn new(symbol: &str) -> Self {
+        Self {
+            symbol: symbol
+                .try_into()
+                .unwrap_or_else(|_| "�".try_into().unwrap()),
+            ..Default::default()
+        }
+    }
+
     /// Set the cell's grapheme
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Cell {
         self.symbol.clear();

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -124,7 +124,7 @@ pub struct Rect {
 
 impl Rect {
     /// Creates a new rect, with width and height
-    pub fn new(x: u16, y: u16, width: u16, height: u16) -> Rect {
+    pub const fn new(x: u16, y: u16, width: u16, height: u16) -> Rect {
         Rect {
             x,
             y,


### PR DESCRIPTION
This takes the [benchmarks](https://github.com/ratatui/ratatui/blob/main/ratatui/benches/main/buffer.rs) from `ratatui` as a reference.

I have added `diff` benchmarks in coordination with #15210.

As `rataui` uses `criterion`, this PR also uses it. It was just simpler that way to translate over. This can be changed in the future if needed, but should work fine for now, as our first real introduction of benchmarking to the project.

I am not familiar enough to know if the benchmarks are good benchmarks, but it makes enough sense to me to start this PR. The benchmarks don't take into account the terminal backends, just the raw operations themselves. 

Some future work would be to translate the other relevant benchmarks over. Another thing that might be worth doing is to refactor `helix-tui` to better match that of `ratatui` where possible. `helix-tui` started off as a fork if `tui-rs`, same as `ratatui`. Keeping them as similar as possible could lend itself to easier future perf improvements `ratatui` might land (of which I can see a couple in the works). This is more work, but shouldn't have to be done often, and the benefits of ongoing improvements could be worth it enough to make a goal

It can also be a frame of reference for contributors where there could be some more helpful docs to look at when wanting to add some tui related functionality, if the similarities are kept close enough. 

There is no integration of CI in this. I would leave this to the direction of the core maintainers. For now, this setup should work well enough for local development work. 