### PR TITLE
build(deps): bump `unicode-width` from `=0.1.12` to `0.2.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1390,6 +1390,7 @@ dependencies = [
  "imara-diff",
  "indoc",
  "log",
+ "memchr",
  "nucleo",
  "once_cell",
  "parking_lot",
@@ -1407,7 +1408,7 @@ dependencies = [
  "tree-house",
  "unicode-general-category",
  "unicode-segmentation",
- "unicode-width 0.1.12",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2664,7 +2665,7 @@ checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2884,15 +2885,9 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ globset = "0.4"
 etcetera = "0.11"
 arc-swap = "1.9"
 arrayvec = "0.7"
+memchr = "2"
 
 [workspace.package]
 version = "25.7.1"

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -24,12 +24,7 @@ ropey.workspace = true
 smallvec = "1.15"
 smartstring = "1.0.1"
 unicode-segmentation.workspace = true
-# unicode-width is changing width definitions
-# that both break our logic and disagree with common
-# width definitions in terminals, we need to replace it.
-# For now lets lock the version to avoid rendering glitches
-# when installing without `--locked`
-unicode-width = "=0.1.12"
+unicode-width = "0.2.2"
 unicode-general-category = "1.1"
 slotmap.workspace = true
 tree-house.workspace = true
@@ -56,6 +51,8 @@ nucleo.workspace = true
 parking_lot.workspace = true
 globset.workspace = true
 regex-cursor = "0.1.5"
+
+memchr.workspace = true
 
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }

--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -3,7 +3,6 @@
 //! Based on <https://github.com/cessen/led/blob/c4fa72405f510b7fd16052f90a598c429b3104a6/src/graphemes.rs>
 use ropey::{str_utils::byte_to_char_idx, RopeSlice};
 use unicode_segmentation::{GraphemeCursor, GraphemeIncomplete};
-use unicode_width::UnicodeWidthStr;
 
 use std::borrow::Cow;
 use std::fmt::{self, Debug, Display};
@@ -13,7 +12,7 @@ use std::ptr::NonNull;
 use std::{slice, str};
 
 use crate::chars::{char_is_whitespace, char_is_word};
-use crate::LineEnding;
+use crate::{unicode, LineEnding};
 
 #[inline]
 pub fn tab_width_at(visual_x: usize, tab_width: u16) -> usize {
@@ -93,29 +92,30 @@ impl Display for Grapheme<'_> {
     }
 }
 
+/// Returns the width of the grapheme.
+///
+/// # Invariant
+///
+/// This function should only be passed a single grapheme.
+#[inline]
 #[must_use]
 pub fn grapheme_width(g: &str) -> usize {
+    // ASCII fast-path.
     if g.as_bytes()[0] <= 127 {
-        // Fast-path ascii.
-        // Point 1: theoretically, ascii control characters should have zero
-        // width, but in our case we actually want them to have width: if they
-        // show up in text, we want to treat them as textual elements that can
-        // be edited.  So we can get away with making all ascii single width
-        // here.
-        // Point 2: we're only examining the first codepoint here, which means
-        // we're ignoring graphemes formed with combining characters.  However,
-        // if it starts with ascii, it's going to be a single-width grapeheme
-        // regardless, so, again, we can get away with that here.
-        // Point 3: we're only examining the first _byte_.  But for utf8, when
-        // checking for ascii range values only, that works.
+        // We're only examining the first _byte_. But for UTF-8, when checking
+        // for ASCII range values only, that works, but which means we're ignoring
+        // graphemes formed with combining characters. However, if it starts with
+        // ASCII, it's going to be a single-width grapheme regardless, so, again,
+        // we can get away with that here.
+        //
+        // Theoretically, ASCII control characters should have zero width, but
+        // in our case we actually want them to have width: if they show up in
+        // text, we want to treat them as textual elements that can be edited.
         1
     } else {
-        // We use max(1) here because all grapeheme clusters--even illformed
-        // ones--should have at least some width so they can be edited
-        // properly.
-        // TODO properly handle unicode width for all codepoints
-        // example of where unicode width is currently wrong: 🤦🏼‍♂️ (taken from https://hsivonen.fi/string-length/)
-        UnicodeWidthStr::width(g).max(1)
+        // We use `.max(1)` here, because all grapheme clusters -- even ill-formed
+        // ones -- should have at least some width, so they can be edited properly.
+        unicode::width(g).max(1)
     }
 }
 

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -38,6 +38,64 @@ pub mod unicode {
     pub use unicode_general_category as category;
     pub use unicode_segmentation as segmentation;
     pub use unicode_width as width;
+    use unicode_width::UnicodeWidthStr;
+
+    #[inline]
+    #[must_use]
+    pub fn width(s: &str) -> usize {
+        if s.is_empty() {
+            return 0;
+        }
+
+        let mut width = s.width();
+        let chars = s.as_bytes();
+        // `UnicodeWidthStr::width` assigns a width of 1 to certain control
+        // sequences at the *string* level.
+        //
+        // Notably, the CRLF sequence (`"\r\n"`) is treated as a single unit
+        // and has a total width of 1, even though `'\r'` and `'\n'` each
+        // have a character width of 1 when considered individually.
+        //
+        // This function needs newline and tab characters to contribute zero
+        // width. We correct for this by subtracting the count of `'\n'` and
+        // `'\t'` characters from the string width.
+        //
+        // NOTE: Subtracting on `\n` works for `\r\n`, as this grapheme only
+        // counts as 1 width, so just subtracting 1 for the `\n` would zero
+        // it out, removing its contribution to the width.
+        for _ in memchr::memchr2_iter(b'\n', b'\t', chars) {
+            if width == 0 {
+                break;
+            }
+
+            width -= 1;
+        }
+        width
+    }
+
+    #[cfg(test)]
+    mod test {
+        use super::width;
+
+        #[test]
+        fn should_have_expected_unicode_width() {
+            assert_eq!(width("\n"), 0);
+            assert_eq!(width("\t"), 0);
+            assert_eq!(width("\r\n"), 0);
+            assert_eq!(width("\r\n\t"), 0);
+            assert_eq!(width("\n\t\r\n"), 0);
+            assert_eq!(width("\n\tH\r\n"), 1);
+            assert_eq!(width("🤦🏼‍♂️"), 2);
+            assert_eq!(width("\n🤦🏼‍♂️\n"), 2);
+            assert_eq!(width("\r\n🤦🏼‍♂️\r\n"), 2);
+            assert_eq!(width("\t🤦🏼‍♂️\t"), 2);
+            assert_eq!(width("\n\t🤦🏼‍♂️\t\n"), 2);
+            assert_eq!(width("\u{200B}"), 0);
+            assert_eq!(width("▲"), 1);
+            assert_eq!(width(" ▲ "), 3);
+            assert_eq!(width("┌"), 1);
+        }
+    }
 }
 
 pub use helix_loader::find_workspace;

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1397,17 +1397,15 @@ fn compute_inlay_hints_for_view(
                 // Truncate the hint if too long
                 if let Some(limit) = inlay_hints_length_limit {
                     // Limit on displayed width
-                    use helix_core::unicode::{
-                        segmentation::UnicodeSegmentation, width::UnicodeWidthStr,
-                    };
+                    use helix_core::unicode::{self, segmentation::UnicodeSegmentation};
 
-                    let width = label.width();
+                    let width = unicode::width(&label);
                     let limit = limit.get().into();
                     if width > limit {
                         let mut floor_boundary = 0;
                         let mut acc = 0;
                         for (i, grapheme_cluster) in label.grapheme_indices(true) {
-                            acc += grapheme_cluster.width();
+                            acc += unicode::width(grapheme_cluster);
 
                             if acc > limit {
                                 floor_boundary = i;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -19,8 +19,7 @@ use helix_core::{
     movement::Direction,
     syntax::{self, OverlayHighlights},
     text_annotations::TextAnnotations,
-    unicode::width::UnicodeWidthStr,
-    visual_offset_from_block, Change, Position, Range, Selection, Transaction,
+    unicode, visual_offset_from_block, Change, Position, Range, Selection, Transaction,
 };
 use helix_view::{
     annotations::diagnostics::DiagnosticFilter,
@@ -1643,7 +1642,7 @@ impl Component for EditorView {
 
         // render status msg
         if let Some((status_msg, severity)) = &cx.editor.status_msg {
-            status_msg_width = status_msg.width();
+            status_msg_width = unicode::width(status_msg);
             use helix_view::editor::Severity;
             let style = if *severity == Severity::Error {
                 cx.editor.theme.get("error")

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -1,7 +1,7 @@
 use crate::compositor::{Component, Compositor, Context, Event, EventResult};
 use crate::{alt, ctrl, key, shift, ui};
 use arc_swap::ArcSwap;
-use helix_core::syntax;
+use helix_core::{syntax, unicode};
 use helix_view::document::Mode;
 use helix_view::input::KeyEvent;
 use helix_view::keyboard::KeyCode;
@@ -13,7 +13,6 @@ use tui::widgets::{Block, Widget};
 
 use helix_core::{
     unicode::segmentation::{GraphemeCursor, UnicodeSegmentation},
-    unicode::width::UnicodeWidthStr,
     Position,
 };
 use helix_view::{
@@ -544,7 +543,7 @@ impl Prompt {
         } else {
             let line_width = self.line_area.width as usize;
 
-            if self.line.width() < line_width {
+            if unicode::width(&self.line) < line_width {
                 self.anchor = 0;
             } else if self.cursor <= self.anchor {
                 // Ensure the grapheme under the cursor is in view.
@@ -553,14 +552,14 @@ impl Prompt {
                     .next_back()
                     .map(|(i, _)| i)
                     .unwrap_or_default();
-            } else if self.line[self.anchor..self.cursor].width() > line_width {
+            } else if unicode::width(&self.line[self.anchor..self.cursor]) > line_width {
                 // Set the anchor to the last grapheme cluster before the width is exceeded.
                 let mut width = 0;
                 self.anchor = self.line[..self.cursor]
                     .grapheme_indices(true)
                     .rev()
                     .find_map(|(idx, g)| {
-                        width += g.width();
+                        width += unicode::width(g);
                         if width > line_width {
                             Some(idx + g.len())
                         } else {
@@ -571,16 +570,18 @@ impl Prompt {
             }
 
             self.truncate_start = self.anchor > 0;
-            self.truncate_end = self.line[self.anchor..].width() > line_width;
+            self.truncate_end = unicode::width(&self.line[self.anchor..]) > line_width;
 
             // if we keep inserting characters just before the end elipsis, we move the anchor
             // so that those new characters are displayed
-            if self.truncate_end && self.line[self.anchor..self.cursor].width() >= line_width {
+            if self.truncate_end
+                && unicode::width(&self.line[self.anchor..self.cursor]) >= line_width
+            {
                 // Move the anchor forward by one non-zero-width grapheme.
                 self.anchor += self.line[self.anchor..]
                     .grapheme_indices(true)
                     .find_map(|(idx, g)| {
-                        if g.width() > 0 {
+                        if unicode::width(g) > 0 {
                             Some(idx + g.len())
                         } else {
                             None
@@ -774,11 +775,11 @@ impl Component for Prompt {
             .clip_left(self.prompt.len() as u16)
             .clip_right(if self.prompt.is_empty() { 2 } else { 0 });
 
-        let mut col = area.left() as usize + self.line[self.anchor..self.cursor].width();
+        let mut col = area.left() as usize + unicode::width(&self.line[self.anchor..self.cursor]);
 
         // ensure the cursor does not go beyond elipses
         if self.truncate_end
-            && self.line[self.anchor..self.cursor].width() >= self.line_area.width as usize
+            && unicode::width(&self.line[self.anchor..self.cursor]) >= self.line_area.width as usize
         {
             col -= 1;
         }
@@ -787,7 +788,7 @@ impl Component for Prompt {
             col += self.line[self.cursor..]
                 .graphemes(true)
                 .next()
-                .map_or(0, |g| g.width());
+                .map_or(0, unicode::width);
         }
 
         let line = area.height as usize - 1;

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,5 +1,5 @@
 use helix_core::indent::IndentStyle;
-use helix_core::{coords_at_pos, encoding, unicode::width::UnicodeWidthStr, Position};
+use helix_core::{coords_at_pos, encoding, unicode, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
@@ -176,7 +176,7 @@ where
         format!(" {mode_str} ")
     } else {
         // If not focused, explicitly leave an empty space instead of returning None.
-        " ".repeat(mode_str.width() + 2)
+        " ".repeat(unicode::width(mode_str) + 2)
     };
     let style = if visible && config.color_modes {
         match context.editor.mode() {

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -3,7 +3,7 @@ use crate::{
     buffer::{Buffer, Cell},
     terminal::Config,
 };
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::unicode;
 use helix_view::graphics::{CursorKind, Rect};
 use std::{fmt::Write, io};
 
@@ -30,7 +30,7 @@ fn buffer_view(buffer: &Buffer) -> String {
             } else {
                 overwritten.push((x, &c.symbol))
             }
-            skip = std::cmp::max(skip, c.symbol.width()).saturating_sub(1);
+            skip = std::cmp::max(skip, unicode::width(&c.symbol)).saturating_sub(1);
         }
         view.push('"');
         if !overwritten.is_empty() {

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -1,6 +1,6 @@
 //! Contents of a terminal screen. A [Buffer] is made up of [Cell]s.
 use crate::text::{Span, Spans};
-use helix_core::unicode::width::{UnicodeWidthChar, UnicodeWidthStr};
+use helix_core::unicode;
 use helix_view::graphics::{Color, Modifier, Rect, Style, UnderlineStyle};
 use std::cmp::min;
 use unicode_segmentation::UnicodeSegmentation;
@@ -36,7 +36,7 @@ impl Cell {
             );
             self.symbol.push(REPLACEMENT_CHARACTER);
         }
-        self.width = self.symbol.width() as u8;
+        self.width = unicode::width(&self.symbol) as u8;
         self
     }
 
@@ -52,7 +52,7 @@ impl Cell {
                 symbol.len()
             );
             self.symbol.push(REPLACEMENT_CHARACTER);
-            self.width = REPLACEMENT_CHARACTER.width().unwrap_or(1) as u8;
+            self.width = unicode::width(&self.symbol) as u8;
         } else {
             self.width = width;
         }
@@ -68,7 +68,7 @@ impl Cell {
     pub fn set_char(&mut self, ch: char) -> &mut Cell {
         self.symbol.clear();
         self.symbol.push(ch);
-        self.width = ch.width().unwrap_or(0) as u8;
+        self.width = unicode::width(&self.symbol) as u8;
         self
     }
 
@@ -191,7 +191,7 @@ impl Buffer {
         let height = lines.len() as u16;
         let width = lines
             .iter()
-            .map(|i| i.as_ref().width() as u16)
+            .map(|i| unicode::width(i.as_ref()) as u16)
             .max()
             .unwrap_or_default();
         let mut buffer = Buffer::empty(Rect {
@@ -347,7 +347,7 @@ impl Buffer {
         let max_x_offset = min(self.area.right() as usize, width.saturating_add(x as usize));
 
         for s in string.graphemes(true) {
-            let grapheme_width = s.width();
+            let grapheme_width = unicode::width(s);
             if grapheme_width == 0 {
                 continue;
             }
@@ -416,7 +416,11 @@ impl Buffer {
         let mut graphemes = string.grapheme_indices(true);
 
         if truncate_start {
-            for _ in 0..graphemes.next().map(|(_, g)| g.width()).unwrap_or_default() {
+            for _ in 0..graphemes
+                .next()
+                .map(|(_, g)| unicode::width(g))
+                .unwrap_or_default()
+            {
                 self.content[index].set_symbol("…");
                 index += 1;
                 rendered_width += 1;
@@ -424,7 +428,7 @@ impl Buffer {
         }
 
         for (byte_offset, s) in graphemes {
-            let grapheme_width = s.width();
+            let grapheme_width = unicode::width(s);
             if truncate_end && rendered_width + grapheme_width >= width {
                 break;
             }
@@ -481,7 +485,7 @@ impl Buffer {
         let max_offset = min(self.area.right() as usize, width.saturating_add(x as usize));
         if !truncate_start {
             for (byte_offset, s) in graphemes {
-                let width = s.width();
+                let width = unicode::width(s);
                 if width == 0 {
                     continue;
                 }
@@ -500,14 +504,14 @@ impl Buffer {
                 index += width;
                 x_offset += width;
             }
-            if ellipsis && x_offset - (x as usize) < string.width() {
+            if ellipsis && x_offset - (x as usize) < unicode::width(string) {
                 self.content[index].set_symbol("…");
             }
         } else {
             let mut start_index = self.index_of(x, y);
             let mut index = self.index_of(max_offset as u16, y);
 
-            let content_width = string.width();
+            let content_width = unicode::width(string);
             let truncated = content_width > width;
             if ellipsis && truncated {
                 self.content[start_index].set_symbol("…");
@@ -517,7 +521,7 @@ impl Buffer {
                 index -= width - content_width;
             }
             for (byte_offset, s) in graphemes.rev() {
-                let width = s.width();
+                let width = unicode::width(s);
                 if width == 0 {
                     continue;
                 }
@@ -560,7 +564,7 @@ impl Buffer {
         }
         for span in spans.0.iter().rev() {
             for s in span.content.graphemes(true).rev() {
-                let width = s.width();
+                let width = unicode::width(s);
                 if width == 0 {
                     continue;
                 }
@@ -847,7 +851,7 @@ mod tests {
         let mut buffer = Buffer::empty(area);
 
         // U+200B is the zero-width space codepoint
-        assert_eq!("\u{200B}".width(), 0);
+        assert_eq!(unicode::width("\u{200B}"), 0);
 
         // Leading grapheme with zero width
         let s = "\u{200B}a";

--- a/helix-tui/src/text.rs
+++ b/helix-tui/src/text.rs
@@ -46,8 +46,7 @@
 //!     Span::raw(" title"),
 //! ]);
 //! ```
-use helix_core::line_ending::str_is_line_ending;
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::{line_ending::str_is_line_ending, unicode};
 use helix_view::graphics::Style;
 use std::borrow::Cow;
 use unicode_segmentation::UnicodeSegmentation;
@@ -108,8 +107,10 @@ impl<'a> Span<'a> {
     }
 
     /// Returns the width of the content held by this span.
+    #[inline]
+    #[must_use]
     pub fn width(&self) -> usize {
-        self.content.width()
+        unicode::width(&self.content)
     }
 
     /// Returns an iterator over the graphemes held by this span.

--- a/helix-tui/src/widgets/paragraph.rs
+++ b/helix-tui/src/widgets/paragraph.rs
@@ -7,7 +7,7 @@ use crate::{
         Block, Widget,
     },
 };
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::unicode;
 use helix_view::graphics::{Rect, Style};
 use std::iter;
 
@@ -214,7 +214,7 @@ impl Widget for Paragraph<'_> {
                             symbol
                         })
                         .set_style(*style);
-                    x += symbol.width() as u16;
+                    x += unicode::width(symbol) as u16;
                 }
             }
             y += 1;

--- a/helix-tui/src/widgets/table.rs
+++ b/helix-tui/src/widgets/table.rs
@@ -4,7 +4,7 @@ use crate::{
     text::Text,
     widgets::{Block, Widget},
 };
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::unicode;
 use helix_view::graphics::{Rect, Style};
 
 /// A [`Cell`] contains the [`Text`] to be displayed in a [`Row`] of a [`Table`].
@@ -273,8 +273,10 @@ impl<'a> Table<'a> {
     fn get_columns_widths(&self, max_width: u16, has_selection: bool) -> Vec<u16> {
         let mut constraints = Vec::with_capacity(self.widths.len() * 2 + 1);
         if has_selection {
-            let highlight_symbol_width =
-                self.highlight_symbol.map(|s| s.width() as u16).unwrap_or(0);
+            let highlight_symbol_width = self
+                .highlight_symbol
+                .map(|s| unicode::width(s) as u16)
+                .unwrap_or(0);
             constraints.push(Constraint::Length(highlight_symbol_width));
         }
         for constraint in self.widths {
@@ -384,7 +386,7 @@ impl Table<'_> {
         let has_selection = state.selected.is_some();
         let columns_widths = self.get_columns_widths(table_area.width, has_selection);
         let highlight_symbol = self.highlight_symbol.unwrap_or("");
-        let blank_symbol = " ".repeat(highlight_symbol.width());
+        let blank_symbol = " ".repeat(unicode::width(highlight_symbol));
         let mut current_height = 0;
         let mut rows_height = table_area.height;
 
@@ -402,7 +404,7 @@ impl Table<'_> {
             );
             let mut col = table_area.left();
             if has_selection {
-                col += (highlight_symbol.width() as u16).min(table_area.width);
+                col += (unicode::width(highlight_symbol) as u16).min(table_area.width);
             }
             for (width, cell) in columns_widths.iter().zip(header.cells.iter()) {
                 render_cell(

--- a/helix-view/src/info.rs
+++ b/helix-view/src/info.rs
@@ -1,5 +1,5 @@
 use crate::register::Registers;
-use helix_core::unicode::width::UnicodeWidthStr;
+use helix_core::unicode;
 use std::{borrow::Cow, fmt::Write};
 
 #[derive(Debug)]
@@ -34,7 +34,7 @@ impl Info {
 
         let item_width = body
             .iter()
-            .map(|(item, _)| item.as_ref().width())
+            .map(|(item, _)| unicode::width(item.as_ref()))
             .max()
             .unwrap();
         let mut text = String::new();
@@ -51,7 +51,7 @@ impl Info {
 
         Self {
             title,
-            width: text.lines().map(|l| l.width()).max().unwrap() as u16,
+            width: text.lines().map(unicode::width).max().unwrap() as u16,
             height: body.len() as u16,
             text,
         }

--- a/helix-view/src/input.rs
+++ b/helix-view/src/input.rs
@@ -1,6 +1,6 @@
 //! Input event handling, currently backed by termina.
 use anyhow::{anyhow, Error};
-use helix_core::unicode::{segmentation::UnicodeSegmentation, width::UnicodeWidthStr};
+use helix_core::unicode::segmentation::UnicodeSegmentation;
 use serde::de::{self, Deserialize, Deserializer};
 use std::fmt;
 
@@ -249,7 +249,7 @@ impl fmt::Display for KeyEvent {
     }
 }
 
-impl UnicodeWidthStr for KeyEvent {
+impl helix_core::unicode::width::UnicodeWidthStr for KeyEvent {
     fn width(&self) -> usize {
         use helix_core::unicode::width::UnicodeWidthChar;
         let mut width = match self.code {


### PR DESCRIPTION
This is (hopefully) a corrected version of #14643, which was reverted in #15150.

Different this time is that we upgrade to `0.2.2`, which includes the newline width = 1 change. In `0.1.14`, despite being free from this change, there was actually a larger change that made *all* control characters have a width of 1. The issue that lead to the reverting of the previous PR was due to this. Its seems that `\t` was the culprit here. As this needed special handling anyways, I decided to handle both this and the newline change, as the "fix" is the same for both.

I started by consolidating the raw `unicode-width` calls and wrapped it in a function that would hold our fixes. With the abstracting in place,  I then propagated the new `width` function where needed.

I say "fix" because its not really that the new widths are wrong, terminals just expect them to be 0, and that there could be other areas where this is fixed, like in the rendering, handling the control characters there instead. But these changes piggyback off of what existed in the most straightforward way, and so was chosen.

The main change is to count the new 1 width control characters and then subtract the width that `unicode-width` gives us. There is some special handling that `\r\n` has in `unicode-width`, where the sequence itself has a width of 1, so this required some extra site documentation explaining how just `\n` can work here.

There is a `char::is_control`, but I opted for the manual `matches!` as this could be faster if the full set of options is realistically only a handle full of known characters. Time will tell if this is enough, 

Beyond the implementation, it would be really nice if this could be tested out for a bit before merging. This is a tricky area that could have some edge cases. For now I have confirmed that the previous `gopls` issue is resolved and that it seems to be fine as far as rendering the rest of the UI.

Closes: #14642