### PR TITLE
feat(queries:comment): highlight "TIP" as `hint`

### DIFF
--- a/runtime/queries/comment/highlights.scm
+++ b/runtime/queries/comment/highlights.scm
@@ -4,10 +4,10 @@
 
 ; Hint level tags
 ((tag (name) @hint)
- (#any-of? @hint "HINT" "MARK" "PASSED" "STUB" "MOCK"))
+ (#any-of? @hint "HINT" "MARK" "PASSED" "STUB" "MOCK" "TIP"))
 
 ("text" @hint
- (#any-of? @hint "HINT" "MARK" "PASSED" "STUB" "MOCK"))
+ (#any-of? @hint "HINT" "MARK" "PASSED" "STUB" "MOCK" "TIP"))
 
 ; Info level tags
 ((tag (name) @info)


### PR DESCRIPTION
Here are examples "in the wild":
- [`// TIP:`](https://github.com/search?q=%22%2F%2F+TIP%3A%22&ref=opensearch&type=code)
- [`# TIP:` (filter: py|sh)](https://github.com/search?q=%22%23+TIP%3A%22+%28language%3APython+OR+language%3AShell%29&ref=opensearch&type=code)

I often use them in [my git-config](https://github.com/Rudxain/dotfiles/blob/1b1c9ced187cab8ff098828fc1acb1b297ea1fca/.config/git/config)
