### PR TITLE
feat(picker-layout): Add a new picker layout conf

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -194,6 +194,14 @@ Valid values for these options are `block`, `bar`, `underline`, or `hidden`.
 [insert mode]: ./keymap.md#insert-mode
 [select mode]: ./keymap.md#select--extend-mode
 
+### `[editor.picker]` Section
+
+Set the layout style for all pickers (file picker, global search, symbol picker, etc.).
+
+| Key | Description | Default |
+|--|--|---------|
+|`layout` | Layout style for the picker. `popup` for centered overlay, `ivy` for bottom panel | `popup`
+
 ### `[editor.file-picker]` Section
 
 Set options for file picker and global search. Ignoring a file means it is

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -26,7 +26,7 @@ use crate::{
     handlers,
     job::Jobs,
     keymap::Keymaps,
-    ui::{self, overlay::overlaid},
+    ui::{self, overlay::overlaid_with_layout},
 };
 
 use log::{debug, error, info, warn};
@@ -163,8 +163,9 @@ impl Application {
 
             // If the first file is a directory, skip it and open a picker
             if let Some((first, _)) = files_it.next_if(|(p, _)| p.is_dir()) {
+                let layout = editor.config().picker.layout;
                 let picker = ui::file_picker(&editor, first);
-                compositor.push(Box::new(overlaid(picker)));
+                compositor.push(Box::new(overlaid_with_layout(picker, layout)));
             }
 
             // If there are any more files specified, open them

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -66,7 +66,7 @@ use crate::{
     compositor::{self, Component, Compositor},
     filter_picker_entry,
     job::Callback,
-    ui::{self, overlay::overlaid, Picker, PickerColumn, Popup, Prompt, PromptEvent},
+    ui::{self, overlay::overlaid_with_layout, Picker, PickerColumn, Popup, Prompt, PromptEvent},
 };
 
 use crate::job::{self, Jobs};
@@ -1377,8 +1377,9 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         let path = path::expand(&sel);
         let path = &rel_path.join(path);
         if path.is_dir() {
+            let layout = cx.editor.config().picker.layout;
             let picker = ui::file_picker(cx.editor, path.into());
-            cx.push_layer(Box::new(overlaid(picker)));
+            cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
         } else if let Err(e) = cx.editor.open(path, action) {
             cx.editor.set_error(format!("Open file failed: {:?}", e));
         }
@@ -1414,8 +1415,9 @@ fn open_url(cx: &mut Context, url: Url, action: Action) {
         Ok(_) | Err(_) => {
             let path = &rel_path.join(url.path());
             if path.is_dir() {
+                let layout = cx.editor.config().picker.layout;
                 let picker = ui::file_picker(cx.editor, path.into());
-                cx.push_layer(Box::new(overlaid(picker)));
+                cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
             } else if let Err(e) = cx.editor.open(path, action) {
                 cx.editor.set_error(format!("Open file failed: {:?}", e));
             }
@@ -2676,7 +2678,8 @@ fn global_search(cx: &mut Context) {
     .with_history_register(Some(reg))
     .with_dynamic_query(get_files, Some(275));
 
-    cx.push_layer(Box::new(overlaid(picker)));
+    let layout = cx.editor.config().picker.layout;
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 enum Extend {
@@ -3063,8 +3066,9 @@ fn file_picker(cx: &mut Context) {
         cx.editor.set_error("Workspace directory does not exist");
         return;
     }
+    let layout = cx.editor.config().picker.layout;
     let picker = ui::file_picker(cx.editor, root);
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 fn file_picker_in_current_buffer_directory(cx: &mut Context) {
@@ -3089,8 +3093,9 @@ fn file_picker_in_current_buffer_directory(cx: &mut Context) {
         }
     };
 
+    let layout = cx.editor.config().picker.layout;
     let picker = ui::file_picker(cx.editor, path);
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 fn file_picker_in_current_directory(cx: &mut Context) {
@@ -3100,8 +3105,9 @@ fn file_picker_in_current_directory(cx: &mut Context) {
             .set_error("Current working directory does not exist");
         return;
     }
+    let layout = cx.editor.config().picker.layout;
     let picker = ui::file_picker(cx.editor, cwd);
-    cx.push_layer(Box::new(overlaid(picker)));
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 fn file_explorer(cx: &mut Context) {
@@ -3112,7 +3118,8 @@ fn file_explorer(cx: &mut Context) {
     }
 
     if let Ok(picker) = ui::file_explorer(root, cx.editor) {
-        cx.push_layer(Box::new(overlaid(picker)));
+        let layout = cx.editor.config().picker.layout;
+        cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
     }
 }
 
@@ -3139,7 +3146,8 @@ fn file_explorer_in_current_buffer_directory(cx: &mut Context) {
     };
 
     if let Ok(picker) = ui::file_explorer(path, cx.editor) {
-        cx.push_layer(Box::new(overlaid(picker)));
+        let layout = cx.editor.config().picker.layout;
+        cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
     }
 }
 
@@ -3152,7 +3160,8 @@ fn file_explorer_in_current_directory(cx: &mut Context) {
     }
 
     if let Ok(picker) = ui::file_explorer(cwd, cx.editor) {
-        cx.push_layer(Box::new(overlaid(picker)));
+        let layout = cx.editor.config().picker.layout;
+        cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
     }
 }
 
@@ -3235,7 +3244,8 @@ fn buffer_picker(cx: &mut Context) {
         });
         Some((meta.id.into(), lines))
     });
-    cx.push_layer(Box::new(overlaid(picker)));
+    let layout = cx.editor.config().picker.layout;
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 fn jumplist_picker(cx: &mut Context) {
@@ -3326,7 +3336,8 @@ fn jumplist_picker(cx: &mut Context) {
         let line = meta.selection.primary().cursor_line(doc.text().slice(..));
         Some((meta.id.into(), Some((line, line))))
     });
-    cx.push_layer(Box::new(overlaid(picker)));
+    let layout = cx.editor.config().picker.layout;
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 fn changed_file_picker(cx: &mut Context) {
@@ -3420,7 +3431,8 @@ fn changed_file_picker(cx: &mut Context) {
                 true
             }
         });
-    cx.push_layer(Box::new(overlaid(picker)));
+    let layout = cx.editor.config().picker.layout;
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 pub fn command_palette(cx: &mut Context) {
@@ -3500,7 +3512,8 @@ pub fn command_palette(cx: &mut Context) {
                     }
                 }
             });
-            compositor.push(Box::new(overlaid(picker)));
+            let layout = cx.editor.config().picker.layout;
+            compositor.push(Box::new(overlaid_with_layout(picker, layout)));
         },
     ));
 }

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -27,7 +27,7 @@ use ignore::{DirEntry, WalkBuilder, WalkState};
 use crate::{
     filter_picker_entry,
     ui::{
-        overlay::overlaid,
+        overlay::overlaid_with_layout,
         picker::{Injector, PathOrId},
         Picker, PickerColumn,
     },
@@ -187,7 +187,8 @@ pub fn syntax_symbol_picker(cx: &mut Context) {
     })
     .truncate_start(false);
 
-    cx.push_layer(Box::new(overlaid(picker)));
+    let layout = cx.editor.config().picker.layout;
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
@@ -431,7 +432,8 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
     })
     .with_history_register(Some(reg))
     .truncate_start(false);
-    cx.push_layer(Box::new(overlaid(picker)));
+    let layout = cx.editor.config().picker.layout;
+    cx.push_layer(Box::new(overlaid_with_layout(picker, layout)));
 }
 
 /// Create a Rope and language config for a given existing path without creating a full Document.

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -153,9 +153,10 @@ fn open_impl(cx: &mut compositor::Context, args: Args, action: Action) -> anyhow
             let callback = async move {
                 let call: job::Callback = job::Callback::EditorCompositor(Box::new(
                     move |editor: &mut Editor, compositor: &mut Compositor| {
+                        let layout = editor.config().picker.layout;
                         let picker =
                             ui::file_picker(editor, path.into_owned()).with_default_action(action);
-                        compositor.push(Box::new(overlaid(picker)));
+                        compositor.push(Box::new(overlaid_with_layout(picker, layout)));
                     },
                 ));
                 Ok(call)
@@ -1558,7 +1559,7 @@ fn lsp_workspace_command(
             .collect::<Vec<_>>();
         let callback = async move {
             let call: job::Callback = Callback::EditorCompositor(Box::new(
-                move |_editor: &mut Editor, compositor: &mut Compositor| {
+                move |editor: &mut Editor, compositor: &mut Compositor| {
                     let columns = [ui::PickerColumn::new(
                         "title",
                         |(_ls_id, command): &(_, helix_lsp::lsp::Command), _| {
@@ -1574,7 +1575,8 @@ fn lsp_workspace_command(
                             cx.editor.execute_lsp_command(command.clone(), *ls_id);
                         },
                     );
-                    compositor.push(Box::new(overlaid(picker)))
+                    let layout = editor.config().picker.layout;
+                    compositor.push(Box::new(overlaid_with_layout(picker, layout)))
                 },
             ));
             Ok(call)

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -336,7 +336,9 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
                     let call: Callback =
                         Callback::EditorCompositor(Box::new(move |editor, compositor| {
                             if let Ok(picker) = file_explorer(new_root, editor) {
-                                compositor.push(Box::new(overlay::overlaid(picker)));
+                                let layout = editor.config().picker.layout;
+                                compositor
+                                    .push(Box::new(overlay::overlaid_with_layout(picker, layout)));
                             }
                         }));
                     Ok(call)

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -174,6 +174,23 @@ impl Default for GutterLineNumbersConfig {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum PickerLayout {
+    /// Centered popup (default)
+    #[default]
+    Popup,
+    /// Bottom panel (ivy-style)
+    Ivy,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct PickerConfig {
+    /// Layout style for pickers. Defaults to "popup".
+    pub layout: PickerLayout,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
@@ -360,6 +377,8 @@ pub struct Config {
     pub continue_comments: bool,
     /// Whether to display infoboxes. Defaults to true.
     pub auto_info: bool,
+    /// General picker configuration (layout, etc.)
+    pub picker: PickerConfig,
     pub file_picker: FilePickerConfig,
     pub file_explorer: FileExplorerConfig,
     /// Configuration of the statusline elements
@@ -1108,6 +1127,7 @@ impl Default for Config {
             preview_completion_insert: true,
             completion_trigger_len: 2,
             auto_info: true,
+            picker: PickerConfig::default(),
             file_picker: FilePickerConfig::default(),
             file_explorer: FileExplorerConfig::default(),
             statusline: StatusLineConfig::default(),


### PR DESCRIPTION


https://github.com/user-attachments/assets/0b2f1fb1-9405-4350-8c22-fc6d2c5c79c1

Add the configuration section with a layout option that controls how pickers are displayed. For now support two modes:

- `popup` (default): Centered overlay.
- `ivy`: Bottom-anchored panel.

The settings applies to all pickers (file picker, global search, etc.)