### PR TITLE
Lazily apply document changes when using the jumplist

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -5658,47 +5658,11 @@ fn match_brackets(cx: &mut Context) {
 //
 
 fn jump_forward(cx: &mut Context) {
-    let count = cx.count();
-    let config = cx.editor.config();
-    let view = view_mut!(cx.editor);
-    let doc_id = view.doc;
-
-    if let Some((id, selection)) = view.jumps.forward(count) {
-        view.doc = *id;
-        let selection = selection.clone();
-        let (view, doc) = current!(cx.editor); // refetch doc
-
-        if doc.id() != doc_id {
-            view.add_to_history(doc_id);
-        }
-
-        doc.set_selection(view.id, selection);
-        // Document we switch to might not have been opened in the view before
-        doc.ensure_view_init(view.id);
-        view.ensure_cursor_in_view_center(doc, config.scrolloff);
-    };
+    cx.editor.jump_forward(cx.editor.tree.focus, cx.count());
 }
 
 fn jump_backward(cx: &mut Context) {
-    let count = cx.count();
-    let config = cx.editor.config();
-    let (view, doc) = current!(cx.editor);
-    let doc_id = doc.id();
-
-    if let Some((id, selection)) = view.jumps.backward(view.id, doc, count) {
-        view.doc = *id;
-        let selection = selection.clone();
-        let (view, doc) = current!(cx.editor); // refetch doc
-
-        if doc.id() != doc_id {
-            view.add_to_history(doc_id);
-        }
-
-        doc.set_selection(view.id, selection);
-        // Document we switch to might not have been opened in the view before
-        doc.ensure_view_init(view.id);
-        view.ensure_cursor_in_view_center(doc, config.scrolloff);
-    };
+    cx.editor.jump_backward(cx.editor.tree.focus, cx.count());
 }
 
 fn save_selection(cx: &mut Context) {

--- a/helix-term/tests/test/splits.rs
+++ b/helix-term/tests/test/splits.rs
@@ -195,3 +195,22 @@ async fn test_changes_in_splits_apply_to_all_views() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_changes_in_splits_jumplist_sync() -> anyhow::Result<()> {
+    // See <https://github.com/helix-editor/helix/issues/9833>
+    // When jumping backwards (<C-o>) switches between two documents, we need to
+    // ensure that the current view has been synced with all changes to the
+    // document that occurred since the last time the view focused this document.
+    // If the view isn't synced then this case panics since we try to form a
+    // selection on "test" (which was deleted in the other view).
+    test((
+        "#[test|]#",
+        "<C-w>sgf<C-w>wd<C-w>w<C-o><C-w>qd",
+        "#[|]#",
+        LineFeedHandling::AsIs,
+    ))
+    .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Views do not eagerly sync with changes to documents which are in their jumplist, so when jumping backwards/forwards to another document, the `Document::set_selection` call could crash if the jump selection pointed past the end of the document.

When jumping forwards and backwards, we now consider the destination document and if it is not the current document, we sync the jump selection with any pending changes between the current and latest doc revisions. To do this we move the jumping functions onto the Editor. We also switch to using the `replace_document_in_view` helper and emitting the `DocumentFocusLost` event.

Continuation of https://github.com/helix-editor/helix/pull/4912
Fixes https://github.com/helix-editor/helix/issues/9833
Using the test case from #15236