### PR TITLE
feat(languages): Update tree-sitter-rego grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3574,7 +3574,7 @@ grammar = "rego"
 
 [[grammar]]
 name = "rego"
-source = { git = "https://github.com/FallenAngel97/tree-sitter-rego", rev = "9ac75e71b2d791e0aadeef68098319d86a2a14cf" }
+source = { git = "https://github.com/FallenAngel97/tree-sitter-rego", rev = "ddd39af81fe8b0288102a7cb97959dfce723e0f3" }
 
 [[language]]
 name = "nim"


### PR DESCRIPTION
Update tree-sitter-rego to commit ddd39af to get latest grammar following the new string interpolation feature.

Following the updates made in https://github.com/FallenAngel97/tree-sitter-rego/pull/19