### PR TITLE
fix(docker-compose/bake): incorrect language-id

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2159,6 +2159,7 @@ source = { git = "https://github.com/camdencheek/tree-sitter-dockerfile", rev = 
 
 [[language]]
 name = "docker-compose"
+language-id = "dockercompose"
 scope = "source.yaml.docker-compose"
 roots = ["docker-compose.yaml", "docker-compose.yml", "compose.yaml", "compose.yml"]
 language-servers = [ "docker-compose-langserver", "yaml-language-server", "docker-language-server" ]
@@ -5082,6 +5083,7 @@ comment-token = ".."
 
 [[language]]
 name = "docker-bake"
+language-id = "dockerbake"
 scope = "source.docker-bake"
 injection-regex = "docker-bake"
 grammar = "hcl"


### PR DESCRIPTION
Docker Compose and Bake files are recognized as dockerfile by [docker-language-server](https://github.com/docker/docker-language-server).

**Screenshots**:

<img width="857" height="278" alt="Screenshot 2026-02-05 at 18 28 10" src="https://github.com/user-attachments/assets/1b66aa06-af2b-4b95-a0f5-bef8a5e803b1" />
<img width="857" height="278" alt="Screenshot 2026-02-05 at 19 16 52" src="https://github.com/user-attachments/assets/008e2f82-5c62-4eb9-aa72-a10ad985f3a5" />

The correct language identifiers are I think `dockercompose` and `dockerbake`: 
https://github.com/docker/docker-language-server/blob/8da6e44c2e08ac23b8fe9657bb6b49c45e56770a/internal/tliron/glsp/protocol/base-structures.go#L770-L779
