### PR TITLE
history search in prompts

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -42,6 +42,8 @@ pub struct Prompt {
     selection: Option<usize>,
     history_register: Option<char>,
     history_pos: Option<usize>,
+    history_pattern: Option<String>,
+    user_edited: bool,
     completion_fn: CompletionFn,
     callback_fn: CallbackFn,
     pub doc_fn: DocFn,
@@ -98,6 +100,8 @@ impl Prompt {
             selection: None,
             history_register,
             history_pos: None,
+            history_pattern: None,
+            user_edited: true,
             completion_fn: Box::new(completion_fn),
             callback_fn: Box::new(callback_fn),
             doc_fn: Box::new(|_| None),
@@ -344,27 +348,40 @@ impl Prompt {
         register: char,
         direction: CompletionDirection,
     ) {
+        if self.line.is_empty() {
+            self.history_pattern = None;
+            self.history_pos = None;
+        } else if self.user_edited {
+            self.history_pattern = Some(self.line.clone());
+            self.history_pos = None;
+        }
         (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
-        let mut values = match cx.editor.registers.read(register, cx.editor) {
-            Some(values) if values.len() > 0 => values.rev(),
+
+        let values: Vec<_> = match cx.editor.registers.read(register, cx.editor) {
+            Some(values) if values.len() > 0 => {
+                if let Some(pattern) = &self.history_pattern {
+                    values.filter(|the| the.contains(pattern)).rev().collect()
+                } else {
+                    values.rev().collect()
+                }
+            }
             _ => return,
         };
+        if values.is_empty() {
+            return;
+        }
 
         let end = values.len().saturating_sub(1);
 
         let index = match direction {
             CompletionDirection::Forward => self.history_pos.map_or(0, |i| i + 1),
-            CompletionDirection::Backward => self
-                .history_pos
-                .unwrap_or_else(|| values.len())
-                .saturating_sub(1),
+            CompletionDirection::Backward => {
+                self.history_pos.unwrap_or(values.len()).saturating_sub(1)
+            }
         }
         .min(end);
 
-        self.line = values.nth(index).unwrap().to_string();
-        // Appease the borrow checker.
-        drop(values);
-
+        self.line = values.into_iter().nth(index).unwrap().to_string();
         self.history_pos = Some(index);
 
         self.move_end();
@@ -623,6 +640,7 @@ impl Component for Prompt {
             compositor.pop();
         })));
 
+        let mut user_edited = true;
         match event {
             ctrl!('c') | key!(Esc) => {
                 (self.callback_fn)(cx, &self.line, PromptEvent::Abort);
@@ -709,11 +727,13 @@ impl Component for Prompt {
                 }
             }
             ctrl!('p') | key!(Up) => {
+                user_edited = false;
                 if let Some(register) = self.history_register {
                     self.change_history(cx, register, CompletionDirection::Backward);
                 }
             }
             ctrl!('n') | key!(Down) => {
+                user_edited = false;
                 if let Some(register) = self.history_register {
                     self.change_history(cx, register, CompletionDirection::Forward);
                 }
@@ -761,6 +781,7 @@ impl Component for Prompt {
             }
             _ => (),
         };
+        self.user_edited = user_edited;
 
         EventResult::Consumed(None)
     }


### PR DESCRIPTION
Previously, <kbd>↑</kbd> and <kbd>↓</kbd> in prompts didn't care at all about what you have typed in — they would always cycle through the entire history.
Now the behavior is different depending on if the prompt input is empty, or filled with something.

If the prompt input is empty, ↓↑ work like normal. \
If the prompt input is *not* empty, and it reached this state *not* by ↓↑, your current prompt input is taken as a substring pattern that you search for in your history.

This works for all prompts, but I'm going to use command mode as the example.
Assume you have this in your command mode history:
```
echo tomato
echo potato
echo potatotron
echo lemon
```
With your prompt input empty, ↑ will result in `echo lemon`. \
But if instead you type in `potato` and tap ↑, you will arrive at `echo potatotron`. If from this state you press `↑` again, you reach `echo potato`.
Pressing ↑ again doesn't change anything because `echo potato` is the oldest command that substring matches the current pattern (`potato`)

If after arriving at `echo potatotron` for the first time you *edit* your input in any way (even ←→ counts as an “edit” here), then *that* now becomes your current pattern. \
Type in `potato`, tap ↑, end up at `echo potatotron`. Press ← then ↑ — nothing happens, because you are at the only result of the new pattern (`echo potatotron`).

If instead of pressing ← you edited `echo potatotron` to `echo potatotronistic` and pressed ↑ — nothing would happen also, because there are *no* matches for that in the history.

If you've used fish shell, you can refer to the ↑ behavior there: that's more or less the behavior that I'm replicating.