### PR TITLE
prompts deduplicate their history

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -693,7 +693,7 @@ impl Component for Prompt {
                             // store in history
                             if let Some(register) = self.history_register {
                                 if let Err(err) =
-                                    cx.editor.registers.push(register, self.line.clone())
+                                    cx.editor.registers.push_unique(register, self.line.clone())
                                 {
                                     cx.editor.set_error(err.to_string());
                                 }


### PR DESCRIPTION

Normally, if you execute these three command mode commands in a row:
```
:echo banana
:echo potato
:echo banana
```

You will have this in your command mode history (meaning, `:` register)
```
echo banana
echo potato
echo banana
```

If we scale this up to a long helix session, you might end up having a lot of repeats, that are annoying to ↑ through.

With this pr, when you accept your input in a prompt and it's added to history, all the previous times this exact input was in history, is cleaned up. \
So, you'll end up with just this instead:
```
echo potato
echo banana
```
If you `:echo potato` from this state, now your history is:
```
echo banana
echo potato
```
I use command mode as the example, but all prompts that have history are affected by this improvement.

If you like this change, check out my #15266 also.