### PR TITLE
OneDark Theme, make primary selection stand out more

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -66,7 +66,7 @@
 "ui.cursor.match" = { fg = "blue", modifiers = ["underlined"]}
 
 "ui.selection" = { bg = "faint-gray" }
-"ui.selection.primary" = { bg = "gray" }
+"ui.selection.primary" = { bg = "light-gray" }
 "ui.cursorline.primary" = { bg = "light-black" }
 
 "ui.highlight" = { bg = "gray" }


### PR DESCRIPTION
Without this change primary selection looks exactly like the other selections in the onedark theme. 

When you only have one selection, it is primary, so it also changes the normal selection color. I have tried other colors but they make the non primary to dark. 

before:
![Screenshot 2026-02-08 at 17 04 41](https://github.com/user-attachments/assets/84c74399-6795-440a-a72d-7181396865ff)

With these changes:
![Screenshot 2026-02-08 at 17 08 16](https://github.com/user-attachments/assets/2a7f01fd-ec74-4e2c-adba-985f520fcfa1)
