### PR TITLE
fix(queries:properties): proper numeric values

### DIFF
--- a/runtime/queries/properties/highlights.scm
+++ b/runtime/queries/properties/highlights.scm
@@ -15,11 +15,15 @@
 ((value) @constant.builtin.boolean
   (#any-of? @constant.builtin.boolean "true" "false" "enabled" "disabled"))
 
-((value) @constant.numeric.integer
-  (#match? @constant.numeric.integer "^-?[0-9]+$"))
-
 ((value) @constant.numeric.float
-  (#match? @constant.numeric.float "^-?[0-9]+\.[0-9]$"))
+  (#match? @constant.numeric.float "^[+-]?(([0-9]*\.[0-9]+([eE][+-]?[0-9]+)?)|([0-9]+[eE][+-]?[0-9]+))$"))
+
+((value) @constant.numeric.integer
+  ; according to the Java spec, hex literals must represent a 64bit int;
+  ; overflow (too long) is considered an error.
+  ; however, since these are just strings,
+  ; a long hex-literal could represent a BigInt, so we allow it
+  (#match? @constant.numeric.integer "^([+-]?[0-9]+)|(0[xX][0-9a-fA-F]+)$"))
 
 ((value) @string.special.path
   (#match? @string.special.path "^(\.{1,2})?/"))


### PR DESCRIPTION
Changes:
- swap the precedence of `float` and `integer` so that `integer` has a chance to match. Previously, only `float` could match a value, because of its order and broadness
- allow "+" as an optional prefix
- allow empty integer part for `float`s (yes, `-.1` [is valid](https://docs.oracle.com/javase/specs/jls/se25/html/jls-3.html#jls-3.10.2)!)
- fractional part can be arbitrary length
- allow exponent for `float`s
- allow unsigned hex integers

Unresolved questions:
- should underscores be allowed?
- should `\d+\.` be considered `float`?
- should `infinity` be considered `float`? if so, case-sensitive?

> [!important]
> The Java spec says "yes" to the first two, but that would make the regexes more complex, and I haven't fully tested it

Questions that I've answered to myself:
- should hex floats be allowed? I'd say no, that's just too much
- should `NaN` be a `float`? absolutely no, who would need that?

follow-up of #13874