### PR TITLE
Fix `mm` inconsistency with some treesitter grammars

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -76,9 +76,7 @@ fn find_pair(
     traverse_parents: bool,
 ) -> Option<usize> {
     let pos = doc.char_to_byte(pos_) as u32;
-
-    let root = syntax.tree_for_byte_range(pos, pos).root_node();
-    let mut node = root.descendant_for_byte_range(pos, pos)?;
+    let mut node = syntax.descendant_for_byte_range(pos, pos + 1)?;
 
     loop {
         if node.is_named() && node.child_count() >= 2 {
@@ -140,7 +138,7 @@ fn find_pair(
         };
         node = parent;
     }
-    let node = root.named_descendant_for_byte_range(pos, pos + 1)?;
+    let node = syntax.named_descendant_for_byte_range(pos, pos + 1)?;
     if node.child_count() != 0 {
         return None;
     }


### PR DESCRIPTION
The following fixes #15287. The change is to simply make the `end` parameter of `descendent_for_byte_range` be `pos + 1` instead of `pos`. I believe the culprit commit that lead to this bug was #10613 (before this change it was also `pos + 1`) but this was a major improvement on how pair matching was implemented so the bug may have existed before this as well. 

I am unsure if this leads to any regressions but I doubt it.