### PR TITLE
Improve docs and logging for lsp root selection

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -4,6 +4,7 @@ use crate::{
     transport::{Payload, Transport},
     Call, Error, LanguageServerId, OffsetEncoding, Result,
 };
+use log::info;
 
 use crate::lsp::{
     self, notification::DidChangeWorkspaceFolders, CodeActionCapabilityResolveSupport,
@@ -219,6 +220,7 @@ impl Client {
         UnboundedReceiver<(LanguageServerId, Call)>,
         Arc<Notify>,
     )> {
+        info!("Starting lsp {name:?} in root {root_path:?}");
         // Resolve path to the binary
         let cmd = helix_stdx::env::which(cmd)?;
 

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -9,6 +9,7 @@ pub use client::Client;
 pub use futures_executor::block_on;
 pub use helix_lsp_types as lsp;
 pub use jsonrpc::Call;
+use log::warn;
 pub use lsp::{Position, Url};
 
 use futures_util::stream::select_all::SelectAll;
@@ -915,6 +916,8 @@ fn start_client(
             .map(|entry| entry.file_name())
             .any(|entry| globset.is_match(entry))
         {
+            // TODO: also show the globset that should be matched: https://github.com/BurntSushi/ripgrep/issues/3274
+            warn!("The lsp {name:?} tried to start at {root_path:?} but failed to match it's 'required_root_patterns'");
             return Err(StartupError::NoRequiredRootFound);
         }
     }


### PR DESCRIPTION
See this issue https://github.com/helix-editor/helix/issues/14649 and in particular @pascalkuthe's comment there. I have tried to keep my wording close to his.

In addition I have looked at the source code and added two log statements. A warning when an lsp is not allowed to start due to it's `required-root-patterns` and an info log when an lsp root has been selected and helix attempts to start it up. I think this is really valuable information that will make debugging these types of issues much easier!