### PR TITLE
update jjconfig globs for secure-config

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3902,7 +3902,7 @@ name = "jjconfig"
 scope = "source.jjconfig"
 injection-regex = "jjconfig"
 grammar = "toml"
-file-types = [{ glob = "jj/config.toml" }, { glob = "jj/conf.d/*.toml" }, { glob = ".jj/repo/*.toml" }]
+file-types = [{ glob = "jj/config.toml" }, { glob = "jj/**/*.toml" }, { glob = ".jj/repo/*.toml" }]
 comment-token = "#"
 language-servers = [ "taplo", "tombi" ]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Since https://github.com/jj-vcs/jj/pull/8222, JJ repo config files are stored in `~/.config/jj/repos/<hash>/config.toml` and `~/.config/jj/workspaces/<hash>/config.toml`