### PR TITLE
tweak(languages): add additional *.Brewfile glob

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1203,6 +1203,7 @@ file-types = [
   { glob = "Podfile" },
   { glob = "Vagrantfile" },
   { glob = "Brewfile" },
+  { glob = "*.Brewfile" },
   { glob = "Guardfile" },
   { glob = "Capfile" },
   { glob = "Cheffile" },


### PR DESCRIPTION
Add a more permissive `*.Brewfile` glob to allow: `.Brewfile` and `temp.Brewfile`.