### PR TITLE
Add cursor position persistence across sessions

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -22,6 +22,7 @@
 - [`[editor.smart-tab]` Section](#editorsmart-tab-section)
 - [`[editor.inline-diagnostics]` Section](#editorinline-diagnostics-section)
 - [`[editor.word-completion]` Section](#editorword-completion-section)
+- [`[editor.session]` Section](#editorsession-section)
 
 ### `[editor]` Section
 
@@ -527,4 +528,27 @@ Example:
 enable = true
 # Set the trigger length lower so that words are completed more often
 trigger-length = 4
+```
+
+### `[editor.session]` Section
+
+Options for controlling session state persistence and garbage collection.
+
+| Key              | Description                                                                                              | Default |
+| ---              | ---                                                                                                      | ---     |
+| `restore-cursor` | Restore cursor position when reopening files                                                             | `false` |
+| `gc-max-age`     | Maximum age in days for session entries before garbage collection removes them. Set to `0` to disable GC | `90`    |
+
+Session state is stored in `~/.cache/helix/sessions.json` and tracks cursor
+positions for previously opened files. Garbage collection runs at most once per
+day on startup and removes entries that haven't been visited within `gc-max-age`
+days. GC only runs when `restore-cursor` is enabled.
+
+Example:
+
+```toml
+[editor.session]
+restore-cursor = true
+# Keep session entries for up to 180 days
+gc-max-age = 180
 ```

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod syntax;
 pub mod test;
 pub mod text_annotations;
 pub mod textobject;
+pub mod time;
 mod transaction;
 pub mod uri;
 pub mod wrap;

--- a/helix-core/src/time.rs
+++ b/helix-core/src/time.rs
@@ -1,0 +1,9 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Returns the current Unix timestamp in seconds.
+pub fn now_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -202,15 +202,18 @@ impl Application {
                         // NOTE: this isn't necessarily true anymore. If
                         // `--vsplit` or `--hsplit` are used, the file which is
                         // opened last is focused on.
-                        let view_id = editor.tree.focus;
-                        let doc = doc_mut!(editor, &doc_id);
-                        let selection = pos
-                            .into_iter()
-                            .map(|coords| {
-                                Range::point(pos_at_coords(doc.text().slice(..), coords, true))
-                            })
-                            .collect();
-                        doc.set_selection(view_id, selection);
+                        let has_explicit_pos = pos.iter().any(|p| !p.is_zero());
+                        if has_explicit_pos {
+                            let view_id = editor.tree.focus;
+                            let doc = doc_mut!(editor, &doc_id);
+                            let selection = pos
+                                .into_iter()
+                                .map(|coords| {
+                                    Range::point(pos_at_coords(doc.text().slice(..), coords, true))
+                                })
+                                .collect();
+                            doc.set_selection(view_id, selection);
+                        }
                     }
                 }
 
@@ -251,7 +254,7 @@ impl Application {
         ])
         .context("build signal handler")?;
 
-        let app = Self {
+        let mut app = Self {
             compositor,
             terminal,
             editor,
@@ -261,6 +264,18 @@ impl Application {
             lsp_progress: LspProgressMap::new(),
             theme_mode,
         };
+
+        let gc_max_age = app.editor.config().session.gc_max_age;
+        if app.editor.config().session.restore_cursor
+            && gc_max_age > 0
+            && app.editor.session_state.needs_gc()
+        {
+            app.jobs.callback(async move {
+                Ok(crate::job::Callback::Editor(Box::new(move |editor| {
+                    editor.session_state.gc(gc_max_age);
+                })))
+            });
+        }
 
         Ok(app)
     }
@@ -1327,6 +1342,14 @@ impl Application {
         //        want to try to run as much cleanup as we can, regardless of
         //        errors along the way
         let mut errs = Vec::new();
+
+        if self.editor.config().session.restore_cursor {
+            let doc_ids: Vec<_> = self.editor.documents().map(|d| d.id()).collect();
+            for doc_id in doc_ids {
+                self.editor.save_doc_cursor_position(doc_id);
+            }
+            self.editor.session_state.save();
+        }
 
         if let Err(err) = self
             .jobs

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -164,11 +164,12 @@ fn open_impl(cx: &mut compositor::Context, args: Args, action: Action) -> anyhow
         } else {
             // Otherwise, just open the file
             let _ = cx.editor.open(&path, action)?;
-            let (view, doc) = current!(cx.editor);
-            let pos = Selection::point(pos_at_coords(doc.text().slice(..), pos, true));
-            doc.set_selection(view.id, pos);
-            // does not affect opening a buffer without pos
-            align_view(doc, view, Align::Center);
+            if !pos.is_zero() {
+                let (view, doc) = current!(cx.editor);
+                let pos = Selection::point(pos_at_coords(doc.text().slice(..), pos, true));
+                doc.set_selection(view.id, pos);
+                align_view(doc, view, Align::Center);
+            }
         }
     }
     Ok(())

--- a/helix-term/tests/integration.rs
+++ b/helix-term/tests/integration.rs
@@ -21,5 +21,6 @@ mod test {
     mod commands;
     mod languages;
     mod movement;
+    mod session;
     mod splits;
 }

--- a/helix-term/tests/test/session.rs
+++ b/helix-term/tests/test/session.rs
@@ -1,0 +1,246 @@
+use super::*;
+
+fn session_config() -> Config {
+    Config {
+        editor: helix_view::editor::Config {
+            session: helix_view::editor::SessionConfig {
+                restore_cursor: true,
+                ..Default::default()
+            },
+            lsp: helix_view::editor::LspConfig {
+                enable: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_save_and_restore_cursor_position() -> anyhow::Result<()> {
+    let file =
+        helpers::temp_file_with_contents("line one\nline two\nline three\nline four\nline five\n")?;
+    let path = file.path().to_string_lossy().to_string();
+
+    let mut app = helpers::AppBuilder::new()
+        .with_config(session_config())
+        .with_file(file.path(), None)
+        .build()?;
+
+    helpers::test_key_sequences(
+        &mut app,
+        vec![
+            // Move cursor to row 2, close buffer, reopen
+            (
+                Some(&format!("2j3l:bc!<ret>:o {}<ret>", path)),
+                Some(&|app| {
+                    let (view, doc) = helix_view::current_ref!(app.editor);
+                    let text = doc.text().slice(..);
+                    let coords =
+                        helix_core::coords_at_pos(text, doc.selection(view.id).primary().head);
+                    assert_eq!(coords.row, 2, "cursor row should be restored");
+                    assert!(coords.col > 0, "cursor col should be restored (non-zero)");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_cursor_clamped_to_valid_position() -> anyhow::Result<()> {
+    let file =
+        helpers::temp_file_with_contents("line one\nline two\nline three\nline four\nline five\n")?;
+    let path = file.path().to_path_buf();
+    let path_str = path.to_string_lossy().to_string();
+
+    let mut app = helpers::AppBuilder::new()
+        .with_config(session_config())
+        .with_file(file.path(), None)
+        .build()?;
+
+    helpers::test_key_sequences(
+        &mut app,
+        vec![
+            // Move to row 3, close buffer. Truncate file in assertion callback.
+            (
+                Some("3j:bc!<ret>"),
+                Some(&|_app| {
+                    // Truncate the file on disk to 2 lines between close and reopen
+                    std::fs::write(&path, "short\nfile\n").unwrap();
+                }),
+            ),
+            // Reopen — cursor should be clamped to valid range
+            (
+                Some(&format!(":o {}<ret>", path_str)),
+                Some(&|app| {
+                    let (view, doc) = helix_view::current_ref!(app.editor);
+                    let text = doc.text().slice(..);
+                    let max_line = text.len_lines().saturating_sub(1);
+                    let coords =
+                        helix_core::coords_at_pos(text, doc.selection(view.id).primary().head);
+                    assert!(
+                        coords.row <= max_line,
+                        "cursor row {} should be <= max line {}",
+                        coords.row,
+                        max_line
+                    );
+                }),
+            ),
+        ],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_disabled_by_default() -> anyhow::Result<()> {
+    let file = helpers::temp_file_with_contents("line one\nline two\nline three\nline four\n")?;
+    let path = file.path().to_string_lossy().to_string();
+
+    // Default config — session.restore_cursor = false
+    let mut app = helpers::AppBuilder::new()
+        .with_file(file.path(), None)
+        .build()?;
+
+    helpers::test_key_sequences(
+        &mut app,
+        vec![(
+            Some(&format!("3j:bc!<ret>:o {}<ret>", path)),
+            Some(&|app| {
+                let (view, doc) = helix_view::current_ref!(app.editor);
+                let text = doc.text().slice(..);
+                let coords = helix_core::coords_at_pos(text, doc.selection(view.id).primary().head);
+                assert_eq!(
+                    coords.row, 0,
+                    "cursor should be at row 0 when session disabled"
+                );
+            }),
+        )],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_explicit_position_overrides_restore() -> anyhow::Result<()> {
+    let file =
+        helpers::temp_file_with_contents("line one\nline two\nline three\nline four\nline five\n")?;
+    let path = file.path().to_string_lossy().to_string();
+
+    let mut app = helpers::AppBuilder::new()
+        .with_config(session_config())
+        .with_file(file.path(), None)
+        .build()?;
+
+    // Move to row 1, close, reopen with explicit line 4 (1-indexed → row 3)
+    helpers::test_key_sequences(
+        &mut app,
+        vec![(
+            Some(&format!("j:bc!<ret>:o {}:4<ret>", path)),
+            Some(&|app| {
+                let (view, doc) = helix_view::current_ref!(app.editor);
+                let text = doc.text().slice(..);
+                let coords = helix_core::coords_at_pos(text, doc.selection(view.id).primary().head);
+                assert_eq!(
+                    coords.row, 3,
+                    "explicit position should override session restore"
+                );
+            }),
+        )],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_multiple_documents() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("alpha\nbeta\ngamma\ndelta\n")?;
+    let file2 = helpers::temp_file_with_contents("one\ntwo\nthree\nfour\nfive\nsix\n")?;
+    let path1 = file1.path().to_string_lossy().to_string();
+    let path2 = file2.path().to_string_lossy().to_string();
+
+    let mut app = helpers::AppBuilder::new()
+        .with_config(session_config())
+        .with_file(file1.path(), None)
+        .build()?;
+
+    helpers::test_key_sequences(
+        &mut app,
+        vec![
+            // Move file1 cursor to row 2, open file2, move to row 4, close both, reopen file1
+            (
+                Some(&format!(
+                    "2j:o {}<ret>4j:bc!<ret>:bc!<ret>:o {}<ret>",
+                    path2, path1
+                )),
+                Some(&|app| {
+                    let (view, doc) = helix_view::current_ref!(app.editor);
+                    let text = doc.text().slice(..);
+                    let coords =
+                        helix_core::coords_at_pos(text, doc.selection(view.id).primary().head);
+                    assert_eq!(coords.row, 2, "file1 cursor should be restored to row 2");
+                }),
+            ),
+            // Open file2 and check its cursor
+            (
+                Some(&format!(":o {}<ret>", path2)),
+                Some(&|app| {
+                    let (view, doc) = helix_view::current_ref!(app.editor);
+                    let text = doc.text().slice(..);
+                    let coords =
+                        helix_core::coords_at_pos(text, doc.selection(view.id).primary().head);
+                    assert_eq!(coords.row, 4, "file2 cursor should be restored to row 4");
+                }),
+            ),
+        ],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_session_scratch_buffer_not_saved() -> anyhow::Result<()> {
+    let file = helpers::temp_file_with_contents("hello\nworld\n")?;
+
+    let mut app = helpers::AppBuilder::new()
+        .with_config(session_config())
+        .with_file(file.path(), None)
+        .build()?;
+
+    helpers::test_key_sequences(
+        &mut app,
+        vec![
+            // Move cursor in named file, then open a scratch buffer, type text, close it
+            (
+                Some(":new<ret>ihello scratch<esc>:bc!<ret>"),
+                Some(&|app| {
+                    // After closing the scratch buffer, only the named file should
+                    // potentially be in session state — no scratch buffer entry.
+                    // Verify we're back on the named file.
+                    let doc = helix_view::doc!(app.editor);
+                    assert!(
+                        doc.path().is_some(),
+                        "should be back on the named file after closing scratch buffer"
+                    );
+                }),
+            ),
+        ],
+        false,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -49,6 +49,7 @@ use helix_core::{
         self,
         config::{AutoPairConfig, IndentationHeuristic, LanguageServerFeature, SoftWrap},
     },
+    time::now_timestamp,
     Change, LineEnding, Position, Range, Selection, Uri, NATIVE_LINE_ENDING,
 };
 use helix_dap::{self as dap, registry::DebugAdapterId};
@@ -431,6 +432,26 @@ pub struct Config {
     /// Whether to enable Kitty Keyboard Protocol
     pub kitty_keyboard_protocol: KittyKeyboardProtocolConfig,
     pub buffer_picker: BufferPickerConfig,
+    pub session: SessionConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct SessionConfig {
+    /// Restore cursor position when reopening files. Defaults to false.
+    pub restore_cursor: bool,
+    /// Maximum age in days for session entries before garbage collection removes them.
+    /// Set to 0 to disable GC. Defaults to 90.
+    pub gc_max_age: u64,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            restore_cursor: false,
+            gc_max_age: 90,
+        }
+    }
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -1153,6 +1174,7 @@ impl Default for Config {
             rainbow_brackets: false,
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
+            session: SessionConfig::default(),
         }
     }
 }
@@ -1255,6 +1277,7 @@ pub struct Editor {
 
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
+    pub session_state: crate::session::SessionState,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1378,6 +1401,11 @@ impl Editor {
             mouse_down_range: None,
             cursor_cache: CursorCache::default(),
             dir_stack: VecDeque::with_capacity(DIR_STACK_CAP),
+            session_state: if conf.session.restore_cursor {
+                crate::session::SessionState::load()
+            } else {
+                crate::session::SessionState::default()
+            },
         }
     }
 
@@ -1913,6 +1941,7 @@ impl Editor {
     pub fn open(&mut self, path: &Path, action: Action) -> Result<DocumentId, DocumentOpenError> {
         let path = helix_stdx::path::canonicalize(path);
         let id = self.document_id_by_path(&path);
+        let is_new_doc = id.is_none();
 
         let id = if let Some(id) = id {
             id
@@ -1947,16 +1976,153 @@ impl Editor {
 
         self.switch(id, action);
 
+        if is_new_doc && self.config().session.restore_cursor {
+            self.restore_doc_cursor_position(id, &path);
+        }
+
         Ok(id)
     }
 
     pub fn close(&mut self, id: ViewId) {
+        // Save cursor positions before removing view data, so session
+        // restore has them available.
+        if self.config().session.restore_cursor {
+            let doc_ids: Vec<_> = self
+                .documents()
+                .filter(|doc| doc.selections().contains_key(&id))
+                .map(|doc| doc.id())
+                .collect();
+            for doc_id in doc_ids {
+                self.save_doc_cursor_for_view(doc_id, id);
+            }
+        }
+
         // Remove selections for the closed view on all documents.
         for doc in self.documents_mut() {
             doc.remove_view(id);
         }
         self.tree.remove(id);
         self._refresh();
+    }
+
+    fn save_doc_cursor_for_view(&mut self, doc_id: DocumentId, view_id: ViewId) {
+        let doc = match self.documents.get(&doc_id) {
+            Some(doc) => doc,
+            None => return,
+        };
+        let path = match doc.path() {
+            Some(path) => path.clone(),
+            None => return, // scratch buffer
+        };
+
+        let text = doc.text().slice(..);
+        let selection = match doc.selections().get(&view_id) {
+            Some(sel) => sel.clone(),
+            None => return,
+        };
+        let primary = selection.primary();
+        let anchor_pos = helix_core::coords_at_pos(text, primary.anchor);
+        let head_pos = helix_core::coords_at_pos(text, primary.head);
+
+        let view_offset = doc.view_offset(view_id);
+        let view_anchor_pos = helix_core::coords_at_pos(text, view_offset.anchor);
+
+        self.session_state.set(
+            &path,
+            crate::session::FileState {
+                anchor_row: anchor_pos.row,
+                anchor_col: anchor_pos.col,
+                head_row: head_pos.row,
+                head_col: head_pos.col,
+                view_anchor_row: view_anchor_pos.row,
+                view_anchor_col: view_anchor_pos.col,
+                horizontal_offset: view_offset.horizontal_offset,
+                timestamp: now_timestamp(),
+            },
+        );
+    }
+
+    pub fn save_doc_cursor_position(&mut self, doc_id: DocumentId) {
+        // Find the best view: prefer focused view if it shows this doc
+        let focused = self.tree.focus;
+        let view_id = if self
+            .documents
+            .get(&doc_id)
+            .and_then(|d| d.selections().get(&focused))
+            .is_some()
+            && self.tree.try_get(focused).is_some_and(|v| v.doc == doc_id)
+        {
+            focused
+        } else {
+            // Fall back to any view showing this doc
+            match self
+                .tree
+                .views()
+                .find(|(v, _)| v.doc == doc_id)
+                .map(|(v, _)| v.id)
+            {
+                Some(id) => id,
+                None => return,
+            }
+        };
+
+        self.save_doc_cursor_for_view(doc_id, view_id);
+    }
+
+    fn restore_doc_cursor_position(&mut self, doc_id: DocumentId, path: &Path) {
+        let file_state = match self.session_state.get(path) {
+            Some(state) => state.clone(),
+            None => return,
+        };
+
+        let view_id = self.tree.focus;
+        let doc = match self.documents.get(&doc_id) {
+            Some(doc) => doc,
+            None => return,
+        };
+
+        let text = doc.text().slice(..);
+        let max_line = text.len_lines().saturating_sub(1);
+
+        // The moving end of the selection range.
+        let head = helix_core::pos_at_coords(
+            text,
+            Position::new(file_state.head_row.min(max_line), file_state.head_col),
+            true,
+        );
+
+        // The non-moving end of the selection range.
+        let anchor = helix_core::pos_at_coords(
+            text,
+            Position::new(file_state.anchor_row.min(max_line), file_state.anchor_col),
+            true,
+        );
+
+        // The top-left character position that determines which part of the document
+        // is visible in the view (i.e. the scroll position).
+        let view_anchor = helix_core::pos_at_coords(
+            text,
+            Position::new(
+                file_state.view_anchor_row.min(max_line),
+                file_state.view_anchor_col,
+            ),
+            true,
+        );
+
+        let doc = match self.documents.get_mut(&doc_id) {
+            Some(doc) => doc,
+            None => return,
+        };
+
+        doc.set_selection(view_id, Selection::single(anchor, head));
+        doc.set_view_offset(
+            view_id,
+            crate::view::ViewPosition {
+                anchor: view_anchor,
+                horizontal_offset: file_state.horizontal_offset,
+                vertical_offset: 0,
+            },
+        );
     }
 
     pub fn close_document(&mut self, doc_id: DocumentId, force: bool) -> Result<(), CloseError> {
@@ -1966,6 +2132,10 @@ impl Editor {
         };
         if !force && doc.is_modified() {
             return Err(CloseError::BufferModified(doc.display_name().into_owned()));
+        }
+
+        if self.config().session.restore_cursor {
+            self.save_doc_cursor_position(doc_id);
         }
 
         // This will also disallow any follow-up writes

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -14,6 +14,7 @@ pub mod info;
 pub mod input;
 pub mod keyboard;
 pub mod register;
+pub mod session;
 pub mod theme;
 pub mod tree;
 pub mod view;

--- a/helix-view/src/session.rs
+++ b/helix-view/src/session.rs
@@ -1,0 +1,351 @@
+use helix_core::time::now_timestamp;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+const MAX_ENTRIES: usize = 1000;
+const FILE_NAME: &str = "sessions.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileState {
+    pub anchor_row: usize,
+    pub anchor_col: usize,
+    pub head_row: usize,
+    pub head_col: usize,
+    pub view_anchor_row: usize,
+    pub view_anchor_col: usize,
+    pub horizontal_offset: usize,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct SessionState {
+    pub files: HashMap<String, FileState>,
+    #[serde(default)]
+    pub last_gc: u64,
+}
+
+impl SessionState {
+    pub fn load() -> Self {
+        let path = helix_loader::cache_dir().join(FILE_NAME);
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => serde_json::from_str(&contents).unwrap_or_else(|err| {
+                log::warn!(
+                    "Failed to parse session state from {}: {}",
+                    path.display(),
+                    err
+                );
+                Self::default()
+            }),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Self::default(),
+            Err(err) => {
+                log::warn!(
+                    "Failed to read session state from {}: {}",
+                    path.display(),
+                    err
+                );
+                Self::default()
+            }
+        }
+    }
+
+    pub fn save(&mut self) {
+        self.prune();
+        let path = helix_loader::cache_dir().join(FILE_NAME);
+        if let Some(parent) = path.parent() {
+            if let Err(err) = std::fs::create_dir_all(parent) {
+                log::warn!(
+                    "Failed to create cache directory {}: {}",
+                    parent.display(),
+                    err
+                );
+                return;
+            }
+        }
+        match serde_json::to_string_pretty(self) {
+            Ok(contents) => {
+                if let Err(err) = std::fs::write(&path, contents) {
+                    log::warn!(
+                        "Failed to write session state to {}: {}",
+                        path.display(),
+                        err
+                    );
+                }
+            }
+            Err(err) => {
+                log::warn!("Failed to serialize session state: {}", err);
+            }
+        }
+    }
+
+    pub fn set(&mut self, path: &Path, state: FileState) {
+        self.files
+            .insert(path.to_string_lossy().into_owned(), state);
+    }
+
+    pub fn get(&self, path: &Path) -> Option<&FileState> {
+        self.files.get(&*path.to_string_lossy())
+    }
+
+    /// Returns `true` if more than 1 day has passed since the last GC run.
+    pub fn needs_gc(&self) -> bool {
+        now_timestamp().saturating_sub(self.last_gc) > 86400
+    }
+
+    /// Remove entries older than `max_age_days` days and update `last_gc`.
+    /// Does NOT save to disk — the caller is responsible for eventual flush.
+    pub fn gc(&mut self, max_age_days: u64) {
+        let now = now_timestamp();
+        let cutoff = now.saturating_sub(max_age_days * 86400);
+        self.files.retain(|_, state| state.timestamp >= cutoff);
+        self.last_gc = now;
+    }
+
+    fn prune(&mut self) {
+        if self.files.len() <= MAX_ENTRIES {
+            return;
+        }
+
+        let mut entries: Vec<(String, u64)> = self
+            .files
+            .iter()
+            .map(|(k, v)| (k.clone(), v.timestamp))
+            .collect();
+        entries.sort_by_key(|(_, ts)| *ts);
+
+        let to_remove = self.files.len() - MAX_ENTRIES;
+        for (key, _) in entries.into_iter().take(to_remove) {
+            self.files.remove(&key);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip_serialization() {
+        let mut state = SessionState::default();
+        state.set(
+            Path::new("/tmp/test.rs"),
+            FileState {
+                anchor_row: 10,
+                anchor_col: 5,
+                head_row: 10,
+                head_col: 5,
+                view_anchor_row: 5,
+                view_anchor_col: 0,
+                horizontal_offset: 0,
+                timestamp: 1000,
+            },
+        );
+
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.files.len(), 1);
+        let file_state = deserialized.get(Path::new("/tmp/test.rs")).unwrap();
+        assert_eq!(file_state.anchor_row, 10);
+        assert_eq!(file_state.head_row, 10);
+        assert_eq!(file_state.head_col, 5);
+    }
+
+    #[test]
+    fn test_get_set() {
+        let mut state = SessionState::default();
+        assert!(state.get(Path::new("/nonexistent")).is_none());
+
+        state.set(
+            Path::new("/tmp/foo.rs"),
+            FileState {
+                anchor_row: 1,
+                anchor_col: 2,
+                head_row: 3,
+                head_col: 4,
+                view_anchor_row: 0,
+                view_anchor_col: 0,
+                horizontal_offset: 10,
+                timestamp: 500,
+            },
+        );
+
+        let fs = state.get(Path::new("/tmp/foo.rs")).unwrap();
+        assert_eq!(fs.anchor_row, 1);
+        assert_eq!(fs.anchor_col, 2);
+        assert_eq!(fs.head_row, 3);
+        assert_eq!(fs.head_col, 4);
+        assert_eq!(fs.horizontal_offset, 10);
+    }
+
+    #[test]
+    fn test_prune() {
+        let mut state = SessionState::default();
+        for i in 0..1050 {
+            state.set(
+                Path::new(&format!("/tmp/file_{}.rs", i)),
+                FileState {
+                    anchor_row: 0,
+                    anchor_col: 0,
+                    head_row: 0,
+                    head_col: 0,
+                    view_anchor_row: 0,
+                    view_anchor_col: 0,
+                    horizontal_offset: 0,
+                    timestamp: i as u64,
+                },
+            );
+        }
+        assert_eq!(state.files.len(), 1050);
+        state.prune();
+        assert_eq!(state.files.len(), MAX_ENTRIES);
+
+        // The oldest entries (lowest timestamps) should have been removed
+        assert!(state.get(Path::new("/tmp/file_0.rs")).is_none());
+        assert!(state.get(Path::new("/tmp/file_49.rs")).is_none());
+        // The newest entries should remain
+        assert!(state.get(Path::new("/tmp/file_1049.rs")).is_some());
+        assert!(state.get(Path::new("/tmp/file_50.rs")).is_some());
+    }
+
+    #[test]
+    fn test_gc() {
+        let now = now_timestamp();
+        let mut state = SessionState::default();
+
+        // Entry from 100 days ago — should be removed with max_age=90
+        state.set(
+            Path::new("/tmp/old.rs"),
+            FileState {
+                anchor_row: 0,
+                anchor_col: 0,
+                head_row: 0,
+                head_col: 0,
+                view_anchor_row: 0,
+                view_anchor_col: 0,
+                horizontal_offset: 0,
+                timestamp: now - 100 * 86400,
+            },
+        );
+
+        // Entry from 10 days ago — should be kept
+        state.set(
+            Path::new("/tmp/recent.rs"),
+            FileState {
+                anchor_row: 1,
+                anchor_col: 0,
+                head_row: 1,
+                head_col: 0,
+                view_anchor_row: 0,
+                view_anchor_col: 0,
+                horizontal_offset: 0,
+                timestamp: now - 10 * 86400,
+            },
+        );
+
+        // Entry from just now — should be kept
+        state.set(
+            Path::new("/tmp/new.rs"),
+            FileState {
+                anchor_row: 2,
+                anchor_col: 0,
+                head_row: 2,
+                head_col: 0,
+                view_anchor_row: 0,
+                view_anchor_col: 0,
+                horizontal_offset: 0,
+                timestamp: now,
+            },
+        );
+
+        assert_eq!(state.last_gc, 0);
+        state.gc(90);
+
+        assert_eq!(state.files.len(), 2);
+        assert!(state.get(Path::new("/tmp/old.rs")).is_none());
+        assert!(state.get(Path::new("/tmp/recent.rs")).is_some());
+        assert!(state.get(Path::new("/tmp/new.rs")).is_some());
+        assert!(state.last_gc >= now);
+    }
+
+    #[test]
+    fn test_needs_gc() {
+        let now = now_timestamp();
+        let mut state = SessionState::default();
+
+        // last_gc = 0, should need GC
+        assert!(state.needs_gc());
+
+        // last_gc = now, should not need GC
+        state.last_gc = now;
+        assert!(!state.needs_gc());
+
+        // last_gc = 2 days ago, should need GC
+        state.last_gc = now - 2 * 86400;
+        assert!(state.needs_gc());
+    }
+
+    #[test]
+    fn test_gc_disabled_with_zero_max_age() {
+        let now = now_timestamp();
+        let mut state = SessionState::default();
+
+        state.set(
+            Path::new("/tmp/old.rs"),
+            FileState {
+                anchor_row: 0,
+                anchor_col: 0,
+                head_row: 0,
+                head_col: 0,
+                view_anchor_row: 0,
+                view_anchor_col: 0,
+                horizontal_offset: 0,
+                timestamp: 1000, // very old
+            },
+        );
+
+        // gc with 0 days would set cutoff to now, removing everything,
+        // but the caller guards against gc_max_age == 0
+        // Just verify the method works with a large max_age that keeps everything
+        state.gc(u64::MAX / 86400);
+        assert_eq!(state.files.len(), 1);
+        assert!(state.last_gc >= now);
+    }
+
+    #[test]
+    fn test_last_gc_persisted_in_json() {
+        let mut state = SessionState::default();
+        state.last_gc = 1234567890;
+        state.set(
+            Path::new("/tmp/test.rs"),
+            FileState {
+                anchor_row: 0,
+                anchor_col: 0,
+                head_row: 0,
+                head_col: 0,
+                view_anchor_row: 0,
+                view_anchor_col: 0,
+                horizontal_offset: 0,
+                timestamp: 1000,
+            },
+        );
+
+        let json = serde_json::to_string(&state).unwrap();
+        let deserialized: SessionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.last_gc, 1234567890);
+    }
+
+    #[test]
+    fn test_last_gc_defaults_when_missing_from_json() {
+        // Simulate old session JSON without last_gc field
+        let json = r#"{"files":{}}"#;
+        let state: SessionState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.last_gc, 0);
+    }
+
+    #[test]
+    fn test_load_missing_file() {
+        // Loading from a non-existent path should return default
+        let state = SessionState::load();
+        assert!(state.files.is_empty());
+    }
+}


### PR DESCRIPTION
Opening a previously edited file in Helix always places the cursor at the top of the document, forcing users to manually navigate back to where they left off. Other editors like Vim and VS Code remember cursor positions, and users have long requested this capability.

Introduce a session persistence layer that saves and restores cursor state (selection anchor/head, viewport scroll position) to a JSON file in the cache directory (~/.cache/helix/sessions.json). The feature is opt-in via a new [editor.session] config section with restore-cursor (default: false) and gc-max-age (default: 90 days).

Cursor state is captured on view close, document close, and editor exit, then restored transparently when a file is reopened. A garbage collector removes stale entries older than gc-max-age days, running at most once per day on startup, and an LRU pruning step caps the store at 1000 entries to bound disk usage.

The :open command and CLI file arguments now only override cursor position when an explicit line/column is provided, so they no longer clobber the restored position for bare file paths.