### PR TITLE
docs: add cargo-rail change-detection config

### DIFF
--- a/.config/cargo-rail-planning-intergation.md
+++ b/.config/cargo-rail-planning-intergation.md
@@ -1,0 +1,42 @@
+# cargo-rail Planning Integration
+
+## Intent
+This repo is best served by `cargo rail plan` + `cargo xtask` execution.
+The `.config/rail.toml` includes custom surfaces for themes, queries, and docs.
+
+## Local developer flow
+```bash
+cargo rail config validate --strict
+cargo rail plan --merge-base --explain
+cargo rail plan --merge-base -f json
+```
+
+## GitHub Actions integration (cargo-rail-action)
+Use planner outputs to gate existing lanes.
+
+```yaml
+- uses: loadingalias/cargo-rail-action@v3
+  id: rail
+
+- name: Rust tests
+  if: steps.rail.outputs.test == 'true'
+  run: cargo test --workspace
+
+- name: Theme check
+  if: steps.rail.outputs.themes == 'true'
+  run: cargo xtask theme-check
+
+- name: Query check
+  if: steps.rail.outputs.queries == 'true'
+  run: cargo xtask query-check
+```
+
+## UI output that teams should read
+- action summary surface table and reasons
+- `steps.rail.outputs.plan-json` for custom job logic
+- `cargo rail plan --explain` as the local CI mirror
+
+## Measured impact (last 20 commits)
+- Could skip build: 30%
+- Could skip tests: 30%
+- Targeted (not full run): 40%

--- a/.config/rail.toml
+++ b/.config/rail.toml
@@ -1,0 +1,103 @@
+# cargo-rail configuration
+# Documentation: https://github.com/loadingalias/cargo-rail
+
+# Targets for multi-platform validation (runs `cargo metadata --filter-platform <target>` per target)
+targets = [
+  "aarch64-apple-darwin",
+  "aarch64-unknown-linux-gnu",
+  "i686-pc-windows-msvc",
+  "riscv64gc-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "x86_64-pc-windows-gnu",
+  "x86_64-pc-windows-msvc",
+  "x86_64-unknown-linux-gnu",
+]
+
+[unify]
+include_paths = true
+include_renamed = false
+
+pin_transitives = false  # enable for hakari/workspace-hack users
+transitive_host = "root"  # only used if pin_transitives = true
+
+strict_version_compat = true
+exact_pin_handling = "warn"
+major_version_conflict = "warn"  # warn = skip, bump = force highest
+
+msrv = true
+msrv_source = "max"  # deps | workspace | max
+enforce_msrv_inheritance = false  # Ensure members inherit workspace rust-version
+
+detect_unused = true
+remove_unused = true  # requires detect_unused = true
+
+prune_dead_features = true
+preserve_features = []  # glob patterns to keep from pruning
+detect_undeclared_features = true
+fix_undeclared_features = true  # requires detect_undeclared_features = true
+skip_undeclared_patterns = [
+  "default",
+  "std",
+  "alloc",
+  "*_backend",
+  "*_impl",
+]
+
+exclude = []  # excluding one workspace member excludes its whole member cohort
+include = []  # workspace-member cohorts are auto-included
+max_backups = 3
+sort_dependencies = true  # false to preserve existing order
+
+
+[release]
+tag_prefix = "v"
+tag_format = "{crate}-{prefix}{version}"  # e.g. my-crate-v1.0.0 (with tag_prefix = "v")
+require_clean = true
+publish_delay = 5  # seconds between publishes
+create_github_release = false
+sign_tags = false
+changelog_path = "CHANGELOG.md"
+changelog_relative_to = "crate"  # crate = per-crate, workspace = single file
+skip_changelog_for = []
+require_changelog_entries = false
+
+
+[change-detection]
+# Helix uses xtask and non-Rust runtime assets (themes/queries/book/docs).
+infrastructure = [
+  ".github/**",
+  "xtask/**",
+  "languages.toml",
+  "rust-toolchain.toml",
+  "Cargo.toml",
+  "Cargo.lock",
+]
+conservative_unclassified_owner_fallback = true
+confidence_profile = "balanced"
+bot_pr_confidence_profile = "strict"
+
+[change-detection.custom]
+themes = ["runtime/themes/**"]
+queries = ["runtime/queries/**"]
+docs = ["docs/**", "book/**"]
+
+# Primary mode: use cargo rail plan + cargo xtask in CI.
+# run profiles stay as fallback/local convenience.
+[run]
+default_profile = "local"
+
+[run.profile.local]
+surfaces = ["test"]
+merge_base = true
+
+[run.profile.ci]
+surfaces = ["build", "test"]
+merge_base = true
+
+
+# Per-crate configuration: run 'cargo rail split init <crate>' to generate
+# [crates.my-crate.split]
+# remote = "git@github.com:org/my-crate.git"
+# branch = "main"
+# mode = "single"
+# paths = [{ crate = "crates/my-crate" }]


### PR DESCRIPTION
Adds two files only:
- `.config/rail.toml`
- `.config/cargo-rail-planning-intergation.md`

Planner config is tuned for Helix runtime assets (themes/queries/docs) and CI gating with `cargo rail plan --merge-base --explain` + `loadingalias/cargo-rail-action@v3`.

Measured on recent history (20 commits): build skip 30%, test skip 30%, targeted/non-full runs 40% - give or take.

No Rust source changes.