### PR TITLE
fix(python): indent after except and finally

### DIFF
--- a/runtime/queries/python/indents.scm
+++ b/runtime/queries/python/indents.scm
@@ -53,6 +53,9 @@
 
   (function_definition)
   (class_definition)
+
+  (except_clause)
+  (finally_clause)
 ] @extend
 
 [
@@ -72,6 +75,10 @@
   "elif" @outdent)
 (else_clause
   "else" @outdent)
+(except_clause
+  "except" @outdent)
+(finally_clause
+  "finally" @outdent)
 
 (parameters
   .


### PR DESCRIPTION
In python, in this scenario:

```py
try:
    print('hello world')
except:
```

and if the cursor is on line 3, creating a new line did not indent properly. The same happened for a `finally:` clause.

This PR adds the two clauses to the python indent queries.