### PR TITLE
fix(tui): ensure correct cursor shape restoration on exit

### DIFF
--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -33,7 +33,7 @@ fn vte_version() -> Option<usize> {
     std::env::var("VTE_VERSION").ok()?.parse().ok()
 }
 fn reset_cursor_approach(terminfo: TermInfo) -> String {
-    let mut reset_str = "\x1B[0 q".to_string();
+    let mut reset_str = String::new();
 
     if let Some(termini::Value::Utf8String(se_str)) = terminfo.extended_cap("Se") {
         reset_str.push_str(se_str);
@@ -44,6 +44,8 @@ fn reset_cursor_approach(terminfo: TermInfo) -> String {
             .utf8_string_cap(termini::StringCapability::CursorNormal)
             .unwrap_or(""),
     );
+
+    reset_str.push_str("\x1B[0 q");
 
     reset_str
 }

--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -214,8 +214,7 @@ impl TerminaBackend {
 
         capabilities.extended_underlines |= config.force_enable_extended_underlines;
 
-        let mut reset_cursor_command =
-            Csi::Cursor(csi::Cursor::CursorStyle(CursorStyle::Default)).to_string();
+        let mut reset_cursor_command = String::new();
         if let Ok(t) = termini::TermInfo::from_env() {
             capabilities.extended_underlines |= t.extended_cap("Smulx").is_some()
                 || t.extended_cap("Su").is_some()
@@ -237,6 +236,8 @@ impl TerminaBackend {
         } else {
             log::debug!("terminfo could not be read, using default cursor reset escape sequence: {reset_cursor_command:?}");
         }
+        reset_cursor_command
+            .push_str(&Csi::Cursor(csi::Cursor::CursorStyle(CursorStyle::Default)).to_string());
 
         terminal.enter_cooked_mode()?;
 


### PR DESCRIPTION
### Description:
This PR ensures that the terminal cursor is correctly restored to the user's initial configuration (e.g., underline or bar) upon exiting the editor, resolving the persistent "cursor shape leak" observed in various terminal emulators.

### The Problem:
In environments using xterm-256color, legacy terminfo sequences were overriding the modern cursor reset commands during the cleanup phase. This resulted in the cursor being forced into a steady block state on exit, regardless of the terminal's global settings.

### The Fix:
I have updated the cursor reset logic to ensure that modern ANSI reset sequences are prioritized over legacy terminfo capabilities. This ensures:
* The cursor now honors the user's global terminal preferences after the process ends.
* he fix is applied to both termina and crossterm backends for a unified behavior across platforms.
* Fallback support for older terminals is maintained without interfering with modern emulator features.

Fixes #15318 