### PR TITLE
Set window title of terminal

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -29,7 +29,7 @@
 
 | Key | Description | Default |
 |--|--|---------|
-| `title-format` | Format to use for window title. Supports [expansions](./command-line.md#expansions). | None |
+| `title-format` | Format to use for window title. Supports [expansions](./command-line.md#expansions). Set to `""` to disable / leave the shell in charge | `"hx %{buffer_name}:%{cursor_line}:%{cursor_column}"`|
 | `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
 | `mouse` | Enable mouse mode | `true` |
 | `mouse-yank-register` | Which register to use for mouse yanks. | `*` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -29,7 +29,7 @@
 
 | Key | Description | Default |
 |--|--|---------|
-| `title_format` | Format to use for window title. Supports [expansions](./command-line.md#expansions). | None |
+| `title-format` | Format to use for window title. Supports [expansions](./command-line.md#expansions). | None |
 | `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
 | `mouse` | Enable mouse mode | `true` |
 | `mouse-yank-register` | Which register to use for mouse yanks. | `*` |

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -29,6 +29,7 @@
 
 | Key | Description | Default |
 |--|--|---------|
+| `title_format` | Format to use for window title. Supports [expansions](./command-line.md#expansions). | None |
 | `scrolloff` | Number of lines of padding around the edge of the screen when scrolling | `5` |
 | `mouse` | Enable mouse mode | `true` |
 | `mouse-yank-register` | Which register to use for mouse yanks. | `*` |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -291,12 +291,15 @@ impl Application {
         self.editor.cursor_cache.reset();
 
         if let Some(title_format) = &self.editor.config().title_format {
-            match expansion::expand(&self.editor, Token::expand(title_format)) {
-                Ok(title) => self.terminal.set_title(&title).unwrap(),
+            let title_result = match expansion::expand(&self.editor, Token::expand(title_format)) {
+                Ok(title) => self.terminal.set_title(&title),
                 Err(err) => {
                     log::error!("Failed to expand title args: {err}");
-                    self.terminal.set_title(&err.to_string()).unwrap();
+                    self.terminal.set_title(&err.to_string())
                 }
+            };
+            if let Err(err) = title_result {
+                log::error!("Failed to set terminal title {err}");
             }
         }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -291,9 +291,13 @@ impl Application {
         self.editor.cursor_cache.reset();
 
         if let Some(title_format) = &self.editor.config().title_format {
-            // TODO: Handle errors here (we shouldn't crash the editor for an invalid expansion)
-            let title = expansion::expand(&self.editor, Token::expand(title_format)).unwrap();
-            self.terminal.set_title(&title).unwrap();
+            match expansion::expand(&self.editor, Token::expand(title_format)) {
+                Ok(title) => self.terminal.set_title(&title).unwrap(),
+                Err(err) => {
+                    log::error!("Failed to expand title args: {err}");
+                    self.terminal.set_title(&err.to_string()).unwrap();
+                }
+            }
         }
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -290,7 +290,8 @@ impl Application {
         // reset cursor cache
         self.editor.cursor_cache.reset();
 
-        if let Some(title_format) = &self.editor.config().title_format {
+        let title_format = &self.editor.config().title_format;
+        if !title_format.is_empty() {
             let title_result = match expansion::expand(&self.editor, Token::expand(title_format)) {
                 Ok(title) => self.terminal.set_title(&title),
                 Err(err) => {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -287,8 +287,10 @@ impl Application {
         // reset cursor cache
         self.editor.cursor_cache.reset();
 
-        // TODO: Make title configurable (& use expansions)
-        self.terminal.set_title("Helix").unwrap();
+        if let Some(title_format) = &self.editor.config().title_format {
+            // TODO: Evaluate expansions
+            self.terminal.set_title(&title_format).unwrap();
+        }
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
         self.terminal.draw(pos, kind).unwrap();

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -287,6 +287,9 @@ impl Application {
         // reset cursor cache
         self.editor.cursor_cache.reset();
 
+        // TODO: Make title configurable (& use expansions)
+        self.terminal.set_title("Helix").unwrap();
+
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
         self.terminal.draw(pos, kind).unwrap();
     }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1,6 +1,8 @@
 use arc_swap::{access::Map, ArcSwap};
 use futures_util::Stream;
-use helix_core::{diagnostic::Severity, pos_at_coords, syntax, Range, Selection};
+use helix_core::{
+    command_line::Token, diagnostic::Severity, pos_at_coords, syntax, Range, Selection,
+};
 use helix_lsp::{
     lsp::{self, notification::Notification},
     util::lsp_range_to_range,
@@ -11,6 +13,7 @@ use helix_view::{
     align_view,
     document::{DocumentOpenError, DocumentSavedEventResult},
     editor::{ConfigEvent, EditorEvent},
+    expansion,
     graphics::Rect,
     theme,
     tree::Layout,
@@ -288,8 +291,9 @@ impl Application {
         self.editor.cursor_cache.reset();
 
         if let Some(title_format) = &self.editor.config().title_format {
-            // TODO: Evaluate expansions
-            self.terminal.set_title(&title_format).unwrap();
+            // TODO: Handle errors here (we shouldn't crash the editor for an invalid expansion)
+            let title = expansion::expand(&self.editor, Token::expand(title_format)).unwrap();
+            self.terminal.set_title(&title).unwrap();
         }
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -309,7 +309,7 @@ where
     }
 
     fn set_title(&mut self, title: &str) -> io::Result<()> {
-        todo!()
+        execute!(self.buffer, terminal::SetTitle(title))
     }
 
     fn clear(&mut self) -> io::Result<()> {

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -308,6 +308,10 @@ where
         queue!(self.buffer, MoveTo(x, y))
     }
 
+    fn set_title(&mut self, title: &str) -> io::Result<()> {
+        todo!()
+    }
+
     fn clear(&mut self) -> io::Result<()> {
         queue!(self.buffer, Clear(ClearType::All))
     }

--- a/helix-tui/src/backend/mod.rs
+++ b/helix-tui/src/backend/mod.rs
@@ -40,6 +40,8 @@ pub trait Backend {
     fn show_cursor(&mut self, kind: CursorKind) -> Result<(), io::Error>;
     /// Sets the cursor to the given position
     fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), io::Error>;
+    /// Sets the window title
+    fn set_title(&mut self, title: &str) -> Result<(), io::Error>;
     /// Clears the terminal
     fn clear(&mut self) -> Result<(), io::Error>;
     /// Begins a synchronized-output frame (if the terminal supports it), so the

--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -583,6 +583,11 @@ impl Backend for TerminaBackend {
         )
     }
 
+    fn set_title(&mut self, title: &str) -> io::Result<()> {
+        write!(self.terminal, "{}", Osc::SetWindowTitle(title))?;
+        self.flush()
+    }
+
     fn clear(&mut self) -> io::Result<()> {
         write!(
             self.terminal,

--- a/helix-tui/src/backend/test.rs
+++ b/helix-tui/src/backend/test.rs
@@ -15,6 +15,7 @@ pub struct TestBackend {
     height: u16,
     cursor: bool,
     pos: (u16, u16),
+    title: String,
 }
 
 /// Returns a string representation of the given buffer for debugging purpose.
@@ -54,6 +55,7 @@ impl TestBackend {
             buffer: Buffer::empty(Rect::new(0, 0, width, height)),
             cursor: false,
             pos: (0, 0),
+            title: String::new(),
         }
     }
 
@@ -141,6 +143,11 @@ impl Backend for TestBackend {
 
     fn set_cursor(&mut self, x: u16, y: u16) -> Result<(), io::Error> {
         self.pos = (x, y);
+        Ok(())
+    }
+
+    fn set_title(&mut self, title: &str) -> Result<(), io::Error> {
+        self.title = title.into();
         Ok(())
     }
 

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -246,6 +246,10 @@ where
         self.backend.set_cursor(x, y)
     }
 
+    pub fn set_title(&mut self, title: &str) -> io::Result<()> {
+        self.backend.set_title(title)
+    }
+
     /// Clear the terminal and force a full redraw on the next draw call.
     ///
     /// The physical erase is deferred to the next `flush` so it shares a

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -294,8 +294,8 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
-    /// Title for the window, supports expansions
-    pub title_format: Option<String>,
+    /// Title for the window, supports expansions. Set to "" to disable
+    pub title_format: String,
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,
     /// Number of lines to scroll at once. Defaults to 3
@@ -1177,7 +1177,7 @@ impl Default for WordCompletion {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            title_format: None,
+            title_format: "hx %{buffer_name}:%{cursor_line}:%{cursor_column}".into(),
             scrolloff: 5,
             scroll_lines: 3,
             mouse: true,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -294,6 +294,8 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct Config {
+    /// Title for the window, supports expansions
+    pub title_format: Option<String>,
     /// Padding to keep between the edge of the screen and the cursor when scrolling. Defaults to 5.
     pub scrolloff: usize,
     /// Number of lines to scroll at once. Defaults to 3
@@ -1175,6 +1177,7 @@ impl Default for WordCompletion {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            title_format: None,
             scrolloff: 5,
             scroll_lines: 3,
             mouse: true,


### PR DESCRIPTION
Adds a customizable `title_format` (similar to vim's titlestring). It re-use command-line expansions to support custom & dynamic titles. 

Demo on Mac OS Tahoe using Ghostty (also tested on default macOS terminal and on Windows Terminal).

https://github.com/user-attachments/assets/bae05808-65b2-4e55-912d-ab8270c3369a


Fixes #928
Fixes #2436
Related #14845