### PR TITLE
fix(languages:cue): Correct default config for CUE

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -39,7 +39,7 @@
 | crystal | ✓ | ✓ | ✓ | ✓ |  | `crystalline`, `ameba-ls` |
 | css | ✓ |  | ✓ |  | ✓ | `vscode-css-language-server` |
 | csv | ✓ |  |  |  |  |  |
-| cue | ✓ |  |  |  |  | `cuelsp` |
+| cue | ✓ |  |  |  |  | `cue` |
 | cylc | ✓ | ✓ | ✓ |  |  |  |
 | cython | ✓ |  | ✓ | ✓ |  |  |
 | d | ✓ | ✓ | ✓ |  |  | `serve-d` |

--- a/languages.toml
+++ b/languages.toml
@@ -31,7 +31,7 @@ commit-lsp = { command = "commit-lsp", args = ["run"] }
 crystalline = { command = "crystalline", args = ["--stdio"] }
 cs = { command = "cs", args = ["launch", "--contrib", "smithy-language-server", "--", "0"] }
 csharp-ls = { command = "csharp-ls" }
-cuelsp = { command = "cuelsp" }
+cuelsp = { command = "cue", args = ["lsp", "serve"] }
 dart = { command = "dart", args = ["language-server", "--client-id=helix"] }
 dhall-lsp-server = { command = "dhall-lsp-server" }
 djlsp = { command = "djlsp" }


### PR DESCRIPTION
Hello team!

LSP support was added to CUE in [v0.15.0](https://github.com/cue-lang/cue/releases/tag/v0.15.0) and is documented [here](https://github.com/cue-lang/cue/wiki/LSP:-Getting-started) with major announcements published [here](https://github.com/cue-lang/cue/issues/1776).