### PR TITLE
queries: add scope for mutable variables / mutable parameters

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -201,6 +201,7 @@ We use a similar set of scopes as
 - `variable` - Variables
   - `mutable` - Mutable variables (e.g. marked with `mut` in Rust)
   - `builtin` - Reserved language variables (`self`, `this`, `super`, etc.)
+    - `mutable` - Mutable language varaibles (e.g. `mut self` in Rust)
   - `parameter` - Function parameters
     - `mutable` - Mutable function parameters (e.g. marked with `mut` in Rust)
   - `other`

--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -221,6 +221,10 @@
   (mutable_specifier)
   pattern: (identifier) @variable.parameter.mutable)
 
+(self_parameter
+  (mutable_specifier)
+  (self) @variable.builtin.mutable)
+
 ; -------
 ; Keywords
 ; -------

--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -34,7 +34,12 @@
   (mutable_specifier)
   pattern: (identifier) @local.definition.variable.parameter.mutable)
 
+(self_parameter
+  (mutable_specifier)
+  (self) @local.definition.variable.builtin.mutable)
+
 ; References
+(self) @local.reference
 (identifier) @local.reference
 ; lifetimes / labels
 (lifetime (identifier) @label)


### PR DESCRIPTION
revive of #14353, except i distinguish between `@variable.mutable` and `@variable.parameter.mutable`. the reason for that is, so that themes can still highlight mutable parameters differently from mutable variables (like you can highlight normal parameters differently from normal variables).

additionally, this also makes it possible to theme mutable builtin variables such as `mut self` in rust parameters.

example images (with mutable variables underlined, customized themes for `solarized_light` and `onedark`):

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/857ab842-454a-41bd-b000-e161b8425375" />
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/2b3ab625-eed7-4de0-8b27-e7d1982db332" />
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/5542ec5b-1006-4334-b727-5be9c1e313e3" />
