### PR TITLE
Take horizontal padding into account when computing required text height of UI prompt help text

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -480,17 +480,21 @@ impl Prompt {
             let mut text = ui::Text::new(doc.to_string());
 
             let max_width = BASE_WIDTH * 3;
-            let padding = 1;
+            let horizontal_padding = 2; // border + margin
+            let vertical_padding = 1; // border only
+            let text_width = max_width - horizontal_padding * 2;
 
             let viewport = area;
 
-            let (_width, height) = ui::text::required_size(&text.contents, max_width);
+            let (_width, height) = ui::text::required_size(&text.contents, text_width);
 
             let area = viewport.intersection(Rect::new(
                 completion_area.x,
-                completion_area.y.saturating_sub(height + padding * 2),
+                completion_area
+                    .y
+                    .saturating_sub(height + vertical_padding * 2),
                 max_width,
-                height + padding * 2,
+                height + vertical_padding * 2,
             ));
 
             let background = theme.get("ui.help");


### PR DESCRIPTION
Closes #15330.

When computing the required area allocated to the help text of a typable command, the height was computed assuming the text could take up the whole width. However, the actual width needed to take into account both the margin and the border width, reducing the actual width by 4.

This led to the problem seen in https://github.com/helix-editor/helix/issues/15330 although I'm not sure the range of 81-90 was correct. It should instead have been `[87-90)` (and would get compounded for each other wrap; `[173-180)`, `[259,270)`, etc).