### PR TITLE
Add `sort` option to file picker config

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -212,6 +212,7 @@ All git related options are only enabled in a git repository.
 |`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`
 |`git-exclude` | Enables reading `.git/info/exclude` files | `true`
 |`max-depth` | Set with an integer value for maximum depth to recurse | Unset by default
+|`sort` | Enables sorting of file picker results | `true`
 
 Ignore files can be placed locally as `.ignore` or put in your home directory as `~/.ignore`. They support the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -228,7 +228,7 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
 
     let mut walk_builder = WalkBuilder::new(&root);
 
-    let mut files = walk_builder
+    walk_builder
         .hidden(config.file_picker.hidden)
         .parents(config.file_picker.parents)
         .ignore(config.file_picker.ignore)
@@ -236,12 +236,17 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         .git_ignore(config.file_picker.git_ignore)
         .git_global(config.file_picker.git_global)
         .git_exclude(config.file_picker.git_exclude)
-        .sort_by_file_name(|name1, name2| name1.cmp(name2))
         .max_depth(config.file_picker.max_depth)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks))
         .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
         .add_custom_ignore_filename(".helix/ignore")
-        .types(get_excluded_types())
+        .types(get_excluded_types());
+
+    if config.file_picker.sort {
+        walk_builder.sort_by_file_name(|name1, name2| name1.cmp(name2));
+    }
+
+    let mut files = walk_builder
         .build()
         .filter_map(|entry| {
             let entry = entry.ok()?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -203,6 +203,8 @@ pub struct FilePickerConfig {
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
+    /// Enables sorting of file picker results. Defaults to true.
+    pub sort: bool,
 }
 
 impl Default for FilePickerConfig {
@@ -217,6 +219,7 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
+            sort: true,
         }
     }
 }


### PR DESCRIPTION
## Summary
Adds a new `sort` boolean option to `[editor.file-picker]` configuration (defaults to `true` to preserve existing behavior). When set to `false`, the file picker skips calling `sort_by_file_name` on the `WalkBuilder`, allowing parallel directory traversal which improves file picker responsiveness on large repositories.

Documentation updated in `book/src/editor.md`.

Closes #11021

## Usage

```toml
[editor.file-picker]
sort = false
```

## Test plan
- [x] File picker works normally with default config (`sort = true`)
- [x] File picker works with `sort = false` — files appear in filesystem traversal order
- [x] Option is correctly documented in editor.md