### PR TITLE
Adjust kconfig file types to uppercase K

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5011,7 +5011,7 @@ source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-requiremen
 
 [[language]]
 name = "kconfig"
-file-types = ["kconfig", { glob = "kconfig.*" }]
+file-types = ["Kconfig", { glob = "Kconfig.*" }]
 scope = "source.kconfig"
 
 [[grammar]]


### PR DESCRIPTION
This is the correct filename spelling as used by the Linux kernel and Zephyr, also reflected in [the treesitter grammar itself](https://github.com/tree-sitter-grammars/tree-sitter-kconfig/blob/9ac99fe4c0c27a35dc6f757cef534c646e944881/tree-sitter.json#L9).