### PR TITLE
fix: freeze in markdown when matching brackets

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -88,7 +88,7 @@ fn find_pair(
             if let (Some((start_pos, open)), Some((end_pos, close))) =
                 (as_char(doc, &open), as_char(doc, &close))
             {
-                if PAIRS.contains(&(open, close)) {
+                if PAIRS.contains(&(open, close)) && start_pos <= pos_ && pos_ <= end_pos {
                     if end_pos == pos_ {
                         return Some(start_pos);
                     }


### PR DESCRIPTION
Previously, for a nested set of pairs in Markdown such as:

```markdown
[foo "bar" b|az]
[foo (bar) b|az]
```

Trying to do `mam` or similar would freeze.

The generated parse tree for the former looks like this:

```
0:0  - 1:0    inline
0:0  - 0:15     shortcut_link
0:0  - 0:1        "["
0:1  - 0:14       link_text
0:5  - 0:6          """
0:9  - 0:10         """
0:14 - 0:15       "]"
```

The node surrounding the cursor is `link_text` and it has two children `"` but these are outside of the cursor, so we don't want to select them. This change makes it so we check that `pos_` is within the `open` and `close` node range so that we don't get stuck in a loop of finding the same `"` pair and instead properly traverse the parents to find the `[]` pair.

Closes #15119