### PR TITLE
Adds `wbca` and `wbca!` to the commands API - Solves #15355

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -17,6 +17,8 @@
 | `:write!`, `:w!` | Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt) |
 | `:write-buffer-close`, `:wbc` | Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt) |
 | `:write-buffer-close!`, `:wbc!` | Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt) |
+| `:write-buffer-close-all`, `:wbca` | Write all changes to disk and closes all open buffers. |
+| `:write-buffer-close-all!`, `:wbca!` | Force write all changes to disk and closes all open buffers. |
 | `:new`, `:n` | Create a new scratch buffer. |
 | `:format`, `:fmt` | Format the file using an external formatter or language server. |
 | `:indent-style` | Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.) |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -561,6 +561,50 @@ fn force_write_buffer_close(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
+fn write_buffer_close_all(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    write_impl(
+        cx,
+        args.first(),
+        WriteOptions {
+            force: false,
+            auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+        },
+    )?;
+
+    let document_ids = buffer_gather_all_impl(cx.editor);
+    buffer_close_by_ids_impl(cx, &document_ids, false)
+}
+
+fn force_write_buffer_close_all(
+    cx: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    write_impl(
+        cx,
+        args.first(),
+        WriteOptions {
+            force: true,
+            auto_format: !args.has_flag(WRITE_NO_FORMAT_FLAG.name),
+        },
+    )?;
+
+    let document_ids = buffer_gather_all_impl(cx.editor);
+    buffer_close_by_ids_impl(cx, &document_ids, false)
+}
+
 fn new_file(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -3005,6 +3049,31 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         completer: CommandCompleter::positional(&[completers::filename]),
         signature: Signature {
             positionals: (0, Some(1)),
+            flags: &[WRITE_NO_FORMAT_FLAG],
+            ..Signature::DEFAULT
+        },
+    },
+
+    TypableCommand {
+        name: "write-buffer-close-all",
+        aliases: &["wbca"],
+        doc: "Write all changes to disk and closes all open buffers.",
+        fun: write_buffer_close_all,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            flags: &[WRITE_NO_FORMAT_FLAG],
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "write-buffer-close-all!",
+        aliases: &["wbca!"],
+        doc: "Force write all changes to disk and closes all open buffers.",
+        fun: force_write_buffer_close_all,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
             flags: &[WRITE_NO_FORMAT_FLAG],
             ..Signature::DEFAULT
         },


### PR DESCRIPTION
Solves #15355

If there is anything missing, please let me know.

This adds the `write-buffer-close-all` and `write-buffer-close-all!` functions, purely based on the APIs of `write-buffer-close*` and `buffer-close-all*` functions.

Not sure if tests for the previous `wbc*` and `bca*` were implemented, but I wrote no tests for this new functions `wbca*`.

Otherwise, all tests passed and documentation seems updated.