### PR TITLE
chore: add "ui.virtual.jump-label" to pop-dark theme

### DIFF
--- a/runtime/themes/pop-dark.toml
+++ b/runtime/themes/pop-dark.toml
@@ -42,6 +42,7 @@ error = { fg = 'redE', modifiers = ['bold'] }
 'ui.virtual.whitespace' = { fg = 'brownV' }
 'ui.virtual.indent-guide' = { fg = 'brownR' }
 'ui.virtual.inlay-hint' = {fg = 'brownD', bg = 'brownU'}
+'ui.virtual.jump-label' = { bg = 'black', fg = 'white', modifiers = ['bold'] }
 'ui.menu' = { fg = 'greyT', bg = 'brownD' }
 'ui.menu.selected' = { fg = 'orangeH', bg = 'brownH' }
 'ui.popup' = { bg = 'brownD' }


### PR DESCRIPTION
<img width="932" height="464" alt="Screenshot 2026-02-24 at 12 49 28 AM" src="https://github.com/user-attachments/assets/3d69e194-0471-4d61-b98f-dce3f2116312" />
