### PR TITLE
fix(nix): fix ill-defined escape warning in grammars.nix

### DIFF
--- a/grammars.nix
+++ b/grammars.nix
@@ -14,7 +14,7 @@
     && builtins.hasAttr "rev" grammar.source;
   isGitHubGrammar = grammar: lib.hasPrefix "https://github.com" grammar.source.git;
   toGitHubFetcher = url: let
-    match = builtins.match "https://github\.com/([^/]*)/([^/]*)/?" url;
+    match = builtins.match "https://github\\.com/([^/]*)/([^/]*)/?" url;
   in {
     owner = builtins.elemAt match 0;
     repo = builtins.elemAt match 1;


### PR DESCRIPTION
```bash
warning: \. is an ill-defined escape. You can drop the \ and simply write . instead. Use --extra-deprecated-features broken-string-escape to silence this warning.
         at /nix/store/60j0yly96s2a00rk919b7whvixb15ifq-source/grammars.nix:17:44:
             16|   toGitHubFetcher = url: let
             17|     match = builtins.match "https://github\.com/([^/]*)/([^/]*)/?" url;
               |                                            ^
             18|   in {
```

In nix strings, non-standard escapes are deprecated.
Doubling the backslash ensures the regex still receives a literal dot without triggering the warning.