### PR TITLE
fix(queries): add local scope to declarations

### DIFF
--- a/runtime/queries/c/locals.scm
+++ b/runtime/queries/c/locals.scm
@@ -1,5 +1,6 @@
 ;; Scopes
 (function_definition) @local.scope
+(declaration) @local.scope
 
 ;; Definitions
 


### PR DESCRIPTION
This fixes a corner case in syntax highlighting best demonstrated by the following example:

```C
static void (*fptr1)(unsigned foo) = 0;
static void (*fptr2)(unsigned foo);

int bar(void)
{
    int foo = 42;
    return foo;
}

int baz(int foo)
{
    return foo;
}
```

Here `foo` is a parameter with regardl to the function pointers `fptr1` and `fptr2` and the function `baz`, but not with regard to the function `bar`. Hence, it should be themed as `variable` within the body of the function `bar`, but prior to this commit was themed as `variable.parameter`.

The reason is that because the function pointer declarations where not there own local scope, the parameter definition captured was applied to the global scope. With this commit declarations are a local scope, hence the parameter declaration is no longer spilling into the global scope.