### PR TITLE
queries/go: Fix doc comment highlights

### DIFF
--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -207,30 +207,25 @@
 ] @constant.builtin
 
 ; Comments
-
 (comment) @comment
 
 ; Doc Comments
 (source_file
-  .
-  (comment)+ @comment.block.documentation)
-
-(source_file
-  (comment)+ @comment.block.documentation
-  .
-  (const_declaration))
-
-(source_file
-  (comment)+ @comment.block.documentation
-  .
-  (function_declaration))
-
-(source_file
-  (comment)+ @comment.block.documentation
-  .
-  (type_declaration))
-
-(source_file
-  (comment)+ @comment.block.documentation
-  .
-  (var_declaration))
+  (comment) @comment.block.documentation . (comment)* . [
+    (package_clause) ; `package`
+    (type_declaration) ; `type`
+    (function_declaration) ; `func`
+    (method_declaration) ; `func`
+    (var_declaration) ; `var`
+    (const_declaration) ; `const`
+    ; var (
+    ; 	A = 1
+    ; 	B = 2
+    ; )
+    (var_spec)
+    ; const (
+    ; 	A = 1
+    ; 	B = 2
+    ; )
+    (const_spec)
+  ])

--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -9,7 +9,7 @@
 ; This is only a partial implementation, which covers only
 ; block comments. For line comments (which are more common),
 ; upstream changes to the grammar are required.
-(
+(source_file
   (comment) @injection.content . (comment)* . [
     (package_clause) ; `package`
     (type_declaration) ; `type`
@@ -21,12 +21,12 @@
     ; 	A = 1
     ; 	B = 2
     ; )
-    (const_spec)
+    (var_spec)
     ; const (
     ; 	A = 1
     ; 	B = 2
     ; )
-    (var_spec)
+    (const_spec)
   ]
   (#set! injection.language "markdown"))
 


### PR DESCRIPTION
Fixes a couple of issues in the Go doc comment queries:

- Fix doc comment highlight queries only matching the first chain of comments in the entire file by reusing the pattern already used in the corresponding injection query.
- Add missing `method_declaration`, `const_spec` and `var_spec` to doc comment highlight matching; these were already handled by the injection query.
- Ensure the doc comment injection query is anchored to the source files's top level as well.

This remains slightly broken because we can't detect newlines that break a chain of comments as far as I understand, though this is much better than the current, entirely broken matching.