### PR TITLE
Add a flag to use default config

### DIFF
--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,7 +17,7 @@ pub struct Args {
     pub verbosity: u64,
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
-    pub default: bool,
+    pub clean: bool,
     pub files: IndexMap<PathBuf, Vec<Position>>,
     pub working_directory: Option<PathBuf>,
 }
@@ -71,7 +71,7 @@ impl Args {
                     Some(path) => args.config_file = Some(path.into()),
                     None => anyhow::bail!("--config must specify a path to read"),
                 },
-                "-d" | "--default" => args.default = true,
+                "--clean" => args.clean = true,
                 "--log" => match argv.next().as_deref() {
                     Some(path) => args.log_file = Some(path.into()),
                     None => anyhow::bail!("--log must specify a path to write"),

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -68,7 +68,7 @@ FLAGS:
                                    the default is the same as 'all', but with languages filtering.
     -g, --grammar {{fetch|build}}    Fetch or builds tree-sitter grammars listed in languages.toml
     -c, --config <file>            Specify a file to use for configuration
-    -d, --default                  Use default configuration
+    --clean                        Use the default configuration
     -v                             Increase logging verbosity each use for up to 3 times
     --log <file>                   Specify a file to use for logging
                                    (default file: {})
@@ -126,7 +126,7 @@ FLAGS:
         helix_stdx::env::set_current_working_dir(path)?;
     }
 
-    let config = if args.default {
+    let config = if args.clean {
         Config::default()
     } else {
         match Config::load_default() {


### PR DESCRIPTION
Resolves: #15371

Adds a `-d / --default` flag to start Helix with the default config, ignoring any existing config file.

Note:
- Currently `main()` still calls `initialize_config_file()` even when `--default` is passed, which is redundant. I'm not sure how to avoid this cleanly, but it does prevent a panic when calling `:config-open`.
- `hx --config /dev/null` also works (as stated in the issue comments)