### PR TITLE
feat(match-brackets): support Rust closure `|...|` delimiter matching

### DIFF
--- a/helix-core/src/match_brackets.rs
+++ b/helix-core/src/match_brackets.rs
@@ -24,8 +24,8 @@ pub const BRACKETS: [(char, char); 9] = [
 // The difference between BRACKETS and PAIRS is that we can find matching
 // BRACKETS in a plain text file, but we can't do the same for PAIRs.
 // PAIRS also contains all BRACKETS.
-pub const PAIRS: [(char, char); BRACKETS.len() + 3] = {
-    let mut pairs = [(' ', ' '); BRACKETS.len() + 3];
+pub const PAIRS: [(char, char); BRACKETS.len() + 4] = {
+    let mut pairs = [(' ', ' '); BRACKETS.len() + 4];
     let mut idx = 0;
     while idx < BRACKETS.len() {
         pairs[idx] = BRACKETS[idx];
@@ -34,6 +34,11 @@ pub const PAIRS: [(char, char); BRACKETS.len() + 3] = {
     pairs[idx] = ('"', '"');
     pairs[idx + 1] = ('\'', '\'');
     pairs[idx + 2] = ('`', '`');
+    // Rust closure parameters use `|...|` delimiters. Tree-sitter exposes
+    // them as a `closure_parameters` node whose first and last children are
+    // both `|`, so the tree-sitter path in `find_pair` matches them
+    // correctly without any false positives for bitwise-OR operators.
+    pairs[idx + 3] = ('|', '|');
     pairs
 };
 


### PR DESCRIPTION
Add `('|', '|')` to the PAIRS array so that the `%` motion and bracket matching can jump between the opening and closing `|` of Rust closure parameter lists.

Fixes #15305
