### PR TITLE
make inactive statusline and split border color visible

### DIFF
--- a/runtime/themes/jetbrains_cyan_light.toml
+++ b/runtime/themes/jetbrains_cyan_light.toml
@@ -88,13 +88,13 @@
 ] }
 
 "ui.statusline" = { fg = "shade06", bg = "shade01" }
-"ui.statusline.inactive" = { fg = "shade04", bg = "shade00" }
+"ui.statusline.inactive" = { fg = "shade03_darker", bg = "shade01_lighter" }
 "ui.statusline.normal" = { fg = "shade00", bg = "blue" }
 "ui.statusline.insert" = { fg = "shade00", bg = "green" }
 "ui.statusline.select" = { fg = "shade00", bg = "purple" }
 
 "ui.popup" = { fg = "shade04", bg = "shade01_lighter" }
-"ui.window" = { fg = "shade04", bg = "shade00" }
+"ui.window" = { fg = "shade03_darker", bg = "shade01_lighter" }
 "ui.help" = { fg = "shade06", bg = "shade00" }
 "ui.text" = "shade05"
 "ui.text.focus" = { fg = "shade07", bg = "light_blue" }


### PR DESCRIPTION
Updates status line inactive background and foreground to make distinguishing the border between splits more visible

### Before
<img width="880" height="771" alt="image" src="https://github.com/user-attachments/assets/823143aa-872f-42a2-a9c5-366f7d3a1cde" />

### After
<img width="885" height="771" alt="image" src="https://github.com/user-attachments/assets/4a7030d2-4fe4-4072-9dcc-a295f525e795" />
