### PR TITLE
Update Scala tree-sitter grammar to v0.24.0

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2130,7 +2130,7 @@ language-servers = [ "metals" ]
 
 [[grammar]]
 name = "scala"
-source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "7891815f42dca9ed6aeb464c2edc39d479ab965c" }
+source = { git = "https://github.com/tree-sitter/tree-sitter-scala", rev = "2d55e74b0485fe05058ffe5e8155506c9710c767" }
 
 [[language]]
 name = "dockerfile"

--- a/runtime/queries/scala/highlights.scm
+++ b/runtime/queries/scala/highlights.scm
@@ -147,9 +147,6 @@
 (integer_literal) @constant.numeric.integer
 (floating_point_literal) @constant.numeric.float
 
-
-(symbol_literal) @string.special.symbol
-
 [
 (string)
 (character_literal)

--- a/runtime/queries/scala/injections.scm
+++ b/runtime/queries/scala/injections.scm
@@ -2,7 +2,6 @@
  (#set! injection.language "comment"))
 
 
-; TODO for some reason multiline string (triple quotes) interpolation works only if it contains interpolated value
 ; Matches these SQL interpolators:
 ;  - Doobie: 'sql', 'fr'
 ;  - Quill: 'sql', 'infix'


### PR DESCRIPTION
This PR simply updates Scala grammar to latest version.

This fixes issue with Scala 2 triple quote multline support, and fixes a lot of Scala 3 issues.

I've also fixed the highlights that was using an old unused token (`symbol_literal`), which have been deleted in latest version.