### PR TITLE
Add tree-sitter query files for multiple languages:

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -43,7 +43,7 @@
 | cylc | ✓ | ✓ | ✓ |  |  |  |
 | cython | ✓ |  | ✓ | ✓ |  |  |
 | d | ✓ | ✓ | ✓ |  |  | `serve-d` |
-| dart | ✓ | ✓ | ✓ |  |  | `dart` |
+| dart | ✓ | ✓ | ✓ |  | ✓ | `dart` |
 | dbml | ✓ |  |  |  |  |  |
 | debian | ✓ |  |  |  |  |  |
 | devicetree | ✓ |  |  |  |  | `dts-lsp` |
@@ -81,7 +81,7 @@
 | freebasic | ✓ | ✓ | ✓ | ✓ |  |  |
 | fsharp | ✓ |  |  |  |  | `fsautocomplete` |
 | gas | ✓ | ✓ |  |  |  | `asm-lsp` |
-| gdscript | ✓ | ✓ | ✓ | ✓ |  |  |
+| gdscript | ✓ | ✓ | ✓ | ✓ | ✓ |  |
 | gemini | ✓ |  |  |  |  |  |
 | gherkin | ✓ |  |  |  |  |  |
 | ghostty | ✓ |  |  |  |  |  |
@@ -102,7 +102,7 @@
 | gnuplot | ✓ |  |  |  |  |  |
 | go | ✓ | ✓ | ✓ | ✓ | ✓ | `gopls`, `golangci-lint-langserver` |
 | go-format-string | ✓ |  |  |  | ✓ |  |
-| godot-resource | ✓ | ✓ |  |  |  |  |
+| godot-resource | ✓ | ✓ |  | ✓ |  |  |
 | gomod | ✓ |  |  |  |  | `gopls` |
 | gotmpl | ✓ |  |  |  |  | `gopls` |
 | gowork | ✓ |  |  |  |  | `gopls` |
@@ -153,7 +153,7 @@
 | just | ✓ | ✓ | ✓ | ✓ |  | `just-lsp` |
 | kcl | ✓ |  |  |  |  | `kcl-language-server` |
 | kconfig | ✓ |  | ✓ |  |  |  |
-| kdl | ✓ | ✓ | ✓ | ✓ |  |  |
+| kdl | ✓ | ✓ | ✓ | ✓ | ✓ |  |
 | klog | ✓ |  |  |  |  |  |
 | koka | ✓ |  | ✓ |  |  | `koka` |
 | kotlin | ✓ | ✓ | ✓ | ✓ |  | `kotlin-language-server` |
@@ -323,5 +323,5 @@
 | xtc | ✓ |  |  |  |  |  |
 | yaml | ✓ | ✓ | ✓ |  | ✓ | `yaml-language-server`, `ansible-language-server` |
 | yara | ✓ |  |  |  |  | `yls` |
-| yuck | ✓ |  |  |  |  |  |
+| yuck | ✓ |  | ✓ |  | ✓ |  |
 | zig | ✓ | ✓ | ✓ |  |  | `zls` |

--- a/runtime/queries/dart/rainbows.scm
+++ b/runtime/queries/dart/rainbows.scm
@@ -1,0 +1,17 @@
+[
+  (configuration_uri_condition)
+  (class_body)
+  (block)
+  (arguments)
+  (list_literal)
+  (formal_parameter_list)
+  (optional_formal_parameters)
+  (parameter_type_list)
+  (record_type)
+  (template_substitution)
+  (index_selector)
+  (if_statement)
+  (assertion_arguments)
+] @rainbow.scope
+
+["(" ")" "[" "]" "{" "}"] @rainbow.bracket

--- a/runtime/queries/gdscript/rainbows.scm
+++ b/runtime/queries/gdscript/rainbows.scm
@@ -1,0 +1,9 @@
+[
+  (parameters)
+  (arguments)
+  (dictionary)
+  (array)
+  (subscript)
+] @rainbow.scope
+
+["(" ")" "[" "]" "{" "}"] @rainbow.bracket

--- a/runtime/queries/godot-resource/tags.scm
+++ b/runtime/queries/godot-resource/tags.scm
@@ -1,0 +1,11 @@
+(section
+  (identifier) @_type
+  (attribute
+    (identifier) @_attr_type
+    (string) @definition.struct)
+  (#eq? @_type "node")
+  (#eq? @_attr_type "name"))
+
+(section
+  (identifier) @definition.struct
+  (#not-eq? @definition.struct "node"))

--- a/runtime/queries/kdl/injections.scm
+++ b/runtime/queries/kdl/injections.scm
@@ -61,3 +61,9 @@
     )
   )
 )
+
+([
+  (single_line_comment)
+  (multi_line_comment)
+] @injection.content
+  (#set! injection.language "comment"))

--- a/runtime/queries/kdl/rainbows.scm
+++ b/runtime/queries/kdl/rainbows.scm
@@ -1,0 +1,3 @@
+(node_children) @rainbow.scope
+
+["{" "}"] @rainbow.bracket

--- a/runtime/queries/yuck/indents.scm
+++ b/runtime/queries/yuck/indents.scm
@@ -1,0 +1,1 @@
+(list) @indent @extend

--- a/runtime/queries/yuck/rainbows.scm
+++ b/runtime/queries/yuck/rainbows.scm
@@ -1,0 +1,9 @@
+[
+  (list)
+  (array)
+] @rainbow.scope
+
+[
+  "[" "]"
+  "(" ")"
+] @rainbow.bracket


### PR DESCRIPTION
- Rainbow brackets support for Dart, GDScript, KDL, and Yuck
- Indentation rules for Yuck
- Tags/definitions support for Godot resource files