### PR TITLE
fix(typst): highlight equal sign and lambda operator

### DIFF
--- a/runtime/queries/typst/highlights.scm
+++ b/runtime/queries/typst/highlights.scm
@@ -12,7 +12,7 @@
 (flow ["break" "continue"] @keyword.control)
 
 ; OPERATOR
-(equals "=" @operator)
+(let "=" @operator)
 (lambda "=>" @operator)
 (in ["in" "not"] @keyword.operator)
 (context "context" @keyword.control)


### PR DESCRIPTION
Currently, the typst highlights do not highlight the equals sign or the lambda. I added highlighting for those as `operator`.