### PR TITLE
fix(queries): highlight C/C++ macro bodies via injection

### DIFF
--- a/runtime/queries/c/injections.scm
+++ b/runtime/queries/c/injections.scm
@@ -1,2 +1,6 @@
 ((comment) @injection.content
  (#set! injection.language "comment"))
+
+((preproc_arg) @injection.content
+ (#set! injection.language "c")
+ (#set! injection.include-children))

--- a/runtime/queries/cpp/injections.scm
+++ b/runtime/queries/cpp/injections.scm
@@ -1,4 +1,9 @@
 ; inherits: c
+
+((preproc_arg) @injection.content
+ (#set! injection.language "cpp")
+ (#set! injection.include-children))
+
 (raw_string_literal
   delimiter: (raw_string_delimiter) @injection.language
   (raw_string_content) @injection.content)


### PR DESCRIPTION
Unlike neovim, helix doesn't support C/C++ macro body's syntax highlighting. Since macro is really important for C developers, I've made this quick fix.

I have tested it myself on C/C++ files.

Linux rbtree header:
<img width="1534" height="1733" alt="image" src="https://github.com/user-attachments/assets/d66698ec-f985-4727-835f-224bc767bb14" />
