### PR TITLE
Update languages.toml

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5175,10 +5175,6 @@ indent = {tab-width = 2, unit = "  "}
 '“' = '”'
 '‘' = '’'
 
-[[grammar]]
-name = "bovex"
-source = { git = "https://github.com/mi2ebi/tree-sitter-bovex", rev = "de7657a9cc3525b9b77c6d268da09dad5b1346b0" }
-
 [[language]]
 name = "haxe"
 scope = "source.haxe"


### PR DESCRIPTION
Remove broken bovex tree-sitter. The repo https://github.com/mi2ebi/tree-sitter-bovex has been deleted or made private. Helix won't build from scratch because of this.