### PR TITLE
fix(theme): add missing `ui.help` color to poimandres

### DIFF
--- a/runtime/themes/poimandres.toml
+++ b/runtime/themes/poimandres.toml
@@ -50,6 +50,7 @@ string = { fg = "brightMint" }
 "ui.cursor.match" = { bg = "focus" }
 "ui.cursorline" = { bg = "#242837" }
 
+"ui.help" = { bg = "#20232d" }
 "ui.popup" = { bg = "#20232d" }
 "ui.window" = "gray"
 

--- a/runtime/themes/poimandres_storm.toml
+++ b/runtime/themes/poimandres_storm.toml
@@ -4,6 +4,7 @@
 inherits = "poimandres"
 
 "ui.cursorline" = { bg = "#303747" }
+"ui.help" = { bg = "#2a303c" }
 "ui.popup" = { bg = "#2a303c" }
 "ui.virtual.indent-guide" = "#3a4151"
 


### PR DESCRIPTION
Sets `ui.help` bg color to the same as `ui.popup` for both poimandres and poimandres_storm.

## Before

<img height="500" alt="before" src="https://github.com/user-attachments/assets/ee193a7c-1308-4f36-8071-d879574fdfca" />

## After

<img height="500" alt="after" src="https://github.com/user-attachments/assets/65103d72-9c51-4751-bd7d-a9d4436b19e9" />
