### PR TITLE
docs(book:build-src): suggest choosing grammars

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -58,6 +58,8 @@ RUSTFLAGS="-C target-feature=-crt-static"
 > the `runtime` directory within the user's helix config directory (more
 > [details below](#multiple-runtime-directories)).
 
+> 💡 If you only want to build _some_ grammars, see [`use-grammars`](./languages.md#choosing-grammars)
+
 ### Configuring Helix's runtime files
 
 #### Linux and macOS


### PR DESCRIPTION
This makes the `use-grammars` field more discoverable. For me, it was hard to find it, because I was searching the "wrong" place