### PR TITLE
perf(completers): use DirEntry::file_type() instead of metadata()

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -743,8 +743,8 @@ pub mod completers {
                 .flatten()
                 .filter_map(|res| {
                     let entry = res.ok()?;
-                    let metadata = entry.metadata().ok()?;
-                    if metadata.is_file() || metadata.is_symlink() {
+                    let file_type = entry.file_type().ok()?;
+                    if file_type.is_file() || file_type.is_symlink() {
                         entry.file_name().into_string().ok()
                     } else {
                         None


### PR DESCRIPTION
### Description

This PR optimizes the program completer by switching from `DirEntry::metadata()` to `DirEntry::file_type()` when scanning directories in `PATH`.

On Linux, `DirEntry::file_type()` utilizes the `d_type` field from `readdir`, which avoids the per-entry `lstat` syscall required by `metadata()`. The behavior remains unchanged, as both methods return symlink-aware file type information without following symlinks.

### Benchmark

Tested on **WSL2 (Linux 6.6)** with 6,956 programs in `PATH`. 
*Note: The overhead of filesystem operations in WSL2 makes this optimization particularly significant.*

| Metric | `metadata()` (Before) | `file_type()` (After) |
| :--- | :--- | :--- |
| **PATH scan time** | 2,894 ms | 48 ms |

By eliminating approximately 7,000 `lstat` syscalls, the first `:sh` invocation (which triggers the program completer) becomes noticeably faster.

---
Thanks for building such a great editor — I use Helix daily and love it!