### PR TITLE
fix(book): add mdbook-theme prefix to colibri

### DIFF
--- a/book/theme/index.hbs
+++ b/book/theme/index.hbs
@@ -156,7 +156,7 @@
                             <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-coal">Coal</button></li>
                             <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-navy">Navy</button></li>
                             <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-ayu">Ayu</button></li>
-                            <li role="none"><button role="menuitem" class="theme" id="colibri">Colibri</button></li>
+                            <li role="none"><button role="menuitem" class="theme" id="mdbook-theme-colibri">Colibri</button></li>
                         </ul>
                         {{#if search_enabled}}
                         <button id="mdbook-search-toggle" class="icon-button" type="button" title="Search (`/`)" aria-label="Toggle Searchbar" aria-expanded="false" aria-keyshortcuts="/ s" aria-controls="mdbook-searchbar">


### PR DESCRIPTION
Sorry I realized this after #15357 was merged, the Colibri theme still works by default but the format for the theme ids changed with the new vendored template which means the theme picker doesn't work, this fixes that.