### PR TITLE
feat: add :languages-open command to open user languages.toml

### DIFF
--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -78,6 +78,7 @@
 | `:config-reload` | Refresh user config. |
 | `:config-open` | Open the user config.toml file. |
 | `:config-open-workspace` | Open the workspace config.toml file. |
+| `:languages-open` | Open the user languages.toml file. |
 | `:log-open` | Open the helix log file. |
 | `:insert-output` | Run shell command, inserting output before each selection. |
 | `:append-output` | Run shell command, appending output after each selection. |

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2403,6 +2403,20 @@ fn open_workspace_config(
     Ok(())
 }
 
+fn open_lang_config(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    cx.editor
+        .open(&helix_loader::lang_config_file(), Action::Replace)?;
+    Ok(())
+}
+
 fn open_log(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -3702,6 +3716,17 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Open the workspace config.toml file.",
         fun: open_workspace_config,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "languages-open",
+        aliases: &[],
+        doc: "Open the user languages.toml file.",
+        fun: open_lang_config,
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),

--- a/helix-term/tests/test/command_line.rs
+++ b/helix-term/tests/test/command_line.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use helix_core::diagnostic::Severity;
+use helix_view::doc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn history_completion() -> anyhow::Result<()> {
@@ -114,5 +115,27 @@ async fn percent_escaping() -> anyhow::Result<()> {
         Severity::Error,
     )
     .await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn languages_open() -> anyhow::Result<()> {
+    test_key_sequence(
+        &mut AppBuilder::new().build()?,
+        Some(":languages-open<ret>"),
+        Some(&|app| {
+            assert!(!app.editor.is_err());
+            let doc = doc!(app.editor);
+            assert!(
+                doc.path()
+                    .map_or(false, |p| p.ends_with("languages.toml")),
+                "expected buffer path to end with languages.toml, got {:?}",
+                doc.path()
+            );
+        }),
+        false,
+    )
+    .await?;
+
     Ok(())
 }


### PR DESCRIPTION
Fixes #15123

Problem: Users can open `config.toml` with `:config-open` but there is no
equivalent command for `languages.toml`. Users must manually find and open
the file, which is inconvenient and varies by platform.

Solution: Add a new `:languages-open` typed command that opens the user's
`languages.toml` file, mirroring the existing `:config-open` command. Uses
the existing `helix_loader::lang_config_file()` function. Users can edit
their language configuration and apply changes with the existing
`:config-reload` command.

Why: Follows the exact pattern of `:config-open`, `:config-open-workspace`,
and `:log-open`. Zero new logic — just wiring an existing path function to
an existing editor.open() call.

Test:
- `cargo check` passes → works
- `cargo xtask docgen` regenerated command docs → works
- Integration test: `:languages-open` opens buffer ending with `languages.toml` → works

Closes #15123