### PR TITLE
Bump tree-sitter-smali

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1496,7 +1496,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "smali"
-source = { git = "https://github.com/amaanq/tree-sitter-smali", rev = "5ae51e15c4d1ac93cba6127caf3d1f0a072c140c" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-smali", rev = "fdfa6a1febc43c7467aa7e937b87b607956f2346" }
 
 [[language]]
 name = "ledger"


### PR DESCRIPTION
Bumps tree-sitter-smali to the latest commit:

- The repo was moved to the tree-sitter-grammars organization
- https://github.com/tree-sitter-grammars/tree-sitter-smali/commit/3f6517855898ef23023e5d64a8b175d4ee8d646e is required to re-generate the parser from source on the latest version of tree-sitter-cli; It would be nice to upgrade to the patched version to ease full-source bootstrapping of Helix in projects such as https://codeberg.org/stagex/stagex.