### PR TITLE
languages(pkl): recognize `PklProject` as Pkl file

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4193,7 +4193,7 @@ source = { git = "https://github.com/tact-lang/tree-sitter-tact", rev = "ec57ab2
 name = "pkl"
 scope = "source.pkl"
 injection-regex = "pkl"
-file-types = ["pkl", "pcf"]
+file-types = ["pkl", "pcf", { glob = "PklProject" }]
 comment-token = "//"
 language-servers = ["pkl-lsp"]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Add `PklProject` to the Pkl `language.file-types`.

`PklProject` is the standard project manifest file in Pkl and contains Pkl code, but it has no extension, so it should be recognized explicitly.

https://pkl-lang.org/main/current/language-reference/index.html#projects