### PR TITLE
Store theme mode when changed via mode 2031

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -729,11 +729,12 @@ impl Application {
             }) => false,
             #[cfg(not(windows))]
             termina::Event::Csi(csi::Csi::Mode(csi::Mode::ReportTheme(mode))) => {
+                self.theme_mode = Some(mode.into());
                 Self::load_configured_theme(
                     &mut self.editor,
                     &self.config.load(),
                     &mut self.terminal,
-                    Some(mode.into()),
+                    self.theme_mode,
                 );
                 true
             }


### PR DESCRIPTION
This allows `:config-reload` to re-use the theme mode potentially modified by mode 2031. Before, `:config-reload` would always reset the theme to the variant detected at editor startup.