### PR TITLE
Bump tree-sitter-blueprint

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3829,7 +3829,7 @@ indent = { tab-width = 4, unit = "    " }
 
 [[grammar]]
 name = "blueprint"
-source = { git = "https://gitlab.com/gabmus/tree-sitter-blueprint", rev = "863cea9f83ad5637300478e0559262f1e791684b" }
+source = { git = "https://gitlab.com/gabmus/tree-sitter-blueprint", rev = "355ef84ef8a958ac822117b652cf4d49bac16c79" }
 
 [[language]]
 name = "forth"

--- a/runtime/queries/blueprint/highlights.scm
+++ b/runtime/queries/blueprint/highlights.scm
@@ -36,6 +36,8 @@
 (menu_section "section" @keyword)
 (menu_item "item" @function.macro)
 
+(condition "condition" @keyword)
+
 (template_definition (template_name_qualifier) @keyword.storage.type)
 
 (import_statement (gobject_library) @namespace)


### PR DESCRIPTION
Bumps tree-sitter-blueprint to the latest commit. This was only two changes behind:

1. Regex fixes for #15437
2. Support for the `condition` keyword, which I've updated queries to cover.

To be fair, there appear to be several other keywords that should be added to highlights but I wanted to cover at least any new features introduced by bumping the commit.