### PR TITLE
Bump tree-sitter-capnp

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3666,7 +3666,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "capnp"
-source = { git = "https://github.com/amaanq/tree-sitter-capnp", rev = "fc6e2addf103861b9b3dffb82c543eb6b71061aa" }
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-capnp", rev = "7b0883c03e5edd34ef7bcf703194204299d7099f" }
 
 [[language]]
 name = "smithy"


### PR DESCRIPTION
Another one down the count for [#15446](https://github.com/helix-editor/helix/issues/15437). The grammar underwent some refactors but no changes to queries seem to be necessary.