### PR TITLE
docs: fix contributing wording

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Some suggestions to get started:
   * Pass the appropriate verbosity level option for the desired log level. (`hx -v <file>` for info, more `v`s for higher verbosity)
   * Want to display the logs in a separate file instead of using the `:log-open` command in your compiled Helix editor? Start your debug version with `cargo run -- --log foo.log` and in a new terminal use `tail -f foo.log`
 - Instead of running a release version of Helix, while developing you may want to run in debug mode with `cargo run` which is way faster to compile
-- Looking for even faster compile times? Give a try to [mold](https://github.com/rui314/mold)
+- Looking for even faster compile times? Give [mold](https://github.com/rui314/mold) a try
 - If your preferred language is missing, integrating a tree-sitter grammar for
     it and defining syntax highlight queries for it is straightforward and
     doesn't require much knowledge of the internals.


### PR DESCRIPTION
## Summary
- Fix phrasing in the contributing guide sentence about using mold.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/helix-editor/helix/blob/master/docs/CONTRIBUTING.md

## Validation/testing
- Not run (docs change only)