### PR TITLE
Keep terminal cursor visible in block mode for cursor tracking

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1700,10 +1700,13 @@ impl Component for EditorView {
 
     fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
         match editor.cursor() {
-            // all block cursors are drawn manually
+            // Keep the terminal cursor visible at the correct position even for
+            // block cursors so that terminal emulators (e.g. Ghostty) can track
+            // cursor movement for shader effects like cursor trails.
+            // The manually-drawn theme overlay still provides the visual styling.
             (pos, CursorKind::Block) => {
                 if self.terminal_focused {
-                    (pos, CursorKind::Hidden)
+                    (pos, CursorKind::Block)
                 } else {
                     // use terminal cursor when terminal loses focus
                     (pos, CursorKind::Underline)


### PR DESCRIPTION
## Problem

Modern terminal emulators like Ghostty expose the cursor position to custom shaders via uniforms (`iCurrentCursor` / `iPreviousCursor`). This enables visual effects like cursor trails. However, Helix hides the real terminal cursor in normal mode (block cursor), which prevents the terminal emulator from tracking cursor movement.

**Result:** Cursor trail shaders work in insert mode (bar cursor) but break in normal mode (block cursor).

## Root Cause

Helix renders block cursors manually using reversed-text styling from the theme (`ui.cursor.normal`, `ui.cursor.select`, etc.). Since the visual is handled by Helix itself, the real terminal cursor is hidden to avoid duplication.

This happens in `helix-term/src/ui/editor.rs`, in the `cursor()` method:

```rust
fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
    match editor.cursor() {
        (pos, CursorKind::Block) => {
            if self.terminal_focused {
                (pos, CursorKind::Hidden)  // <-- hides terminal cursor
            } else {
                (pos, CursorKind::Underline)
            }
        }
        cursor => cursor,
    }
}
```

This return value flows into `helix-tui/src/terminal.rs` → `draw()`:

```rust
pub fn draw(&mut self, cursor_position: Option<(u16, u16)>, cursor_kind: CursorKind) {
    self.flush()?;
    if let Some((x, y)) = cursor_position {
        self.set_cursor(x, y)?;       // positions the cursor
    }
    match cursor_kind {
        CursorKind::Hidden => self.hide_cursor()?,  // hides it immediately after
        kind => self.show_cursor(kind)?,
    }
}
```

The position IS sent before hiding, but terminal emulators like Ghostty do not update shader uniforms for hidden cursors.

## Fix

In `helix-term/src/ui/editor.rs`, change `CursorKind::Hidden` to `CursorKind::Block`:

```rust
fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
    match editor.cursor() {
        (pos, CursorKind::Block) => {
            if self.terminal_focused {
                (pos, CursorKind::Block)   // keep terminal cursor visible
            } else {
                (pos, CursorKind::Underline)
            }
        }
        cursor => cursor,
    }
}
```

https://github.com/user-attachments/assets/1d03ecda-8399-489d-ab2b-1c8a9d7f38ef


## Why This Is Safe

- **No visual change:** Helix's theme-based block cursor overlay (reversed text) still renders on top of the terminal's native block cursor at the exact same position.
- **No conflict:** Both cursors occupy the same cell, so there is no double-cursor artifact.
- **Other modes unaffected:** Bar and underline cursors already use the real terminal cursor — this change only affects block mode.

## Impact

Any terminal emulator that uses cursor position for features beyond simple display benefits from this fix:

- Ghostty custom shader cursor trails
- Potential future terminal features that rely on cursor tracking