### PR TITLE
Add highlighting of mutable variables to dark_plus (VS Code) theme

### DIFF
--- a/runtime/themes/dark_plus.toml
+++ b/runtime/themes/dark_plus.toml
@@ -32,9 +32,12 @@
 "type.builtin"              = "type"
 "type.enum.variant"         = "constant"
 "variable"                  = "variable"
+"variable.mutable"          = { fg = "variable", underline.style= "line" }
 "variable.builtin"          = "blue2"
+"variable.builtin.mutable"  = { fg = "blue2", underline.style= "line" }
 "variable.other.member"     = "variable"
 "variable.parameter"        = "variable"
+"variable.parameter.mutable" = { fg = "variable", underline.style= "line" }
 
 # MARKUP
 "markup.heading"       = { fg = "blue2", modifiers = ["bold"] }


### PR DESCRIPTION
Since https://github.com/helix-editor/helix/pull/15328 we can style mutable variables.

With this PR Helix now looks very similar to VS Code, but being tree-sitter it is a bit different. VS Code seems to highlight method names. Highlighting method names seems overkill and makes Rust look too underlined.

@m4rch3n1ng This is the first theme to offer this feature. Do you think it is working well here?

## VS Code

<img width="1914" height="1382" alt="image" src="https://github.com/user-attachments/assets/772b0c68-a98e-49d7-92d7-31c159fc2ca8" />

## Helix
<img width="1880" height="1244" alt="image" src="https://github.com/user-attachments/assets/44e97e20-7dad-4043-9deb-05179809bd32" />



