### PR TITLE
Change hit_breakpoint_ids type from usize to i32

### DIFF
--- a/helix-dap-types/src/lib.rs
+++ b/helix-dap-types/src/lib.rs
@@ -831,7 +831,7 @@ pub mod events {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub all_threads_stopped: Option<bool>,
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub hit_breakpoint_ids: Option<Vec<usize>>,
+        pub hit_breakpoint_ids: Option<Vec<i32>>,
     }
 
     #[derive(Debug)]


### PR DESCRIPTION
As of v1.71.0, the DAP spec defines this field to be int32. delve is already using negative values for system breakpoints which breaks with usize.

References:
[Delve system breakpoint definitions](https://github.com/go-delve/delve/blob/1c2321ee24831980bed159600f5d393bad8519d6/pkg/proc/breakpoints.go#L38)
[DAP protocol](https://microsoft.github.io/debug-adapter-protocol/debugAdapterProtocol.json)
<img width="357" height="108" alt="image" src="https://github.com/user-attachments/assets/1f242a9d-a5f7-436a-91b3-7c05f4d03e4b" />
