### PR TITLE
fix(lsp): using :lsp-restart might silently fail

### DIFF
--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -345,6 +345,11 @@ impl Transport {
         let mut pending_messages: Vec<Payload> = Vec::new();
         let mut is_pending = true;
 
+        // Pin outside the loop to avoid cancellation-safety issue:
+        // recreating `notified()` inside `select!` can lose the permit.
+        let notified = initialize_notify.notified();
+        tokio::pin!(notified);
+
         // Determine if a message is allowed to be sent early
         fn is_initialize(payload: &Payload) -> bool {
             use lsp::{
@@ -375,7 +380,7 @@ impl Transport {
         loop {
             tokio::select! {
                 biased;
-                _ = initialize_notify.notified() => { // TODO: notified is technically not cancellation safe
+                _ = &mut notified, if is_pending => {
                     // server successfully initialized
                     is_pending = false;
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                        
Language servers that take long time to start like `rust-analyzer` might fail to work correctly
                                                                                                                                                                                               
  - Fix `tokio::Notify::notified()` cancellation-safety bug in LSP transport send loop                                                                                                               
  - Move `notified()` future creation outside the loop and pin it, preventing lost permits when select! cancels the future between iterations                                                        
  - This fixes `:lsp-restart` silently failing to send `didOpen` notifications for open buffers