### PR TITLE
feat: auto-document-highlight on by default

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -169,7 +169,7 @@ The following statusline elements can be configured:
 | `display-messages`    | Display LSP `window/showMessage` messages below statusline[^1] | `true` |
 | `display-progress-messages` | Display LSP progress messages below statusline[^1]    | `false` |
 | `auto-signature-help` | Enable automatic popup of signature help (parameter hints)  | `true`  |
-| `auto-document-highlight` | Automatically highlight symbol references at the cursor | `false` |
+| `auto-document-highlight` | Automatically highlight symbol references at the cursor | `true` |
 | `display-inlay-hints` | Display inlay hints[^2]                                     | `false` |
 | `inlay-hints-length-limit` | Maximum displayed length (non-zero number) of inlay hints | Unset by default  |
 | `display-color-swatches` | Show color swatches next to colors | `true` |

--- a/helix-term/src/handlers/document_highlight.rs
+++ b/helix-term/src/handlers/document_highlight.rs
@@ -17,25 +17,33 @@ fn request_document_highlights(editor: &mut Editor, doc_id: DocumentId, view_id:
         return;
     }
 
+    if editor.tree.try_get(view_id).is_none() {
+        return;
+    }
+
     let Some(doc) = editor.document_mut(doc_id) else {
         return;
     };
 
-    doc.ensure_view_init(view_id);
-
-    let Some(language_server) = doc
-        .language_servers_with_feature(LanguageServerFeature::DocumentHighlight)
-        .next()
-    else {
+    if !doc.has_language_server_with_feature(LanguageServerFeature::DocumentHighlight) {
         doc.clear_document_highlights(view_id);
         return;
-    };
+    }
 
-    let offset_encoding = language_server.offset_encoding();
-    let pos = doc.position(view_id, offset_encoding);
-    let Some(future) =
-        language_server.text_document_document_highlight(doc.identifier(), pos, None)
-    else {
+    doc.ensure_view_init(view_id);
+    let Some((offset_encoding, future)) = (match doc
+        .language_servers_with_feature(LanguageServerFeature::DocumentHighlight)
+        .next()
+    {
+        Some(language_server) => {
+            let offset_encoding = language_server.offset_encoding();
+            let pos = doc.position(view_id, offset_encoding);
+            language_server
+                .text_document_document_highlight(doc.identifier(), pos, None)
+                .map(|future| (offset_encoding, future))
+        }
+        None => None,
+    }) else {
         doc.clear_document_highlights(view_id);
         return;
     };
@@ -109,6 +117,10 @@ fn apply_document_highlights(
         return;
     }
 
+    if editor.tree.try_get(view_id).is_none() {
+        return;
+    }
+
     let Some(doc) = editor.document_mut(doc_id) else {
         return;
     };
@@ -128,7 +140,11 @@ fn apply_document_highlights(
 
 pub(super) fn register_hooks(_handlers: &Handlers) {
     register_hook!(move |event: &mut SelectionDidChange<'_>| {
-        if event.doc.config.load().lsp.auto_document_highlight {
+        if event.doc.config.load().lsp.auto_document_highlight
+            && event
+                .doc
+                .has_language_server_with_feature(LanguageServerFeature::DocumentHighlight)
+        {
             let doc_id = event.doc.id();
             let view_id = event.view;
             job::dispatch_blocking(move |editor, _| {
@@ -151,7 +167,12 @@ pub(super) fn register_hooks(_handlers: &Handlers) {
     });
 
     register_hook!(move |event: &mut DocumentDidChange<'_>| {
-        if event.doc.config.load().lsp.auto_document_highlight && !event.ghost_transaction {
+        if event.doc.config.load().lsp.auto_document_highlight
+            && !event.ghost_transaction
+            && event
+                .doc
+                .has_language_server_with_feature(LanguageServerFeature::DocumentHighlight)
+        {
             let doc_id = event.doc.id();
             let view_id = event.view;
             job::dispatch_blocking(move |editor, _| {

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -303,6 +303,7 @@ pub fn test_editor_config() -> helix_view::editor::Config {
     helix_view::editor::Config {
         lsp: LspConfig {
             enable: false,
+            auto_document_highlight: false,
             ..Default::default()
         },
         // The word-index hook accumulates per-document pending changes across

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -654,7 +654,7 @@ impl Default for LspConfig {
             auto_signature_help: true,
             display_signature_help_docs: true,
             display_inlay_hints: false,
-            auto_document_highlight: false,
+            auto_document_highlight: true,
             inlay_hints_length_limit: None,
             snippets: true,
             goto_reference_include_declaration: true,


### PR DESCRIPTION
Make `auto-document-highlight` `true` by default, matching the behaviour of VScode and Zed. This is an opinionated change, "no" and closing the PR is completely fine 🙇

Feature implemented in: https://github.com/helix-editor/helix/pull/15221