### PR TITLE
feat(languages): recognize podman systemd unit file extensions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3387,6 +3387,13 @@ file-types = [
   "swap",
   "target",
   "timer",
+  "container",
+  "pod",
+  "volume",
+  "network",
+  "kube",
+  "image",
+  "build",
   { glob = "systemd/**/*.conf" },
 ]
 injection-regex = "systemd"


### PR DESCRIPTION
Extend the built-in systemd file type list so Podman unit files are associated with the systemd language and systemd-lsp.

Fixes: https://github.com/helix-editor/helix/issues/15444