### PR TITLE
feat(runtime): explain tutor buffer saving and quitting

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -35,6 +35,10 @@
  CapsLock key is not pressed and hold the j key until you reach
  the first lesson.
 
+ This tutor opens in an unnamed buffer.
+ * To quit without saving changes, use :q!.
+ * To save your changes to a file, use :w <path> and then :q.
+
 
 
 


### PR DESCRIPTION
Add a note near in the tutor doc to clarify that it opens in an unnamed buffer and how to quit/save it.

Fixes: https://github.com/helix-editor/helix/issues/14636