### PR TITLE
feat(languages): detect virtualenv activate scripts as bash

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1310,6 +1310,7 @@ file-types = [
   { glob = "bash_completion" },
   { glob = "bash-completion/completions/*" },
   { glob = "bash_completion.d/*" },
+  { glob = "bin/activate" },
   { glob = ".Renviron" },
   { glob = ".xprofile" },
   { glob = ".xsession" },


### PR DESCRIPTION
Add `bin/activate` path to the bash file globs to detect Python virtual environment activation scripts as bash.

Fixes: https://github.com/helix-editor/helix/issues/14766

(from a series of fixing small issues)