### PR TITLE
fix(queries): highlight TODO tags in rust doc comments

### DIFF
--- a/runtime/queries/markdown-rustdoc/highlights.scm
+++ b/runtime/queries/markdown-rustdoc/highlights.scm
@@ -1,1 +1,1 @@
-; inherits: markdown
+; inherits: markdown,comment


### PR DESCRIPTION
Make markdown-rustdoc highlight queries inherit comment rules to get higlights for TODO, FIX, and other semantic comments.

Fixes: https://github.com/helix-editor/helix/issues/13557

(from a series of fixing small issues)