### PR TITLE
fix(queries): use import scope for TypeScript export keywords

### DIFF
--- a/runtime/queries/_typescript/highlights.scm
+++ b/runtime/queries/_typescript/highlights.scm
@@ -88,7 +88,6 @@
   "abstract"
   "declare"
   "module"
-  "export"
   "infer"
   "implements"
   "keyof"
@@ -96,6 +95,11 @@
   "override"
   "satisfies"
 ] @keyword
+
+[
+  "export"
+  "from"
+] @keyword.control.import
 
 [
   "type"


### PR DESCRIPTION
Move TypeScript export-related keywords to the `import` scope.

Fixes: https://github.com/helix-editor/helix/issues/14362

(from a series of fixing small issues)