### PR TITLE
fix(queries): restore highlighting for scoped C++ enum values

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -9,6 +9,7 @@
 
 (using_declaration ("using" "namespace" (identifier) @namespace))
 (using_declaration ("using" "namespace" (qualified_identifier name: (identifier) @namespace)))
+(qualified_identifier name: (identifier) @type.enum.variant)
 (namespace_definition name: (namespace_identifier) @namespace)
 (namespace_identifier) @namespace
 


### PR DESCRIPTION
Add back the qualified identifier selector for enum variants with `type.enum.variant` scope.

Fixes: https://github.com/helix-editor/helix/issues/14139

(from a series of fixing small issues)