### PR TITLE
feat(dap): guard configurationDone by capability

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -434,6 +434,15 @@ impl Client {
     }
 
     pub async fn configuration_done(&self) -> Result<()> {
+        if !self
+            .caps
+            .as_ref()
+            .and_then(|caps| caps.supports_configuration_done_request)
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+
         self.request::<requests::ConfigurationDone>(Some(requests::ConfigurationDoneArguments {}))
             .await
     }

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -346,8 +346,16 @@ impl Editor {
                         }
                         // TODO: fetch breakpoints (in case we're attaching)
 
-                        if let Err(err) = debugger.configuration_done().await {
-                            self.set_error(format!("Debugger configuration failed: {}", err));
+                        if debugger
+                            .capabilities()
+                            .supports_configuration_done_request
+                            .unwrap_or(false)
+                        {
+                            if let Err(err) = debugger.configuration_done().await {
+                                self.set_error(format!("Debugger configuration failed: {}", err));
+                            } else {
+                                self.set_status("Debugged application started");
+                            }
                         } else {
                             self.set_status("Debugged application started");
                         }

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -346,16 +346,8 @@ impl Editor {
                         }
                         // TODO: fetch breakpoints (in case we're attaching)
 
-                        if debugger
-                            .capabilities()
-                            .supports_configuration_done_request
-                            .unwrap_or(false)
-                        {
-                            if let Err(err) = debugger.configuration_done().await {
-                                self.set_error(format!("Debugger configuration failed: {}", err));
-                            } else {
-                                self.set_status("Debugged application started");
-                            }
+                        if let Err(err) = debugger.configuration_done().await {
+                            self.set_error(format!("Debugger configuration failed: {}", err));
                         } else {
                             self.set_status("Debugged application started");
                         }


### PR DESCRIPTION
`supports_configuration_done_request` is a configurable capability. Respect it by sending the configuration done request only when it's on.