### PR TITLE
commands: Add line column to jumplist_picker

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3286,6 +3286,7 @@ fn jumplist_picker(cx: &mut Context) {
         id: DocumentId,
         path: Option<PathBuf>,
         selection: Selection,
+        line: usize,
         text: String,
         is_current: bool,
     }
@@ -3306,11 +3307,15 @@ fn jumplist_picker(cx: &mut Context) {
                 .collect::<Vec<_>>()
                 .join(" ")
         });
+        let line = doc.map_or(0usize, |d| {
+            selection.primary().cursor_line(d.text().slice(..)) + 1
+        });
 
         JumpMeta {
             id: doc_id,
             path: doc.and_then(|d| d.path().cloned()),
             selection,
+            line,
             text,
             is_current: view.doc == doc_id,
         }
@@ -3329,6 +3334,7 @@ fn jumplist_picker(cx: &mut Context) {
                 .to_string()
                 .into()
         }),
+        ui::PickerColumn::new("line", |item: &JumpMeta, _| item.line.to_string().into()),
         ui::PickerColumn::new("flags", |item: &JumpMeta, _| {
             let mut flags = Vec::new();
             if item.is_current {


### PR DESCRIPTION
Jump list picker is for intentional jump to previous point. But when list of jump points is shown, it is hard to identify other than from its (one word?) content.

<img width="348" height="272" alt="image" src="https://github.com/user-attachments/assets/e12d710f-17b0-404a-bb33-6a37d7e0a81f" />

So, adding line number can make user mental model a bit ease at differentiating the position after jump.

<img width="470" height="195" alt="image" src="https://github.com/user-attachments/assets/71a40879-8ec6-4e75-ba4d-5d02029ecf2e" />