### PR TITLE
helix-modern-dark theme inspired by VS Code

### DIFF
--- a/licenses/moderndark.license
+++ b/licenses/moderndark.license
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Erik Schwagerus
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/runtime/themes/moderndark.toml
+++ b/runtime/themes/moderndark.toml
@@ -1,0 +1,65 @@
+# Author: Erik Schwagerus <erikcsgooff@gmail.com>
+# License: MIT
+# Description: A Helix theme inspired by Visual Studio Code.
+# Repository: https://github.com/erikkabanela/helix-modern-dark
+
+attribute = "#9CDCFE"
+
+namespace = "#4EC9B0"
+
+type = "#4EC9B0"
+"type.builtin" = "#569CD6"
+"type.enum.variant" = "#4FC1FF"
+
+function = "#DCDCAA"
+"function.macro" = "#569CD6"
+
+label = "#D7BA7D"
+
+tag = "#569CD6"
+
+comment = "#6A9955"
+
+constructor = "#DCDCAA"
+
+string = "#CE9178"
+
+punctuation = "#D4D4D4"
+
+"constant.builtin" = "#569CD6"
+constant = "#4FC1FF"
+"constant.numeric" = "#B5CEA8"
+"constant.character.escape" = "#D7BA7D"
+
+variable = "#9CDCFE"
+"variable.builtin" = "#569CD6"
+"variable.parameter" = "#9CDCFE"
+"variable.other.member" = "#9CDCFE"
+
+keyword = "#569CD6"
+"keyword.control" = "#C586C0"
+"keyword.directive" = "#C586C0"
+"keyword.control.repeat" = "#C586C0"
+
+"ui.background" = { bg = "background" }
+
+"ui.selection" = { bg = "selection" }
+"ui.selection.primary" = { bg = "selection" }
+
+"ui.statusline" = { bg = "statusline_bg" }
+
+"ui.linenr" = { fg = "#6E7681" }
+"ui.linenr.selected" = { fg = "foreground" }
+
+"ui.cursor" = { fg = "hover", bg = "#AEAFAD" }
+"ui.cursor.match" = { fg = "foreground", bg = "#525252" }
+
+[palette]
+background = "#1F1F1F"
+statusline_bg = "#181818"
+
+foreground = "#CCCCCC"
+
+hover = "#2B2B2B"
+
+selection = "#264F78"


### PR DESCRIPTION
With this PR I add a Helix theme called helix-modern-dark.
I was inspired by Visual Studio Code’s "Dark Modern" theme.
Includes the theme file and MIT license.

<img width="1878" height="959" alt="c example" src="https://github.com/user-attachments/assets/b50e70a2-365b-40b4-a0b8-dbde2f8e5cb2" />
<img width="1870" height="956" alt="go example" src="https://github.com/user-attachments/assets/5cb651ae-5ddc-4dd6-97c5-7c4557057c00" />
<img width="1875" height="955" alt="javascript and html examples" src="https://github.com/user-attachments/assets/4b297a43-e90d-42a9-8bd6-c8277a44b6b0" />
<img width="1870" height="955" alt="python and css examples" src="https://github.com/user-attachments/assets/8f61f98b-a48d-4d88-bcf9-44eeea5e2edd" />
<img width="1876" height="970" alt="rust example" src="https://github.com/user-attachments/assets/26ad1059-5b04-49d8-844f-69f24471fdc1" />
