### PR TITLE
fix(highlights/cpp): highlight auto as `@type.builtin`

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -12,8 +12,7 @@
 (namespace_definition name: (namespace_identifier) @namespace)
 (namespace_identifier) @namespace
 
-(auto) @type
-"decltype" @type
+(auto) @type.builtin
 
 (ref_qualifier ["&" "&&"] @type.builtin)
 (reference_declarator ["&" "&&"] @type.builtin)
@@ -162,6 +161,7 @@
 
 ; Modifiers that aren't plausibly type/storage related.
 [
+  "decltype"
   "explicit"
   "friend"
   "virtual"


### PR DESCRIPTION
... and also highlight "decltype" as `@keyword` because it seems more logical (and neovim does it too).

before:
<img width="794" height="391" alt="image" src="https://github.com/user-attachments/assets/8c1df6d1-96a9-4ebd-8893-45d25605e3c3" />

after:
<img width="794" height="391" alt="image" src="https://github.com/user-attachments/assets/cbce6e79-2bc1-4e53-8c93-2ec7906d70cf" />

(notice how `int` and `auto` are now the same color)

i debated a little on whether or not to highlight it as a keyword, but since it is more a "placeholder" type and essentially replaces a type identifier and doesn't modify it or anything, i thought it made more sense to keep it highlighted as a type, but make it a builtin one.

the c grammar/queries still consider "auto" to be a keyword, but c still had it as an storage class specifier like `auto int x = 0;` up until very recently (c23, though it hasn't had an actual use in a while), while this hasn't been allowed in c++ since 2011.

fixes #15504