### PR TITLE
Update Caddyfile tree-sitter grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5002,7 +5002,7 @@ auto-format = true
 
 [[grammar]]
 name = "caddyfile"
-source = { git = "https://github.com/caddyserver/tree-sitter-caddyfile", rev = "b04bdb4ec53e40c44afbf001e15540f60a296aef" }
+source = { git = "https://github.com/caddyserver/tree-sitter-caddyfile", rev = "8951716aa2855e02dada302c540a90f277546095" }
 
 [[language]]
 name = "properties"

--- a/runtime/queries/caddyfile/highlights.scm
+++ b/runtime/queries/caddyfile/highlights.scm
@@ -42,6 +42,7 @@
 [
   (duration_literal)
   (int_literal)
+  (status_code_fallback)
 ] @constant.numeric
 
 [

--- a/runtime/queries/caddyfile/textobjects.scm
+++ b/runtime/queries/caddyfile/textobjects.scm
@@ -13,4 +13,4 @@
 (named_route
   (block) @class.inside) @class.around
 
-(site_definition (block) @class.inside) @class.around
+(site_block (block) @class.inside) @class.around


### PR DESCRIPTION
"site_definition" was renamed to "site_block" in the upstream commit:
8951716aa2855e02dada302c540a90f277546095

"status_code_fallback" was added in the upstream commit:
7a489e94fb80d8946d66eabf432286eef1b3e0f2