### PR TITLE
docs: fix duplicated word in indent comment

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -180,7 +180,7 @@ pub fn auto_detect_indent_style(document_text: &Rope) -> Option<IndentStyle> {
         .max()
         .unwrap();
 
-    // Return the the auto-detected result if we're confident enough in its
+    // Return the auto-detected result if we're confident enough in its
     // accuracy, based on some heuristics.
     if indent_freq >= 1 && (indent_freq_2 as f64 / indent_freq as f64) < 0.66 {
         Some(match indent {


### PR DESCRIPTION
## Summary
- fix a duplicated word in the auto-indent detection comment

## Related issue
- N/A (trivial comment typo fix)

## Guideline alignment
- Read https://github.com/helix-editor/helix/blob/master/docs/CONTRIBUTING.md
- one-file comment-only change
- no behavior change

## Validation
- Not run (comment-only change)
