### PR TITLE
fix: golang indent issues when auto-pairs = false

### DIFF
--- a/runtime/queries/go/indents.scm
+++ b/runtime/queries/go/indents.scm
@@ -38,3 +38,9 @@
   (default_case)
   (type_case)
 ] @extend
+
+; Handle ERROR nodes for when auto-pairs is disabled.
+; Typing an opening delimiter without a closing one produces an ERROR node.
+(ERROR "{") @indent @extend
+(ERROR "(") @indent
+(ERROR "[") @indent


### PR DESCRIPTION
Fixes #7910

When `auto-pairs = false`, typing an opening delimiter like `{` without a matching `}` causes tree-sitter to produce an ERROR node instead of the expected AST node (like `block`). The Go indent queries don't match ERROR nodes, so indentation doesn't trigger on Enter.

This adds ERROR node matching to `runtime/queries/go/indents.scm` for `{`, `(`, and `[` — similar to how Swift, Koka, and Python indent queries already handle this pattern.

Changes:
- `(ERROR "{") @indent @extend` — handles incomplete blocks (e.g., `func main() {` without closing brace)
- `(ERROR "(") @indent` — handles incomplete argument lists
- `(ERROR "[") @indent` — handles incomplete slice/array literals

Validated with `cargo xtask query-check` and `cargo test --workspace`.