### PR TITLE
fix: Scala `for` indent

### DIFF
--- a/runtime/queries/scala/indents.scm
+++ b/runtime/queries/scala/indents.scm
@@ -15,6 +15,8 @@
   (match_expression)
 ] @indent
 
+(ERROR "for") @indent
+
 [
   "}"
   "]"


### PR DESCRIPTION
Fixes #6406

When typing an incomplete `for {`, tree-sitter creates an ERROR node instead of a `for_expression`, so the existing indent rule doesn't match and indentation breaks.

This adds `(ERROR "for") @indent` to `runtime/queries/scala/indents.scm`, following the same pattern used by Python (`ERROR "try"`), Koka (`ERROR "fun"`, `ERROR "match"`), and other languages in the project.

Validated with `cargo xtask query-check` and `cargo test --workspace`.