### PR TITLE
avoid coloring conflicts for rust locals.scm queries

### DIFF
--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -41,6 +41,25 @@
 ; References
 (self) @local.reference
 (identifier) @local.reference
+
 ; lifetimes / labels
 (lifetime (identifier) @label)
 (label (identifier) @label)
+
+; == scoped function calls and function defs ==
+; avoid coloring functions as variables
+; taken from highlights.scm
+(call_expression
+  function: (scoped_identifier
+    name: (identifier) @function))
+(generic_function
+  function: (scoped_identifier
+    name: (identifier) @function))
+
+(function_item
+  name: (identifier) @function)
+(function_signature_item
+  name: (identifier) @function)
+
+; == other ==
+(enum_variant (identifier) @type.enum.variant)


### PR DESCRIPTION
fixes #15513 and previously appearing issues when having parameters that have the same name as functions. here parameters are red, variables are white and function calls are blue:

before:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/7c92218c-c51f-4c80-98af-824221118800" />

after:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/5dbe0467-d4c2-4f45-b7af-a3da37d5f4a8" />

i've left it for now, that when calling a parameter / mutable variable itself, so that. this is what vscode does as well:
<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/1fcfd95c-fa1a-407e-b058-0986ea0898aa" />

this fix is probably by no means exhaustive, but i didn't find anything else where this happened and i would just wait for new bug reports if someone notices.