### PR TITLE
Add buckconfig to ini language file-types

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3420,6 +3420,11 @@ file-types = [
   "cfg",
   "directory",
   { glob = ".wslconfig" },
+  { glob = ".buckconfig" },
+  { glob = ".buckconfig.local" },
+  { glob = ".buckconfig.d/*" },
+  { glob = "/etc/buckconfig" },
+  { glob = "/etc/buckconfig.d/*" },
 ]
 injection-regex = "ini"
 comment-token = "#"


### PR DESCRIPTION
Includes all potential buckconfig files as documented: https://buck2.build/docs/concepts/buckconfig/#other-initialization-files