### PR TITLE
feat(lsp): Add basic biome lsp-proxy configuration

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -17,6 +17,7 @@ bash-language-server = { command = "bash-language-server", args = ["start"] }
 bass = { command = "bass", args = ["--lsp"] }
 beancount-language-server = { command = "beancount-language-server" }
 bicep-langserver = { command = "bicep-langserver" }
+biome-lsp-proxy = { command = "biome", args = ["lsp-proxy"] }
 bitbake-language-server = { command = "bitbake-language-server" }
 buf = { command = "buf", args = ["lsp", "serve", "--timeout", "0"] }
 c3-lsp = { command = "c3-lsp" }


### PR DESCRIPTION
I use biome in a bunch of project and I'm moving away from VSCode. I'm accustomed to see inline annotations from biome (LSP style) and I set it up for Helix locally. I figured this could help others, maybe.

Example usage in project's `.helix/languages.toml`:
<img width="772" height="61" alt="Screenshot from 2026-03-26 06-28-13" src="https://github.com/user-attachments/assets/dd522e13-7cfa-43e2-9f83-2d178c9cb2d2" />

Example hint/diagnostic:
<img width="772" height="61" alt="Screenshot from 2026-03-26 06-27-08" src="https://github.com/user-attachments/assets/0dbdec34-f362-4f46-9eca-e50cefd90199" />

One thing I wasn't sure of was whether it should also be set as a default on appropriate languages, such as `typescript` or `javascript`, but I think this would only make sense if the LSP is active when a `biome.json` file is found at the project root.

I tried to make the [`require_configuration = true`](https://biomejs.dev/guides/editors/create-an-extension/#require_configuration) setting work by passing it as a config (i.e.: `config = { require_configuration = true }`), but that didn't take. I could see that the LSP was active even after I had removed the biome.json. I looked at the LSP logs and could see the setting being received, but then reverted back to `false` for a reason that escapes me.