### PR TITLE
fix: respect cx.register into account for `replace_with_yanked`

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4892,7 +4892,8 @@ fn paste_primary_clipboard_before(cx: &mut Context) {
 fn replace_with_yanked(cx: &mut Context) {
     replace_selections_with_register(
         cx.editor,
-        cx.editor.config().default_yank_register,
+        cx.register
+            .unwrap_or(cx.editor.config().default_yank_register),
         cx.count(),
     );
     exit_select_mode(cx);


### PR DESCRIPTION
fixes #15525, see original issue for bug report
this regressed in #11414, seemingly by accident in [`helix-term/src/commands.rs` in line 4810](https://github.com/helix-editor/helix/pull/11414/changes#diff-d782c07f22492bcae17333aba5dc5b840fb30317727e71267ebf4863f84787fdR4810).