### PR TITLE
feat(jumplist): Add custom "marks" on specific jumps

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3288,6 +3288,7 @@ fn jumplist_picker(cx: &mut Context) {
         selection: Selection,
         text: String,
         is_current: bool,
+        mark: Option<char>,
     }
 
     for (view, _) in cx.editor.tree.views_mut() {
@@ -3297,7 +3298,7 @@ fn jumplist_picker(cx: &mut Context) {
         }
     }
 
-    let new_meta = |view: &View, doc_id: DocumentId, selection: Selection| {
+    let new_meta = |view: &View, doc_id: DocumentId, selection: Selection, mark: Option<char>| {
         let doc = &cx.editor.documents.get(&doc_id);
         let text = doc.map_or("".into(), |d| {
             selection
@@ -3313,10 +3314,23 @@ fn jumplist_picker(cx: &mut Context) {
             selection,
             text,
             is_current: view.doc == doc_id,
+            mark,
         }
     };
 
     let columns = [
+        ui::PickerColumn::new("key", |item: &JumpMeta, _| {
+            let mut marks = Vec::new();
+            if let Some(mark) = item.mark {
+                marks.push(mark.to_string());
+            }
+
+            if marks.is_empty() {
+                "".into()
+            } else {
+                format!(" ({})", marks.join("")).into()
+            }
+        }),
         ui::PickerColumn::new("id", |item: &JumpMeta, _| item.id.to_string().into()),
         ui::PickerColumn::new("path", |item: &JumpMeta, _| {
             let path = item
@@ -3344,31 +3358,36 @@ fn jumplist_picker(cx: &mut Context) {
         ui::PickerColumn::new("contents", |item: &JumpMeta, _| item.text.as_str().into()),
     ];
 
-    let picker = Picker::new(
-        columns,
-        1, // path
-        cx.editor.tree.views().flat_map(|(view, _)| {
-            view.jumps
-                .iter()
-                .rev()
-                .map(|(doc_id, selection)| new_meta(view, *doc_id, selection.clone()))
-        }),
-        (),
-        |cx, meta, action| {
-            cx.editor.switch(meta.id, action);
-            let config = cx.editor.config();
-            let (view, doc) = (view_mut!(cx.editor), doc_mut!(cx.editor, &meta.id));
-            doc.set_selection(view.id, meta.selection.clone());
-            if action.align_view(view, doc.id()) {
-                view.ensure_cursor_in_view_center(doc, config.scrolloff);
-            }
-        },
-    )
-    .with_preview(|editor, meta| {
-        let doc = &editor.documents.get(&meta.id)?;
-        let line = meta.selection.primary().cursor_line(doc.text().slice(..));
-        Some((meta.id.into(), Some((line, line))))
-    });
+    let picker =
+        Picker::new(
+            columns,
+            0, // path
+            cx.editor.tree.views().flat_map(|(view, _)| {
+                let jumps = view.jumps.iter().rev().map(|(doc_id, selection, mark)| {
+                    new_meta(view, *doc_id, selection.clone(), *mark)
+                });
+                let marks = view.jumps.iter_marks().map(|(doc_id, selection, mark)| {
+                    new_meta(view, *doc_id, selection.clone(), *mark)
+                });
+
+                marks.chain(jumps)
+            }),
+            (),
+            |cx, meta, action| {
+                cx.editor.switch(meta.id, action);
+                let config = cx.editor.config();
+                let (view, doc) = (view_mut!(cx.editor), doc_mut!(cx.editor, &meta.id));
+                doc.set_selection(view.id, meta.selection.clone());
+                if action.align_view(view, doc.id()) {
+                    view.ensure_cursor_in_view_center(doc, config.scrolloff);
+                }
+            },
+        )
+        .with_preview(|editor, meta| {
+            let doc = &editor.documents.get(&meta.id)?;
+            let line = meta.selection.primary().cursor_line(doc.text().slice(..));
+            Some((meta.id.into(), Some((line, line))))
+        });
     cx.push_layer(Box::new(overlaid(picker)));
 }
 
@@ -3846,7 +3865,13 @@ fn normal_mode(cx: &mut Context) {
 // Store a jump on the jumplist.
 fn push_jump(view: &mut View, doc: &mut Document) {
     doc.append_changes_to_history(view);
-    let jump = (doc.id(), doc.selection(view.id).clone());
+    let jump = (doc.id(), doc.selection(view.id).clone(), None);
+    view.jumps.push(jump);
+}
+
+fn push_jump_with_mark(view: &mut View, doc: &mut Document, mark: Option<char>) {
+    doc.append_changes_to_history(view);
+    let jump = (doc.id(), doc.selection(view.id).clone(), mark);
     view.jumps.push(jump);
 }
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -174,6 +174,57 @@ fn open_impl(cx: &mut compositor::Context, args: Args, action: Action) -> anyhow
     Ok(())
 }
 
+fn mark(context: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let cx = crate::commands::Context {
+        editor: context.editor,
+        count: None,
+        register: None,
+        callback: Vec::new(),
+        on_next_key_callback: None,
+        jobs: context.jobs,
+    };
+
+    let (view, doc) = current!(cx.editor);
+
+    let mark = args
+        .get(0)
+        .as_ref()
+        .map(|mark| Some(mark.chars().next().unwrap()))
+        .unwrap();
+
+    push_jump_with_mark(view, doc, mark);
+    Ok(())
+}
+
+fn jump_to_mark(
+    context: &mut compositor::Context,
+    args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let mark = args
+        .get(0)
+        .as_ref()
+        .map(|mark| Some(mark.chars().next().unwrap()))
+        .unwrap()
+        .unwrap();
+
+    let view = view!(context.editor);
+
+    if let Some(_) = view.jumps.get_jump_with_mark(mark) {
+        context.editor.jump_to_mark(view.id, mark);
+    }
+
+    Ok(())
+}
+
 fn buffer_close_by_ids_impl(
     cx: &mut compositor::Context,
     doc_ids: &[DocumentId],
@@ -2141,7 +2192,7 @@ pub(super) fn goto_line_number(
                 .expect("update_goto_line_number_preview should always set last_selection");
 
             let (view, doc) = current!(cx.editor);
-            view.jumps.push((doc.id(), last_selection));
+            view.jumps.push((doc.id(), last_selection, None));
         }
 
         // When a user hits backspace and there are no numbers left,
@@ -2951,6 +3002,28 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
             positionals: (1, None),
             ..Signature::DEFAULT
         },
+    },
+    TypableCommand {
+        name: "mark",
+        aliases: &["m"],
+        doc: "Add selection to jumplist with assigned key.",
+        fun: mark,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (1, Some(1)),
+            ..Signature::DEFAULT
+        }
+    },
+    TypableCommand {
+        name: "jump_to_mark",
+        aliases: &["jtm"],
+        doc: "Jump to a jumplist item using assigned key.",
+        fun: jump_to_mark,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (1, Some(1)),
+            ..Signature::DEFAULT
+        }
     },
     TypableCommand {
         name: "buffer-close",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -193,8 +193,15 @@ fn mark(context: &mut compositor::Context, args: Args, event: PromptEvent) -> an
     let mark = args
         .get(0)
         .as_ref()
-        .map(|mark| Some(mark.chars().next().unwrap()))
-        .unwrap();
+        .map(|arg| {
+            let mark = arg.chars().next();
+            if mark.is_some() {
+                mark
+            } else {
+                None
+            }
+        })
+        .ok_or(anyhow!("No <mark> provided"))?;
 
     push_jump_with_mark(view, doc, mark);
     Ok(())
@@ -212,13 +219,19 @@ fn jump_to_mark(
     let mark = args
         .get(0)
         .as_ref()
-        .map(|mark| Some(mark.chars().next().unwrap()))
-        .unwrap()
-        .unwrap();
+        .and_then(|arg| {
+            let mark = arg.chars().next();
+            if mark.is_some() {
+                mark
+            } else {
+                None
+            }
+        })
+        .ok_or(anyhow!("No <mark> provided "))?;
 
     let view = view!(context.editor);
 
-    if let Some(_) = view.jumps.get_jump_with_mark(mark) {
+    if view.jumps.get_jump_with_mark(mark).is_some() {
         context.editor.jump_to_mark(view.id, mark);
     }
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -142,7 +142,7 @@ pub fn raw_regex_prompt(
 
                             if event == PromptEvent::Validate {
                                 // Equivalent to push_jump to store selection just before jump
-                                view.jumps.push((doc_id, snapshot.clone()));
+                                view.jumps.push((doc_id, snapshot.clone(), None));
                             }
 
                             fun(cx, regex, input, event);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1794,7 +1794,7 @@ impl Editor {
                         view.remove_document(&id);
                     }
                 } else {
-                    let jump = (view.doc, doc.selection(view.id).clone());
+                    let jump = (view.doc, doc.selection(view.id).clone(), None);
                     view.jumps.push(jump);
                     // Set last accessed doc if it is a different document
                     if doc.id != id {
@@ -2401,17 +2401,26 @@ impl Editor {
     }
 
     pub fn jump_forward(&mut self, view_id: ViewId, count: usize) {
-        if let Some((doc_id, selection)) = view_mut!(self, view_id).jumps.forward(count).cloned() {
+        if let Some((doc_id, selection, _)) = view_mut!(self, view_id).jumps.forward(count).cloned()
+        {
             self.jump_to(view_id, doc_id, selection);
         }
     }
 
     pub fn jump_backward(&mut self, view_id: ViewId, count: usize) {
         let view = view_mut!(self, view_id);
-        if let Some((doc_id, selection)) = view
+        if let Some((doc_id, selection, _)) = view
             .jumps
             .backward(view_id, doc_mut!(self, &view.doc), count)
             .cloned()
+        {
+            self.jump_to(view_id, doc_id, selection);
+        }
+    }
+
+    pub fn jump_to_mark(&mut self, view_id: ViewId, mark: char) {
+        if let Some((doc_id, selection, _)) =
+            view!(self, view_id).jumps.get_jump_with_mark(mark).cloned()
         {
             self.jump_to(view_id, doc_id, selection);
         }

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -62,7 +62,9 @@ impl JumpList {
     }
 
     fn add_mark_impl(&mut self, jump: Jump) {
-        self.marks.insert(jump.2.unwrap(), jump);
+        if let Some(mark) = jump.2 {
+            self.marks.insert(mark, jump);
+        }
     }
 
     pub fn push(&mut self, jump: Jump) {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -24,19 +24,24 @@ use std::{
 
 const JUMP_LIST_CAPACITY: usize = 30;
 
-type Jump = (DocumentId, Selection);
+type Jump = (DocumentId, Selection, Option<char>);
 
 #[derive(Debug, Clone)]
 pub struct JumpList {
     jumps: VecDeque<Jump>,
     current: usize,
+    marks: HashMap<char, Jump>,
 }
 
 impl JumpList {
     pub fn new(initial: Jump) -> Self {
         let mut jumps = VecDeque::with_capacity(JUMP_LIST_CAPACITY);
         jumps.push_back(initial);
-        Self { jumps, current: 0 }
+        Self {
+            jumps,
+            current: 0,
+            marks: HashMap::new(),
+        }
     }
 
     fn push_impl(&mut self, jump: Jump) -> usize {
@@ -56,8 +61,20 @@ impl JumpList {
         num_removed_from_front
     }
 
+    fn add_mark_impl(&mut self, jump: Jump) {
+        self.marks.insert(jump.2.unwrap(), jump);
+    }
+
     pub fn push(&mut self, jump: Jump) {
-        self.push_impl(jump);
+        if jump.2.is_none() {
+            self.push_impl(jump);
+        } else {
+            self.add_mark_impl(jump);
+        }
+    }
+
+    pub fn get_jump_with_mark(&self, mark: char) -> Option<&Jump> {
+        self.marks.get(&mark)
     }
 
     pub(crate) fn forward(&mut self, count: usize) -> Option<&Jump> {
@@ -78,14 +95,14 @@ impl JumpList {
     ) -> Option<&Jump> {
         if let Some(mut current) = self.current.checked_sub(count) {
             if self.current == self.jumps.len() {
-                let jump = (doc.id(), doc.selection(view_id).clone());
+                let jump = (doc.id(), doc.selection(view_id).clone(), None);
                 let num_removed = self.push_impl(jump);
                 current = current.saturating_sub(num_removed);
             }
             self.current = current;
 
             // Avoid jumping to the current location.
-            let (doc_id, selection) = self.jumps.get(self.current)?;
+            let (doc_id, selection, _) = self.jumps.get(self.current)?;
             if doc.id() == *doc_id && doc.selection(view_id) == selection {
                 self.current = self.current.checked_sub(1)?;
             }
@@ -96,11 +113,15 @@ impl JumpList {
     }
 
     pub fn remove(&mut self, doc_id: &DocumentId) {
-        self.jumps.retain(|(other_id, _)| other_id != doc_id);
+        self.jumps.retain(|(other_id, _, _)| other_id != doc_id);
     }
 
     pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Jump> {
         self.jumps.iter()
+    }
+
+    pub fn iter_marks(&self) -> impl Iterator<Item = &Jump> {
+        self.marks.iter().map(|m| m.1)
     }
 
     /// Applies a [`Transaction`] of changes to the jumplist.
@@ -109,7 +130,7 @@ impl JumpList {
     fn apply(&mut self, transaction: &Transaction, doc: &Document) {
         let text = doc.text().slice(..);
 
-        for (doc_id, selection) in &mut self.jumps {
+        for (doc_id, selection, _) in &mut self.jumps {
             if doc.id() == *doc_id {
                 *selection = selection
                     .clone()
@@ -175,7 +196,7 @@ impl View {
             id: ViewId::default(),
             doc,
             area: Rect::default(), // will get calculated upon inserting into tree
-            jumps: JumpList::new((doc, Selection::point(0))), // TODO: use actual sel
+            jumps: JumpList::new((doc, Selection::point(0), None)), // TODO: use actual sel
             docs_access_history: Vec::new(),
             last_modified_docs: [None, None],
             object_selections: Vec::new(),


### PR DESCRIPTION
Add `:mark <char>` and `:jump_to_mark <char>`
commands. It uses the jumplist feature by allowing 
the user to set an arbitrary character as an
identifier for the jump.

Since it's using the jumplist, it has the added
functionality of the "harpoon" neovim plugin of
jumping between files on designated keys/marks.

Is this something the community want or just me? xD

Quick demo
where I remapped `Ctrl-s` to `@:m ` and `'` to `@:jtm ` in my config.
[![asciicast](https://asciinema.org/a/hBxFWb9kBpB1EHTK.svg)](https://asciinema.org/a/hBxFWb9kBpB1EHTK)

This also adds a 'key' column to the jumplist to and make
it the default searchable column. So this could be related to this https://github.com/helix-editor/helix/pull/15499