### PR TITLE
docs: fix typo in env substitution comment

### DIFF
--- a/helix-stdx/src/env.rs
+++ b/helix-stdx/src/env.rs
@@ -151,7 +151,7 @@ fn expand_impl(src: &OsStr, mut resolve: impl FnMut(&OsStr) -> Option<OsString>)
     }
 }
 
-/// performs substitution of enviorment variables. Supports the following (POSIX) syntax:
+/// performs substitution of environment variables. Supports the following (POSIX) syntax:
 ///
 /// * `$<var>`, `${<var>}`
 /// * `${<var>:-<default>}`, `${<var>-<default>}`


### PR DESCRIPTION
## Summary
- fix a typo in the environment substitution doc comment in `helix-stdx/src/env.rs`

## Related issue
- N/A

## Guideline alignment
- Reviewed [docs/CONTRIBUTING.md](https://github.com/helix-editor/helix/blob/master/docs/CONTRIBUTING.md)
- Kept this to a single doc-comment change in one file with no behavior change

## Validation/testing note
- Not run locally; doc-comment-only change
