### PR TITLE
chore(msrv): bump from 1.87 to 1.90

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     - cron: "00 01 * * *"
 
 env:
-  MSRV: "1.87"
+  MSRV: "1.90"
   # This key can be changed to bust the cache of tree-sitter grammars.
   GRAMMAR_CACHE_VERSION: ""
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,4 +66,4 @@ categories = ["editor"]
 repository = "https://github.com/helix-editor/helix"
 homepage = "https://helix-editor.com"
 license = "MPL-2.0"
-rust-version = "1.87"
+rust-version = "1.90"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.90.0"
 components = ["rustfmt", "rust-src", "clippy"]


### PR DESCRIPTION
This makes back to back [firefox updates](https://firefox-source-docs.mozilla.org/writing-rust-code/update-policy.html) where they bumped the MSRV: [rust-version = "1.90.0"](https://github.com/mozilla-firefox/firefox/blob/c6cd82dbb38d07dce52587714cf739c7c171f84b/Cargo.toml#L67)

This includes the new `let-chains` that where added in `1.88`, but which requires the [2024 Edition](https://github.com/helix-editor/helix/pull/15209). `1.89` stabilizes `avx512` for `x86_64`. `1.90` switches to use `lld` by default on linux. `x86_64 Apple` was demoted a tier.