### PR TITLE
fix(lsp): track pull diagnostic result ids per server

### DIFF
--- a/helix-term/src/handlers/diagnostics.rs
+++ b/helix-term/src/handlers/diagnostics.rs
@@ -174,8 +174,13 @@ fn request_document_diagnostics_for_language_severs(
         .iter()
         .filter_map(|x| doc.language_servers().find(|y| &y.id() == x))
         .filter_map(|language_server| {
-            let future = language_server
-                .text_document_diagnostic(doc.identifier(), doc.previous_diagnostic_id.clone())?;
+            let language_server_id = language_server.id();
+            let future = language_server.text_document_diagnostic(
+                doc.identifier(),
+                doc.previous_diagnostic_ids
+                    .get(&language_server_id)
+                    .cloned(),
+            )?;
 
             let identifier = language_server
                 .capabilities()
@@ -190,7 +195,6 @@ fn request_document_diagnostics_for_language_severs(
                     }
                 });
 
-            let language_server_id = language_server.id();
             let provider = DiagnosticProvider::Lsp {
                 server_id: language_server_id,
                 identifier,
@@ -293,7 +297,17 @@ fn handle_pull_diagnostics_response(
             };
 
             if let Some(doc) = editor.document_mut(document_id) {
-                doc.previous_diagnostic_id = result_id;
+                let server_id = provider
+                    .language_server_id()
+                    .expect("pull diagnostics always originate from an LSP");
+                match result_id {
+                    Some(result_id) => {
+                        doc.previous_diagnostic_ids.insert(server_id, result_id);
+                    }
+                    None => {
+                        doc.previous_diagnostic_ids.remove(&server_id);
+                    }
+                }
             };
         }
         lsp::DocumentDiagnosticReportResult::Partial(_) => {}

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -207,7 +207,7 @@ pub struct Document {
 
     pub readonly: bool,
 
-    pub previous_diagnostic_id: Option<String>,
+    pub previous_diagnostic_ids: HashMap<LanguageServerId, String>,
 
     /// Annotations for LSP document color swatches
     pub color_swatches: Option<DocumentColorSwatches>,
@@ -761,7 +761,7 @@ impl Document {
             color_swatch_controller: TaskController::new(),
             document_highlight_controllers: HashMap::new(),
             syn_loader,
-            previous_diagnostic_id: None,
+            previous_diagnostic_ids: HashMap::new(),
             pull_diagnostic_controller: TaskController::new(),
             document_link_controller: TaskController::new(),
         }


### PR DESCRIPTION
Cache pull diagnostics result ids by language server instead of per document. This preserves LSP-server-side incremental diagnostic state when multiple LSPs are attached to the same buffer.