### PR TITLE
chore(helix-term): avoid buffering URL opener output

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -79,7 +79,7 @@ fn open_external_url_callback(
     async {
         for cmd in commands {
             let mut command: tokio::process::Command = cmd.into();
-            if command.output().await.is_ok() {
+            if command.status().await.is_ok() {
                 return Ok(job::Callback::Editor(Box::new(|_| {})));
             }
         }


### PR DESCRIPTION
Use process status checks when checking external URL opener commands, we don't use the output so no need to buffer it.