### PR TITLE
Add inactive text color to kanagawa theme

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -34,6 +34,7 @@
 "ui.window" = { fg = "sumiInk0" }
 "ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.text" = "fujiWhite"
+"ui.text.inactive" = "fujiGray"
 "ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
 
 "ui.cursor" = { fg = "waveBlue1", bg = "waveAqua2" }


### PR DESCRIPTION
Adds the `ui.text.inactive` key to the Kanagawa theme, mapping it to the "fujiGray" color.

Previously, inactive text inside the command line (accessed via :) lacked proper dimming.Explicitly setting this color ensures that inactive or secondary text (such as command suggestions) is appropriately dimmed.