### PR TITLE
refactor: no longer bail on error fetching/building grammars

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -86,7 +86,7 @@ fn ensure_git_is_available() -> Result<()> {
     Ok(())
 }
 
-pub fn fetch_grammars() -> Result<()> {
+pub fn fetch_grammars(strict: bool) -> Result<()> {
     ensure_git_is_available()?;
 
     // We do not need to fetch local grammars.
@@ -141,13 +141,15 @@ pub fn fetch_grammars() -> Result<()> {
         for (i, (grammar, error)) in errors.into_iter().enumerate() {
             println!("Failure {}/{len}: {grammar} {error}", i + 1);
         }
-        bail!("{len} grammars failed to fetch");
+        if strict {
+            bail!("{len} grammars failed to fetch");
+        }
     }
 
     Ok(())
 }
 
-pub fn build_grammars(target: Option<String>) -> Result<()> {
+pub fn build_grammars(target: Option<String>, strict: bool) -> Result<()> {
     ensure_git_is_available()?;
 
     let grammars = get_grammar_configs()?;
@@ -184,7 +186,9 @@ pub fn build_grammars(target: Option<String>) -> Result<()> {
         for (i, (grammar_id, error)) in errors.into_iter().enumerate() {
             println!("Failure {}/{len}: {grammar_id} {error}", i + 1);
         }
-        bail!("{len} grammars failed to build");
+        if strict {
+            bail!("{len} grammars failed to build");
+        }
     }
 
     Ok(())

--- a/helix-loader/src/main.rs
+++ b/helix-loader/src/main.rs
@@ -4,6 +4,8 @@ use helix_loader::grammar::fetch_grammars;
 // This binary is used in the Release CI as an optimization to cut down on
 // compilation time. This is not meant to be run manually.
 
+const STRICT: bool = true;
+
 fn main() -> Result<()> {
-    fetch_grammars()
+    fetch_grammars(STRICT)
 }

--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -1,9 +1,11 @@
 use helix_loader::grammar::{build_grammars, fetch_grammars};
 
+const STRICT: bool = true;
+
 fn main() {
     if std::env::var("HELIX_DISABLE_AUTO_GRAMMAR_BUILD").is_err() {
-        fetch_grammars().expect("Failed to fetch tree-sitter grammars");
-        build_grammars(Some(std::env::var("TARGET").unwrap()))
+        fetch_grammars(STRICT).expect("Failed to fetch tree-sitter grammars");
+        build_grammars(Some(std::env::var("TARGET").unwrap()), STRICT)
             .expect("Failed to compile tree-sitter grammars");
     }
 

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -13,6 +13,7 @@ pub struct Args {
     pub load_tutor: bool,
     pub fetch_grammars: bool,
     pub build_grammars: bool,
+    pub strict: bool,
     pub split: Option<Layout>,
     pub verbosity: u64,
     pub log_file: Option<PathBuf>,
@@ -22,6 +23,7 @@ pub struct Args {
 }
 
 impl Args {
+    #[allow(clippy::too_many_lines)]
     pub fn parse_args() -> Result<Args> {
         let mut args = Args::default();
         let mut argv = std::env::args().peekable();
@@ -46,6 +48,7 @@ impl Args {
                 "--" => break, // stop parsing at this point treat the remaining as files
                 "--version" => args.display_version = true,
                 "--help" => args.display_help = true,
+                "--strict" => args.strict = true,
                 "--tutor" => args.load_tutor = true,
                 "--vsplit" => match args.split {
                     Some(_) => anyhow::bail!("can only set a split once of a specific type"),

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -60,13 +60,14 @@ ARGS:
 
 FLAGS:
     -h, --help                     Print help information
+    --strict                       Bail on error for commands that can fail.
     --tutor                        Load the tutorial
     --health [CATEGORY]            Check for potential errors in editor setup
                                    CATEGORY can be a language or one of 'clipboard', 'languages',
                                    'all-languages' or 'all'. 'languages' is filtered according to
                                    user config, 'all-languages' and 'all' are not. If not specified,
                                    the default is the same as 'all', but with languages filtering.
-    -g, --grammar {{fetch|build}}    Fetch or builds tree-sitter grammars listed in languages.toml
+    -g, --grammar {{fetch|build}}    Fetch or builds tree-sitter grammars listed in languages.toml.
     -c, --config <file>            Specify a file to use for configuration
     -v                             Increase logging verbosity each use for up to 3 times
     --log <file>                   Specify a file to use for logging
@@ -105,12 +106,12 @@ FLAGS:
     }
 
     if args.fetch_grammars {
-        helix_loader::grammar::fetch_grammars()?;
+        helix_loader::grammar::fetch_grammars(args.strict)?;
         return Ok(0);
     }
 
     if args.build_grammars {
-        helix_loader::grammar::build_grammars(None)?;
+        helix_loader::grammar::build_grammars(None, args.strict)?;
         return Ok(0);
     }
 


### PR DESCRIPTION
The goal is to log any grammar fetching or building issues, but continue with grammars that are fine. Similar to the `VendoredGrammar` changes made previously, the goal is to try to isolate individual grammar issues and keep them from interfering with an otherwise clean build.

I think this is all that is needed to prevent the previously reported issues, but not entirely sure. Also not sure how to test to make sure this actually works, so relying on reviewers' knowledge about the grammar fetching/building pipeline. 

Closes: #15420