### PR TITLE
feat: Add delete_sub_word_* commands

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -178,6 +178,8 @@
 | `delete_char_forward` | Delete next char | insert: `` <C-d> ``, `` <del> `` |
 | `delete_word_backward` | Delete previous word | insert: `` <C-w> ``, `` <A-backspace> `` |
 | `delete_word_forward` | Delete next word | insert: `` <A-d> ``, `` <A-del> `` |
+| `delete_sub_word_backward` | Delete previous sub word |  |
+| `delete_sub_word_forward` | Delete next sub word |  |
 | `kill_to_line_start` | Delete till start of line | insert: `` <C-u> `` |
 | `kill_to_line_end` | Delete till end of line | insert: `` <C-k> `` |
 | `undo` | Undo change | normal: `` u ``, select: `` u `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -481,6 +481,8 @@ impl MappableCommand {
         delete_char_forward, "Delete next char",
         delete_word_backward, "Delete previous word",
         delete_word_forward, "Delete next word",
+        delete_sub_word_backward, "Delete previous sub word",
+        delete_sub_word_forward, "Delete next sub word",
         kill_to_line_start, "Delete till start of line",
         kill_to_line_end, "Delete till end of line",
         undo, "Undo change",
@@ -4612,6 +4614,32 @@ pub mod insert {
             cx,
             |text, range| {
                 let head = movement::move_next_word_end(text, *range, count).to();
+                (range.cursor(text), head)
+            },
+            Direction::Forward,
+        );
+    }
+
+    pub fn delete_sub_word_backward(cx: &mut Context) {
+        let count = cx.count();
+        delete_by_selection_insert_mode(
+            cx,
+            |text, range| {
+                let anchor = movement::move_prev_sub_word_start(text, *range, count).from();
+                let next = Range::new(anchor, range.cursor(text));
+                let range = exclude_cursor(text, next, *range);
+                (range.from(), range.to())
+            },
+            Direction::Backward,
+        );
+    }
+
+    pub fn delete_sub_word_forward(cx: &mut Context) {
+        let count = cx.count();
+        delete_by_selection_insert_mode(
+            cx,
+            |text, range| {
+                let head = movement::move_next_sub_word_end(text, *range, count).to();
                 (range.cursor(text), head)
             },
             Direction::Forward,


### PR DESCRIPTION
Add two new commands:
- `delete_sub_word_forward`
- `delete_sub_word_backward`

I copied these from the equivalent `delete_word_*` commands. None of the existing `sub_word` commands (such as `move_next_sub_word_start`) are bound to keys by default, so I didn't bind these either. For the same reason, I didn't add these to the docs.

I saw the `delete_word_*` commands are used in `ui/prompt.rs` and `handlers/completion.rs`. I'm not sure what either of these are, but neither of them contain any references to the other existing `sub_word` commands, so I'm guessing these changes aren't needed for commands that are unbound by default.

I did NOT write any tests for this. I didn't see any existing tests for other `sub_word` commands, and the tests for the `delete_word_*` commands in `test/commands.rs` use the default keybindings to invoke them, so I'm not sure how to write tests without there being default keybindings.

![demo](https://github.com/user-attachments/assets/721e17e3-6b21-45b1-afca-1f2f0233d84e)