### PR TITLE
ci: add ubuntu-24.04-riscv runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm]
+        os: [ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm, windows-11-arm, ubuntu-24.04-riscv]
 
   lints:
     name: Lints

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos, aarch64-windows]
+        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos, aarch64-windows, riscv64-linux]
         include:
         - build: x86_64-linux
           # WARN: When changing this to a newer version, make sure that the GLIBC isnt too new, as this can cause issues
@@ -80,6 +80,21 @@ jobs:
           os: windows-11-arm
           rust: stable
           target: aarch64-pc-windows-msvc
+        - build: riscv64-linux
+          # This is provided by the RISE Project:
+          #
+          #   - https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/
+          #
+          # There is only the ubuntu-24.04 version, and is inherently limited
+          # compared with the GitHub provided ubuntu versions.
+          #
+          # This includes the GLIBC version, which can cause issues if the version
+          # provided here is too new compared to what a user might have.
+          # Considering that RISC-V as a desktop is still fairly new, we will
+          # considered support to be best effort.
+          os: ubuntu-24.04-riscv
+          rust: stable
+          target: riscv64gc-unknown-linux-gnu
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Adds support for testing and releasing RISC-V Linux.

The runners are provided by the RISE Project:
- https://riseproject.dev/2026/03/24/announcing-the-rise-risc-v-runners-free-native-risc-v-ci-on-github/
- https://riseproject-dev.github.io/riscv-runner/

To note, the runners' Ubuntu version is not coupled with the traditional full version offerings GitHub provides. This means that we have to use the 24.04 version, even though this could provide a GLIBC version that is newer than what users might have, and is also currently out of sync with the version we use for the other Linux releases for `x86_64` and `aarch64`. Given that RISC-V is fairly new for desktop Linux, I think its fine to offer a best effort support here, as you could expect that most users would be on new kernels as support expands.

Considering that this is a 3rd party offering, this could be very slow to run. It might be worth it for releases, which are done rarely, but I'm also hesitant to offer a release build without also testing it.

RISC-V Linux is currently [Tier: 2 (with Host Tools)](https://doc.rust-lang.org/beta/rustc/platform-support/riscv64gc-unknown-linux-gnu.html)

Closes: #15478
