### PR TITLE
Add `*.{dtx,ins}` file types to the LaTeX language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1390,7 +1390,7 @@ source = { git = "https://github.com/gbprod/tree-sitter-twig", rev = "085648e01d
 name = "latex"
 scope = "source.tex"
 injection-regex = "tex"
-file-types = ["tex", "sty", "dtx", "ins", "cls", "Rd", "bbx", "cbx"]
+file-types = ["tex", "dtx", "ins", "sty", "cls", "Rd", "bbx", "cbx"]
 comment-token = "%"
 language-servers = [ "texlab" ]
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
- dtx: A documented source file, whose comments can be extracted by DocStrip into another TeX document, and compiled to the PDF manual.
- ins: A installation file that controls DocStrip.

Both files use the same syntax of `*.tex`.

https://texfaq.org/FAQ-dtx

`*.{dtx,ins}` are common in repos that develop LaTeX packages and templates. https://github.com/josephwright/siunitx is an instance.

[Neovim also includes `*.{clo,ltx}` in the list](https://neovim.io/doc/user/syntax/#_tex:~:text=sty%2C%20cls%2C%20clo%2C%20dtx%2C%20or%20ltx), but I've never seen them and I'm not sure if LaTeX is dominant for `*.{clo,ltx}`. Therefore, I only added `*.{dtx,ins}`.

I put dtx and ins before sty and cls, because `*.{sty,cls}` can be generated from `*.{dtx,ins}`.