### PR TITLE
languages: Fix robot language-id and update grammar/queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -243,7 +243,7 @@
 | rescript | ✓ | ✓ |  |  |  | `rescript-language-server` |
 | ripple | ✓ |  |  | ✓ | ✓ | `ripple-language-server` |
 | rmarkdown | ✓ |  | ✓ |  |  | `R` |
-| robot | ✓ |  |  |  |  | `robotcode`, `robotframework_ls` |
+| robot | ✓ |  | ✓ |  |  | `robotcode`, `robotframework_ls` |
 | robots.txt | ✓ | ✓ |  | ✓ |  |  |
 | ron | ✓ |  | ✓ | ✓ | ✓ | `ron-lsp` |
 | rpmspec | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -2490,6 +2490,7 @@ source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-ron", rev 
 
 [[language]]
 name = "robot"
+language-id="robotframework"
 scope = "source.robot"
 injection-regex = "robot"
 file-types = ["robot", "resource"]

--- a/languages.toml
+++ b/languages.toml
@@ -2500,7 +2500,7 @@ language-servers = [ "robotcode", "robotframework_ls" ]
 
 [[grammar]]
 name = "robot"
-source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "322e4cc65754d2b3fdef4f2f8a71e0762e3d13af" }
+source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "0f010f439e7873db42d3aabae8a48a8f61a89910" }
 
 [[language]]
 name = "r"

--- a/runtime/queries/robot/highlights.scm
+++ b/runtime/queries/robot/highlights.scm
@@ -10,7 +10,9 @@
   (test_case_setting)
 ] @keyword
 
-(variable_definition (variable_name) @variable)
+(scalar_variable (variable_name) @variable)
+(list_variable (variable_name) @variable)
+(dictionary_variable (variable_name) @variable)
 (keyword_definition (name) @function)
 (test_case_definition (name) @function)
 

--- a/runtime/queries/robot/indents.scm
+++ b/runtime/queries/robot/indents.scm
@@ -1,0 +1,21 @@
+(keyword_definition) @indent
+(test_case_definition) @indent
+
+(for_statement) @indent
+(for_statement "END" @outdent)
+(for_statement
+  right: (_ (arguments (continuation (ellipses) @outdent))))
+
+(while_statement) @indent
+(while_statement "END" @outdent)
+
+(if_statement) @indent
+(if_statement (elseif_statement) @outdent)
+(if_statement (else_statement) @outdent)
+(if_statement "END" @outdent)
+
+(try_statement) @indent
+(try_statement (except_statement) @outdent)
+(try_statement (finally_statement) @outdent)
+(try_statement (else_statement) @outdent)
+(try_statement "END" @outdent)


### PR DESCRIPTION
Based on the issue discussed in [robotcodedev/robotcode!575](https://github.com/robotcodedev/robotcode/issues/575), this PR changes the `language-id` for the `robot` language to `robotframework`. This was chosen since the ID `robot` is apparently also used by other languages, which is why the robotcode language server expects `robotframework`.

Besides this change, the grammar and highlight queries are updated from [Hubro/tree-sitter-robot](https://github.com/Hubro/tree-sitter-robot) and new indentation queries are added, based on the queries present in in tree-sitter-robot with the capture names adjusted for helix.