### PR TITLE
Add support for varlink language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -311,6 +311,7 @@
 | uxntal | ✓ |  |  |  |  |  |
 | v | ✓ | ✓ | ✓ |  |  | `v-analyzer` |
 | vala | ✓ | ✓ |  |  |  | `vala-language-server` |
+| varlink | ✓ |  |  |  |  | `varlink-language-server` |
 | vento | ✓ |  |  |  |  |  |
 | verilog | ✓ | ✓ |  |  |  | `verible-verilog-ls` |
 | vhdl | ✓ |  |  |  |  | `vhdl_ls` |

--- a/languages.toml
+++ b/languages.toml
@@ -158,6 +158,7 @@ ty = { command = "ty", args = ["server"] }
 typespec = { command = "tsp-server", args = ["--stdio"] }
 vala-language-server = { command = "vala-language-server" }
 vale-ls = { command = "vale-ls" }
+varlink-language-server = { command = "varlink-language-server" }
 verible-verilog-ls = { command = "verible-verilog-ls" }
 vhdl_ls = { command = "vhdl_ls", args = [] }
 vlang-language-server = { command = "v-analyzer" }
@@ -5509,3 +5510,16 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "concerto"
 source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "920ba23ea93af56b19dfc38fcddf80b3ddc62685" }
+
+[[language]]
+name = "varlink"
+scope = "source.varlink"
+file-types = ["varlink"]
+injection-regex = "varlink"
+indent = { tab-width = 2, unit = "  " }
+comment-token = "#"
+language-servers = ["varlink-language-server"]
+
+[[grammar]]
+name = "varlink"
+source = { git = "https://github.com/bachorp/tree-sitter-varlink", rev = "a80ecffda60b28612cbda652e38d97c1d8b90568" }

--- a/runtime/queries/varlink/highlights.scm
+++ b/runtime/queries/varlink/highlights.scm
@@ -1,0 +1,40 @@
+(comment) @comment
+
+(keyword_interface) @keyword
+(keyword_type) @keyword.storage.type
+(keyword_method) @keyword.function
+(keyword_error) @keyword.storage.type
+
+(interface_name) @string
+(method name: (_) @function)
+(error name: (_) @type)
+(typedef name: (_) @type)
+(typeref (name) @type)
+(struct_field name: (_) @variable.parameter)
+(enum member: (_) @type)
+
+[
+  (bool)
+  (int)
+  (float)
+  (string)
+  (object)
+  (any)
+] @type.builtin
+
+[
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  (questionmark)
+  (arrow)
+] @operator


### PR DESCRIPTION
~This is using my own fork right now, with two small adjustments. If upstream commits the generated parser to the source tree, we could point to the upstream grammar instead.~ Edit: We can point to upstream now.