### PR TITLE
feat: add breadcrumb navigation bar

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -1,6 +1,7 @@
 ## Editor
 
 - [`[editor]` Section](#editor-section)
+- [`[editor.breadcrumb]` Section](#editorbreadcrumb-section)
 - [`[editor.clipboard-provider]` Section](#editorclipboard-provider-section)
 - [`[editor.statusline]` Section](#editorstatusline-section)
 - [`[editor.lsp]` Section](#editorlsp-section)
@@ -72,6 +73,26 @@
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
 
 [^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
+
+### `[editor.breadcrumb]` Section
+
+Allows configuration of the breadcrumb navigation bar.
+
+|  Setting |                 Description                     | Default |
+|----------|-------------------------------------------------|---------|
+| `enable` | Whether to enable the breadcrumb navigation bar | `false` |
+|  `path`  | Selecting how much path information is shown    | `"full"`|
+
+```toml
+[editor.breadcrumb]
+enable = true
+# full: helix-term > src > commands > typed.rs > TypeableCommand > name
+# file: typed.rs > TypeableCommand > name
+# none: TypeableCommand > name
+path = "full|file|none"
+```
+
+The bar is displayed at the top of the view.
 
 ### `[editor.clipboard-provider]` Section
 

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -739,7 +739,7 @@ impl Client {
                         symbol_kind: Some(lsp::SymbolKindCapability {
                             value_set: Some(lsp::SymbolKind::all()),
                         }),
-                        hierarchical_document_symbol_support: Some(false),
+                        hierarchical_document_symbol_support: Some(true),
                         ..Default::default()
                     }),
                     ..Default::default()

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1147,7 +1147,7 @@ fn goto_window(cx: &mut Context, align: Align) {
     let (view, doc) = current!(cx.editor);
     let view_offset = doc.view_offset(view.id);
 
-    let height = view.inner_height();
+    let height = view.inner_height(doc);
 
     // respect user given count if any
     // - 1 so we have at least one gap in the middle.
@@ -1938,7 +1938,7 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
     let text = doc.text().slice(..);
 
     let cursor = range.cursor(text);
-    let height = view.inner_height();
+    let height = view.inner_height(doc);
 
     let scrolloff = config.scrolloff.min(height.saturating_sub(1) / 2);
     let offset = match direction {
@@ -2039,50 +2039,50 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
 }
 
 fn page_up(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height();
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc);
     scroll(cx, offset, Direction::Backward, false);
 }
 
 fn page_down(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height();
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc);
     scroll(cx, offset, Direction::Forward, false);
 }
 
 fn half_page_up(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height() / 2;
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc) / 2;
     scroll(cx, offset, Direction::Backward, false);
 }
 
 fn half_page_down(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height() / 2;
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc) / 2;
     scroll(cx, offset, Direction::Forward, false);
 }
 
 fn page_cursor_up(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height();
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc);
     scroll(cx, offset, Direction::Backward, true);
 }
 
 fn page_cursor_down(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height();
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc);
     scroll(cx, offset, Direction::Forward, true);
 }
 
 fn page_cursor_half_up(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height() / 2;
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc) / 2;
     scroll(cx, offset, Direction::Backward, true);
 }
 
 fn page_cursor_half_down(cx: &mut Context) {
-    let view = view!(cx.editor);
-    let offset = view.inner_height() / 2;
+    let (view, doc) = current_ref!(cx.editor);
+    let offset = view.inner_height(doc) / 2;
     scroll(cx, offset, Direction::Forward, true);
 }
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1332,7 +1332,7 @@ fn compute_inlay_hints_for_view(
     // will not show half the view with hints and half without while still being faster
     // than computing all the hints for the full file (which could be dozens of time
     // longer than the view is).
-    let view_height = view.inner_height();
+    let view_height = view.inner_height(doc);
     let first_visible_line =
         doc_text.char_to_line(doc.view_offset(view_id).anchor.min(doc_text.len_chars()));
     let first_line = first_visible_line.saturating_sub(view_height);

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1908,6 +1908,7 @@ fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
                 doc.clear_diagnostics_for_language_server(client.id());
                 doc.reset_all_inlay_hints();
                 doc.inlay_hints_oudated = true;
+                doc.clear_document_symbols();
             }
         }
     }

--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -22,6 +22,7 @@ pub mod diagnostics;
 mod document_colors;
 mod document_highlight;
 mod document_links;
+mod document_symbols;
 mod prompt;
 mod signature_help;
 mod snippet;
@@ -57,6 +58,7 @@ pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
     signature_help::register_hooks(&handlers);
     document_highlight::register_hooks(&handlers);
     code_action_hint::register_hooks(&handlers);
+    document_symbols::register_hooks(&handlers);
     auto_save::register_hooks(&handlers);
     diagnostics::register_hooks(&handlers);
     snippet::register_hooks(&handlers);

--- a/helix-term/src/handlers/document_symbols.rs
+++ b/helix-term/src/handlers/document_symbols.rs
@@ -1,0 +1,139 @@
+use crate::job;
+use helix_core::syntax::config::LanguageServerFeature;
+use helix_event::{cancelable_future, register_hook};
+use helix_lsp::lsp::DocumentSymbolResponse;
+use helix_view::{
+    events::{
+        ConfigDidChange, DocumentDidChange, DocumentDidOpen, LanguageServerExited,
+        LanguageServerInitialized, SelectionDidChange,
+    },
+    handlers::Handlers,
+    DocumentId, Editor,
+};
+
+fn request_document_symbols(editor: &mut Editor, doc_id: DocumentId) {
+    if !editor.config().breadcrumb.enable {
+        return;
+    }
+
+    let Some(doc) = editor.document_mut(doc_id) else {
+        return;
+    };
+
+    let Some(language_server) = doc
+        // Get the first LSP Server that supports `DocumentSymbols`.
+        .language_servers_with_feature(LanguageServerFeature::DocumentSymbols)
+        .next()
+    else {
+        return;
+    };
+
+    let offset_encoding = language_server.offset_encoding();
+    let Some(future) = language_server.document_symbols(doc.identifier()) else {
+        return;
+    };
+    let cancel = doc.document_symbols_controller.restart();
+
+    tokio::spawn(async move {
+        let Some(Ok(Some(response))) = cancelable_future(future, &cancel).await else {
+            return;
+        };
+
+        job::dispatch(move |editor, _| {
+            if let Some(doc) = editor.document_mut(doc_id) {
+                match response {
+                    DocumentSymbolResponse::Nested(symbols) => {
+                        doc.set_document_symbols(symbols, offset_encoding);
+                    }
+                    // TODO: Using the `Location`, it should be possible to map cursor
+                    // to a hierarchical tree?
+                    DocumentSymbolResponse::Flat(_) => {}
+                }
+            }
+        })
+        .await;
+    });
+}
+
+pub(super) fn register_hooks(_handlers: &Handlers) {
+    register_hook!(move |event: &mut DocumentDidOpen<'_>| {
+        let doc_id = event.doc;
+        let view_id = event.editor.tree.focus;
+        request_document_symbols(event.editor, doc_id);
+        if let Some(doc) = event.editor.document_mut(doc_id) {
+            doc.update_breadcrumbs_for_view(view_id);
+        }
+        Ok(())
+    });
+
+    register_hook!(move |event: &mut DocumentDidChange<'_>| {
+        if !event.ghost_transaction {
+            // Cancel the ongoing request, if present.
+            event.doc.document_symbols_controller.cancel();
+            let view_id = event.view;
+            let doc_id = event.doc.id();
+            job::dispatch_blocking(move |editor, _| {
+                request_document_symbols(editor, doc_id);
+                if let Some(doc) = editor.document_mut(doc_id) {
+                    doc.update_breadcrumbs_for_view(view_id);
+                }
+            });
+        }
+        Ok(())
+    });
+
+    register_hook!(move |event: &mut LanguageServerInitialized<'_>| {
+        let view_id = event.editor.tree.focus;
+        if let Some(view) = event.editor.tree.try_get(view_id) {
+            let doc_id = view.doc;
+            request_document_symbols(event.editor, doc_id);
+            if let Some(doc) = event.editor.document_mut(doc_id) {
+                doc.update_breadcrumbs_for_view(view_id);
+            }
+        }
+        Ok(())
+    });
+
+    register_hook!(move |event: &mut LanguageServerExited<'_>| {
+        for doc in event.editor.documents_mut() {
+            if doc.supports_language_server(event.server_id) {
+                doc.clear_document_symbols();
+            }
+        }
+        Ok(())
+    });
+
+    register_hook!(move |event: &mut ConfigDidChange<'_>| {
+        if !event.old.breadcrumb.enable && event.new.breadcrumb.enable {
+            let view_id = event.editor.tree.focus;
+            if let Some(view) = event.editor.tree.try_get(view_id) {
+                let doc_id = view.doc;
+                request_document_symbols(event.editor, doc_id);
+                if let Some(doc) = event.editor.document_mut(doc_id) {
+                    doc.update_breadcrumbs_for_view(view_id);
+                }
+            }
+            return Ok(());
+        }
+
+        if event.old.breadcrumb.enable && !event.new.breadcrumb.enable {
+            for doc in event.editor.documents_mut() {
+                doc.clear_document_symbols();
+            }
+        }
+
+        Ok(())
+    });
+
+    register_hook!(move |event: &mut SelectionDidChange<'_>| {
+        let doc_id = event.doc.id();
+        let view_id = event.view;
+
+        job::dispatch_blocking(move |editor, _| {
+            if let Some(doc) = editor.document_mut(doc_id) {
+                doc.update_breadcrumbs_for_view_inlined(view_id);
+            }
+        });
+        Ok(())
+    });
+}

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -75,6 +75,7 @@ impl EditorView {
         &mut self.spinners
     }
 
+    #[allow(clippy::too_many_lines)]
     pub fn render_view(
         &self,
         editor: &Editor,
@@ -94,6 +95,10 @@ impl EditorView {
 
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
+
+        if config.breadcrumb.enable {
+            Self::render_breadcrumb(editor, doc, view, area.with_height(1), surface);
+        }
 
         if is_focused && config.cursorline {
             decorations.add_decoration(Self::cursorline(doc, view, theme));
@@ -714,7 +719,13 @@ impl EditorView {
     }
 
     #[allow(clippy::too_many_lines)]
-    pub fn render_breadcrumb(editor: &Editor, viewport: Rect, surface: &mut Surface) {
+    pub fn render_breadcrumb(
+        editor: &Editor,
+        doc: &Document,
+        view: &View,
+        viewport: Rect,
+        surface: &mut Surface,
+    ) {
         use helix_view::editor::BreadcrumbPathOptions::{File, Full};
 
         #[inline]
@@ -732,11 +743,6 @@ impl EditorView {
                 .0
         }
 
-        let (view, _) = current_ref!(editor);
-        let Some(doc) = editor.document(view.doc) else {
-            return;
-        };
-
         let config = editor.config();
 
         let style = editor
@@ -746,7 +752,7 @@ impl EditorView {
 
         surface.clear_with(viewport, style);
 
-        let mut x = viewport.x;
+        let mut x = viewport.x.saturating_add(1);
 
         let separator = " > ";
         let separator_style = editor.theme.get("ui.breadcrumb.separator");
@@ -1756,15 +1762,9 @@ impl Component for EditorView {
             _ => false,
         };
 
-        let render_breadcrumb = config.breadcrumb.enable;
-
         // -1 for commandline and -1 for bufferline
         let mut editor_area = area.clip_bottom(1);
         if use_bufferline {
-            editor_area = editor_area.clip_top(1);
-        }
-
-        if render_breadcrumb {
             editor_area = editor_area.clip_top(1);
         }
 
@@ -1773,16 +1773,6 @@ impl Component for EditorView {
 
         if use_bufferline {
             Self::render_bufferline(cx.editor, area.with_height(1), surface);
-        }
-
-        if render_breadcrumb {
-            let area = area
-                .with_height(1)
-                // Position it at y=1 if bufferline is used, otherwise y=0
-                .with_y(if use_bufferline { area.y + 1 } else { area.y })
-                // Adds padding to the start of the breadcrumb.
-                .clip_left(1);
-            Self::render_breadcrumb(cx.editor, area, surface);
         }
 
         for (view, is_focused) in cx.editor.tree.views() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -22,10 +22,11 @@ use helix_core::{
     unicode::width::UnicodeWidthStr,
     visual_offset_from_block, Change, Position, Range, Selection, Transaction,
 };
+use helix_lsp::lsp::SymbolKind;
 use helix_view::{
     annotations::diagnostics::DiagnosticFilter,
     document::{Mode, SCRATCH_BUFFER_NAME},
-    editor::{CompleteAction, CursorShapeConfig},
+    editor::{BufferLine, CompleteAction, CursorShapeConfig},
     graphics::{Color, CursorKind, Modifier, Rect, Style},
     input::{KeyEvent, MouseButton, MouseEvent, MouseEventKind},
     keyboard::{KeyCode, KeyModifiers},
@@ -708,6 +709,134 @@ impl EditorView {
 
             if x >= surface.area.right() {
                 break;
+            }
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub fn render_breadcrumb(editor: &Editor, viewport: Rect, surface: &mut Surface) {
+        use helix_view::editor::BreadcrumbPathOptions::{File, Full};
+
+        #[inline]
+        #[must_use]
+        fn draw_element(
+            surface: &mut Surface,
+            viewport: Rect,
+            x: u16,
+            content: &str,
+            style: Style,
+        ) -> u16 {
+            let remaining = viewport.right().saturating_sub(x) as usize;
+            surface
+                .set_stringn(x, viewport.y, content, remaining, style)
+                .0
+        }
+
+        let (view, _) = current_ref!(editor);
+        let Some(doc) = editor.document(view.doc) else {
+            return;
+        };
+
+        let config = editor.config();
+
+        let style = editor
+            .theme
+            .try_get_exact("ui.breadcrumb")
+            .unwrap_or_else(|| editor.theme.get("ui.text"));
+
+        surface.clear_with(viewport, style);
+
+        let mut x = viewport.x;
+
+        let separator = " > ";
+        let separator_style = editor.theme.get("ui.breadcrumb.separator");
+        let mut draw_separator = false;
+
+        if matches!(config.breadcrumb.path, Full | File) {
+            if let Some(path) = doc.relative_path() {
+                let mut components = path.components().peekable();
+
+                if matches!(config.breadcrumb.path, File) {
+                    // Skip until the filename component.
+                    //
+                    // NOTE:
+                    // We could use `next_back` to get this element directly, but
+                    // this keeps our logic below simpler, with the logic for `Full`
+                    // and `File` being the same below this point.
+                    //
+                    // PERF: The `clone` is cheap; should be equivalent to a `Copy`.
+                    while components.clone().nth(1).is_some() {
+                        components.next();
+                    }
+                }
+
+                while let Some(component) = components.next() {
+                    if draw_separator {
+                        x = draw_element(surface, viewport, x, separator, separator_style);
+                    } else {
+                        draw_separator = true;
+                    }
+
+                    let segment = component.as_os_str().to_string_lossy();
+                    let is_directory = components.peek().is_some();
+
+                    let style = if is_directory {
+                        editor.theme.get("ui.text.directory")
+                    } else {
+                        style
+                    };
+
+                    x = draw_element(surface, viewport, x, &segment, style);
+                }
+            } else {
+                // Handle `[scratch]`
+                x = draw_element(surface, viewport, x, SCRATCH_BUFFER_NAME, style);
+            }
+        }
+
+        // Draw symbols, if any.
+        if let Some(breadcrumb) = doc.breadcrumbs.get(&view.id) {
+            for symbol in breadcrumb.iter() {
+                if draw_separator {
+                    x = draw_element(surface, viewport, x, separator, separator_style);
+                } else {
+                    draw_separator = true;
+                }
+
+                let style = match symbol.kind {
+                    SymbolKind::MODULE
+                    | SymbolKind::NAMESPACE
+                    | SymbolKind::PACKAGE => editor.theme.get("namespace"),
+
+                    SymbolKind::OBJECT // impl Block
+                    | SymbolKind::STRUCT
+                    | SymbolKind::INTERFACE
+                    | SymbolKind::CLASS => editor.theme.get("type"),
+
+                    SymbolKind::METHOD => editor.theme.get("function.method"),
+                    SymbolKind::FUNCTION => editor.theme.get("function"),
+
+                    SymbolKind::ENUM => editor.theme.get("type.enum"),
+                    SymbolKind::ENUM_MEMBER => editor.theme.get("type.enum.variant"),
+
+                   SymbolKind::FIELD | SymbolKind::PROPERTY => {
+                        editor.theme.get("variable.other.member")
+                    }
+
+                    SymbolKind::VARIABLE => editor.theme.get("variable"),
+                    SymbolKind::CONSTANT => editor.theme.get("constant"),
+                    SymbolKind::CONSTRUCTOR => editor.theme.get("constructor"),
+                    SymbolKind::STRING => editor.theme.get("string"),
+                    SymbolKind::NUMBER => editor.theme.get("constant.numeric"),
+                    SymbolKind::BOOLEAN => editor.theme.get("constant.builtin.boolean"),
+                    SymbolKind::ARRAY => editor.theme.get("punctuation.bracket"),
+                    SymbolKind::KEY => editor.theme.get("label"),
+                    SymbolKind::NULL => editor.theme.get("constant.builtin"),
+                    SymbolKind::TYPE_PARAMETER => editor.theme.get("type.parameter"),
+                    _ => style,
+                };
+
+                x = draw_element(surface, viewport, x, symbol.name.as_ref(), style);
             }
         }
     }
@@ -1621,16 +1750,21 @@ impl Component for EditorView {
         let config = cx.editor.config();
 
         // check if bufferline should be rendered
-        use helix_view::editor::BufferLine;
         let use_bufferline = match config.bufferline {
             BufferLine::Always => true,
             BufferLine::Multiple if cx.editor.documents.len() > 1 => true,
             _ => false,
         };
 
+        let render_breadcrumb = config.breadcrumb.enable;
+
         // -1 for commandline and -1 for bufferline
         let mut editor_area = area.clip_bottom(1);
         if use_bufferline {
+            editor_area = editor_area.clip_top(1);
+        }
+
+        if render_breadcrumb {
             editor_area = editor_area.clip_top(1);
         }
 
@@ -1639,6 +1773,16 @@ impl Component for EditorView {
 
         if use_bufferline {
             Self::render_bufferline(cx.editor, area.with_height(1), surface);
+        }
+
+        if render_breadcrumb {
+            let area = area
+                .with_height(1)
+                // Position it at y=1 if bufferline is used, otherwise y=0
+                .with_y(if use_bufferline { area.y + 1 } else { area.y })
+                // Adds padding to the start of the breadcrumb.
+                .clip_left(1);
+            Self::render_breadcrumb(cx.editor, area, surface);
         }
 
         for (view, is_focused) in cx.editor.tree.views() {

--- a/helix-term/tests/test/commands/write.rs
+++ b/helix-term/tests/test/commands/write.rs
@@ -284,7 +284,7 @@ async fn test_write_quit() -> anyhow::Result<()> {
 async fn test_write_concurrent() -> anyhow::Result<()> {
     let mut file = tempfile::NamedTempFile::new()?;
     let mut command = String::new();
-    const RANGE: RangeInclusive<i32> = 1..=1000;
+    const RANGE: RangeInclusive<i32> = 1..=100;
     let mut app = helpers::AppBuilder::new()
         .with_file(file.path(), None)
         .build()?;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -13,6 +13,7 @@ use helix_core::snippets::{ActiveSnippet, SnippetRenderCtx};
 use helix_core::syntax::config::LanguageServerFeature;
 use helix_core::text_annotations::{InlineAnnotation, Overlay};
 use helix_event::TaskController;
+use helix_lsp::lsp::DocumentSymbol;
 use helix_lsp::util::lsp_pos_to_pos;
 use helix_stdx::faccess::{copy_metadata, readonly};
 use helix_vcs::{DiffHandle, DiffProviderRegistry};
@@ -149,15 +150,22 @@ pub struct Document {
     ///
     /// To know if they're up-to-date, check the `id` field in `DocumentInlayHints`.
     pub(crate) inlay_hints: HashMap<ViewId, DocumentInlayHints>,
+    /// Set to `true` when the document is updated, reset to `false` on the next inlay hints
+    /// update from the LSP
+    pub inlay_hints_oudated: bool,
+
     /// Jump label overlays for each view.
     pub(crate) jump_labels: HashMap<ViewId, Vec<Overlay>>,
+
     /// LSP document highlights for each view, stored as char ranges.
     pub(crate) document_highlights: HashMap<ViewId, DocumentHighlights>,
     /// LSP code action hints for each view.
     pub(crate) code_action_hints: HashSet<ViewId>,
-    /// Set to `true` when the document is updated, reset to `false` on the next inlay hints
-    /// update from the LSP
-    pub inlay_hints_oudated: bool,
+
+    // Stores all the symbols of the Document.
+    pub(crate) symbols: Option<DocumentSymbolCache>,
+    /// Breadcrumb trail for each view showing this document.
+    pub breadcrumbs: HashMap<ViewId, Breadcrumbs>,
 
     path: Option<PathBuf>,
     relative_path: OnceCell<Option<PathBuf>>,
@@ -229,11 +237,89 @@ pub struct Document {
     pub code_action_controllers: HashMap<ViewId, TaskController>,
     pub pull_diagnostic_controller: TaskController,
     pub document_link_controller: TaskController,
+    pub document_symbols_controller: TaskController,
 
     // NOTE: this field should eventually go away - we should use the Editor's syn_loader instead
     // of storing a copy on every doc. Then we can remove the surrounding `Arc` and use the
     // `ArcSwap` directly.
     syn_loader: Arc<ArcSwap<syntax::Loader>>,
+}
+
+pub struct DocumentSymbolCache {
+    pub tree: Vec<ThinDocumentSymbol>,
+    pub offset_encoding: OffsetEncoding,
+}
+
+#[derive(Debug, Clone)]
+pub struct ThinDocumentSymbol {
+    pub name: Box<str>,
+    pub kind: lsp::SymbolKind,
+    pub range: lsp::Range,
+    pub children: Option<Box<[Self]>>,
+}
+
+impl From<DocumentSymbol> for ThinDocumentSymbol {
+    #[inline]
+    fn from(symbol: DocumentSymbol) -> Self {
+        Self {
+            name: symbol.name.into(),
+            kind: symbol.kind,
+            range: symbol.range,
+            children: symbol.children.map(|children| {
+                let mut vec = Vec::with_capacity(children.len());
+                vec.extend(children.into_iter().map(Self::from));
+                vec.into_boxed_slice()
+            }),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Breadcrumbs(Vec<Crumb>);
+
+impl Breadcrumbs {
+    #[inline]
+    pub fn push(&mut self, crumb: Crumb) {
+        self.0.push(crumb);
+    }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0.clear();
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
+    #[must_use]
+    pub const fn depth(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &Crumb> {
+        self.0.iter()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Crumb {
+    pub name: Box<str>,
+    pub kind: lsp::SymbolKind,
+}
+
+impl From<&ThinDocumentSymbol> for Crumb {
+    #[inline]
+    fn from(symbol: &ThinDocumentSymbol) -> Self {
+        Self {
+            name: symbol.name.clone(),
+            kind: symbol.kind,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -715,7 +801,7 @@ where
     *mut_ref = f(mem::take(mut_ref));
 }
 
-use helix_lsp::{lsp, Client, LanguageServerId, LanguageServerName};
+use helix_lsp::{lsp, Client, LanguageServerId, LanguageServerName, OffsetEncoding};
 use helix_stdx::Url;
 
 impl Document {
@@ -776,6 +862,9 @@ impl Document {
             previous_diagnostic_ids: HashMap::new(),
             pull_diagnostic_controller: TaskController::new(),
             document_link_controller: TaskController::new(),
+            symbols: None,
+            document_symbols_controller: TaskController::new(),
+            breadcrumbs: HashMap::new(),
         }
     }
 
@@ -1436,12 +1525,13 @@ impl Document {
         self.focused_at = std::time::Instant::now();
     }
 
-    /// Remove a view's selection and inlay hints from this document.
+    /// Remove any views' data and state that is stored in the `Document`.
     pub fn remove_view(&mut self, view_id: ViewId) {
         self.selections.remove(&view_id);
         self.view_data.remove(&view_id);
         self.inlay_hints.remove(&view_id);
         self.jump_labels.remove(&view_id);
+        self.breadcrumbs.remove(&view_id);
         self.document_highlights.remove(&view_id);
         self.document_highlight_controllers.remove(&view_id);
         self.code_action_hints.remove(&view_id);
@@ -2414,6 +2504,103 @@ impl Document {
 
     pub fn remove_jump_labels(&mut self, view_id: ViewId) {
         self.jump_labels.remove(&view_id);
+    }
+
+    #[inline(always)]
+    pub fn set_document_symbols(
+        &mut self,
+        symbols: Vec<DocumentSymbol>,
+        offset_encoding: OffsetEncoding,
+    ) {
+        self.symbols = Some(DocumentSymbolCache {
+            tree: {
+                let mut tree = Vec::with_capacity(symbols.len());
+                tree.extend(symbols.into_iter().map(ThinDocumentSymbol::from));
+                tree
+            },
+            offset_encoding,
+        });
+    }
+
+    #[inline]
+    pub fn clear_document_symbols(&mut self) {
+        self.symbols = None;
+        self.clear_breadcrumbs();
+    }
+
+    #[inline]
+    pub fn clear_breadcrumbs(&mut self) {
+        self.breadcrumbs.clear();
+    }
+
+    // For all non-hotpaths, we use this function to prevent code bloat.
+    #[inline(never)]
+    pub fn update_breadcrumbs_for_view(&mut self, view_id: ViewId) {
+        self.update_breadcrumbs_for_view_inlined(view_id);
+    }
+
+    // We want to make sure this is inlined in the hotpath (cursor position change).
+    #[inline(always)]
+    pub fn update_breadcrumbs_for_view_inlined(&mut self, view_id: ViewId) {
+        #[inline(always)]
+        const fn in_range(pos: lsp::Position, range: lsp::Range) -> bool {
+            // PERF:
+            // Line-based filtering is the most effective early exit indicator,
+            // so do first, before other evaluations; this should be friendly to
+            // the CPU branch predictor.
+            if pos.line < range.start.line || pos.line > range.end.line {
+                return false;
+            }
+
+            // Check if the cursor position is "in" the symbols "depth".
+            //
+            // In the context of breadcrumbs, this would be the difference between
+            // if the cursor is in an impl block or in an impl block and in a
+            // function of the impl block (`|` is the cursor):
+            //
+            // ```rust
+            // impl Foo {
+            //     f|n bar() {} // In `bar`: impl Foo > bar
+            //
+            //   | fn baz() {} // Not in `baz`: impl Foo
+            //
+            //     fn quux() {} | // Not in `quux`: impl Foo
+            // }
+            // ```
+            if pos.line == range.start.line && pos.character < range.start.character {
+                return false;
+            }
+            if pos.line == range.end.line && pos.character > range.end.character {
+                return false;
+            }
+
+            true
+        }
+
+        let Some(symbols) = self.symbols.as_ref() else {
+            return;
+        };
+
+        let position = self.position(view_id, symbols.offset_encoding);
+
+        let breadcrumb = {
+            let breadcrumb = self.breadcrumbs.entry(view_id).or_default();
+            breadcrumb.clear();
+            breadcrumb
+        };
+
+        let mut current = symbols.tree.as_slice();
+
+        while let Some(symbol) = current
+            .iter()
+            .find(|&symbol| in_range(position, symbol.range))
+        {
+            breadcrumb.push(Crumb::from(symbol));
+            match symbol.children.as_deref() {
+                Some(children) => current = children,
+                _ => break,
+            }
+        }
     }
 
     pub fn set_document_highlights(

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1518,6 +1518,10 @@ impl Document {
         }
 
         self.view_data_mut(view_id);
+
+        if self.config.load().breadcrumb.enable {
+            self.update_breadcrumbs_for_view(view_id);
+        }
     }
 
     /// Mark document as recent used for MRU sorting

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -385,6 +385,8 @@ pub struct Config {
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
     pub bufferline: BufferLine,
+    /// Persistently display breadcrumb along the top, below any bufferline.
+    pub breadcrumb: BreadcrumbConfig,
     /// Vertical indent width guides.
     pub indent_guides: IndentGuidesConfig,
     /// Whether to color modes with different colors. Defaults to `false`.
@@ -511,6 +513,23 @@ impl Config {
                 .right
                 .contains(&StatusLineElement::CodeActionHint)
     }
+}
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub struct BreadcrumbConfig {
+    pub enable: bool,
+    #[serde(default)]
+    pub path: BreadcrumbPathOptions,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum BreadcrumbPathOptions {
+    #[default]
+    Full,
+    File,
+    None,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -1213,6 +1232,7 @@ impl Default for Config {
             rulers: Vec::new(),
             whitespace: WhitespaceConfig::default(),
             bufferline: BufferLine::default(),
+            breadcrumb: BreadcrumbConfig::default(),
             indent_guides: IndentGuidesConfig::default(),
             color_modes: false,
             soft_wrap: SoftWrap {
@@ -1810,6 +1830,7 @@ impl Editor {
         let diagnostics = Editor::doc_diagnostics(&self.language_servers, &self.diagnostics, doc);
         doc.replace_diagnostics(diagnostics, &[], None);
         doc.reset_all_inlay_hints();
+        doc.clear_document_symbols();
     }
 
     /// Launch a language server for a given document

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -385,7 +385,7 @@ pub struct Config {
     pub whitespace: WhitespaceConfig,
     /// Persistently display open buffers along the top
     pub bufferline: BufferLine,
-    /// Persistently display breadcrumb along the top, below any bufferline.
+    /// Persistently display breadcrumb along the top of each view, below any bufferline.
     pub breadcrumb: BreadcrumbConfig,
     /// Vertical indent width guides.
     pub indent_guides: IndentGuidesConfig,

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -200,6 +200,12 @@ impl Rect {
         }
     }
 
+    #[inline]
+    pub fn with_y(self, y: u16) -> Rect {
+        // new y may make area > u16::max_value, so use new()
+        Self::new(self.x, y, self.width, self.height)
+    }
+
     pub fn with_height(self, height: u16) -> Rect {
         // new height may make area > u16::max_value, so use new()
         Self::new(self.x, self.y, self.width, height)

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -242,9 +242,10 @@ pub fn breakpoints<'doc>(
 
     let breakpoints = doc.path().and_then(|path| editor.breakpoints.get(path));
 
-    let breakpoints = match breakpoints {
-        Some(breakpoints) => breakpoints,
-        None => return Box::new(move |_, _, _, _| None),
+    let breadcrumbs_enabled = editor.config().breadcrumb.enable;
+
+    let Some(breakpoints) = breakpoints else {
+        return Box::new(move |_, _, _, _| None);
     };
 
     Box::new(
@@ -254,7 +255,7 @@ pub fn breakpoints<'doc>(
             }
             let breakpoint = breakpoints
                 .iter()
-                .find(|breakpoint| breakpoint.line == line)?;
+                .find(|breakpoint| breakpoint.line == line + usize::from(breadcrumbs_enabled))?;
 
             let style = if breakpoint.condition.is_some() && breakpoint.log_message.is_some() {
                 error.underline_style(UnderlineStyle::Line)

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -208,11 +208,18 @@ impl View {
     }
 
     pub fn inner_area(&self, doc: &Document) -> Rect {
-        self.area.clip_left(self.gutter_offset(doc)).clip_bottom(1) // -1 for statusline
+        self.area
+            .clip_top(self.breadcrumb_offset(doc))
+            .clip_left(self.gutter_offset(doc))
+            .clip_bottom(1) // -1 for statusline
     }
 
-    pub fn inner_height(&self) -> usize {
-        self.area.clip_bottom(1).height.into() // -1 for statusline
+    pub fn inner_height(&self, doc: &Document) -> usize {
+        self.area
+            .clip_top(self.breadcrumb_offset(doc))
+            .clip_bottom(1) // -1 for statusline
+            .height
+            .into()
     }
 
     pub fn inner_width(&self, doc: &Document) -> u16 {
@@ -237,7 +244,10 @@ impl View {
         }
     }
 
-    //
+    pub fn breadcrumb_offset(&self, doc: &Document) -> u16 {
+        u16::from(doc.config.load().breadcrumb.enable)
+    }
+
     pub fn offset_coords_to_in_view(
         &self,
         doc: &Document,
@@ -378,7 +388,7 @@ impl View {
         let doc_text = doc.text().slice(..);
         let line = doc_text.char_to_line(doc.view_offset(self.id).anchor.min(doc_text.len_chars()));
         // Saturating subs to make it inclusive zero indexing.
-        (line + self.inner_height())
+        (line + self.inner_height(doc))
             .min(doc_text.len_lines())
             .saturating_sub(1)
     }


### PR DESCRIPTION
This PR implements a breadcrumb navigation bar at the top of the editor.

Breadcrumbs are common in other editors:
- [VSCode](https://code.visualstudio.com/docs/editing/editingevolved#_breadcrumbs)
- [Zed](https://zed.dev/features)
-  [LunarVim](https://www.lunarvim.org/)
- [AstroVim](https://astronvim.com/)
- [JetBrains IDEA](https://www.jetbrains.com/help/idea/using-code-editor.html#breadcrumbs)
- [Xcode](https://developer.apple.com/xcode)

The main use for them is to help contextualize the current cursor scope, which can be hidden from all other context clues.  For me personally, this alone can replace the statusline path information completely as well.

The commits should hopefully be re-viewable in order. I started by setting up the machinery in the event system to get the symbols for a document. I did need to add a new capability to tell LSPs that we support trees as a response. Without this setting, only a flat structure will be returned. I have testing this with `rust-analyzer` and it works as I expect. There was care to hopefully properly cache the symbols in the `Document` without constantly spamming the server. The symbols are kept in a tree structure for later traversal. I did make a note that perhaps this can work with flat structures too, for LSPs that don't support the nested data return, but will leave this for later. This gets the symbols from the first LSP that supports it, as i'm not sure how we would even handle multiple symbols and which gets priority that wouldn't just be the first priority anyways. One unfortunate thing here is that the `DocumentSymbol` is quite large(136 bytes). When storing lots of symbols, this can take up a lot of memory unnecessarily. I would love to go over ways we can optimize the size and/or the use to try to get this down. 

I then set up the actual breadcrumb logic, but not yet add the UI element. This part is pretty straight forward. There are separate breadcrumbs for each view of the document, as is standard. After that, it was mainly just setting up an event that monitors the selection change, and then walks the tree to get the new symbols in the breadcrumb. `Breadcrumb` wraps a `Vec` and reuses the buffer so that allocations are kept to a minimum. One thing to be aware of is that I did not add a depth limit. This should be fine, with most nesting only being around 2 or 3, with some of the most common deep ones being 5-7, but this could hit a pathological situation, from generated code, for example. But it was simpler to implement this way. I added a configuration to enable the breadcrumb gathering. It defaults to `false`, meaning its disabled. There shouldn't be any extra overhead while disabled.

Finally, I added the UI element. This part is also straight forward. Just access the document and traverse the symbols for the view. Inline with other common breadcrumb implementations, I have added the relative path at the beginning. This helps the goal of adding navigational context, as there could be similar code in multiple places, so the path really is part of where the cursor is. The theming is to help the symbols pop more when looking, and take from the already defined theme keys. Its not perfect, as seen in the examples showing an `impl` block, but its better than just plain text. Extending this, I applied the directory theme to the path elements as well, fulfilling the visual expectation. Im also not sure if I matched up the themes to the items as they should, but this is easy to fix in followup PRs if anyone notices something strange.

The documentation still needs to be fleshed out, but I need help figuring out how the theme structure should be. Once that is done, I can implement it and add to the documentation.

AI Disclosure: I needed help finding the LSP capabilities part that would enable the hierarchical symbol configuration. I didn't know what it would be called, though in hindsight its incredibly obvious.

Much of this was taken from @matoous in #15221. Thanks for your work!

Examples:

<img width="118" height="126" alt="image" src="https://github.com/user-attachments/assets/14aca033-3ba2-4511-97dc-7af779daf6c2" />

<img width="946" height="579" alt="image" src="https://github.com/user-attachments/assets/5a5223c5-2c8f-4a79-a802-d5540e880ffd" />

<img width="946" height="579" alt="image" src="https://github.com/user-attachments/assets/0b124213-b308-4e17-a80a-9333bbabb850" />

<img width="946" height="528" alt="image" src="https://github.com/user-attachments/assets/9338d858-82c4-44cd-b0e0-21a65e7c2bad" />


I did set this up in my daily driver, and added icons. This looks much better to me, but it waits on #12369 to be completed.

https://github.com/user-attachments/assets/5e3cd5e4-c0c6-4123-ae9b-97394485b082

Related: #13492
Related: #8407
Related: #6118
