### PR TITLE
fix(lsp): don't send `null` in textDocument/diagnostic previousResultId

### DIFF
--- a/helix-lsp-types/src/document_diagnostic.rs
+++ b/helix-lsp-types/src/document_diagnostic.rs
@@ -108,6 +108,7 @@ pub struct DocumentDiagnosticParams {
     pub identifier: Option<Arc<str>>,
 
     /// The result ID of a previous response if provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub previous_result_id: Option<String>,
 
     #[serde(flatten)]


### PR DESCRIPTION
fixes #15577 by just skipping serialization if previousResultId is `None` instead of sending a `null`.