### PR TITLE
feat: add i18n support with zh-CN and zh-TW translations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "base62"
+version = "2.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd637ac531c60eb7fbc4684dc061c2d7d90d73d758181aa02eeff0464b9eee4b"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,7 +254,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "crossterm_winapi",
  "futures-core",
  "mio",
@@ -672,7 +684,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "441a300bc3645a1f45cba495b9175f90f47256ce43f2ee161da0031e3ac77c92"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-path",
  "libc",
@@ -821,7 +833,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-features",
  "gix-path",
@@ -869,7 +881,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b28482b86662c8b78160e0750b097a35fd61185803a960681351b3a07de07e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "filetime",
  "fnv",
@@ -993,7 +1005,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e7636782b35bb1d3ade19ea7387278e96fd49f6963ab41bfca81cef4b61b20"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bstr",
  "gix-attributes",
  "gix-config-value",
@@ -1108,7 +1120,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e014df75f3d7f5c98b18b45c202422da6236a1c0c0a50997c3f41e601f3ad511"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "gix-path",
  "libc",
  "windows-sys 0.61.2",
@@ -1206,7 +1218,7 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c99b3cf9dc87c13f1404e7b0e8c5e4bff4975d6f788831c02d6c006f3c76b4a0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "gix-commitgraph",
  "gix-date",
  "gix-hash",
@@ -1268,6 +1280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1296,17 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e3af942408868f6934a7b85134a3230832b9977cf66125df2f9edcfce4ddcc"
+dependencies = [
+ "bitflags 1.3.2",
+ "ignore",
+ "walkdir",
 ]
 
 [[package]]
@@ -1376,7 +1405,7 @@ version = "25.7.1"
 dependencies = [
  "anyhow",
  "arc-swap",
- "bitflags",
+ "bitflags 2.11.0",
  "chrono",
  "encoding_rs",
  "foldhash 0.2.0",
@@ -1400,7 +1429,7 @@ dependencies = [
  "smallvec",
  "smartstring",
  "textwrap",
- "toml",
+ "toml 1.1.1+spec-1.1.0",
  "tree-house",
  "unicode-general-category",
  "unicode-segmentation",
@@ -1464,7 +1493,7 @@ dependencies = [
  "serde",
  "tempfile",
  "threadpool",
- "toml",
+ "toml 1.1.1+spec-1.1.0",
  "tree-house",
 ]
 
@@ -1496,7 +1525,7 @@ dependencies = [
 name = "helix-lsp-types"
 version = "0.95.1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "serde",
  "serde_json",
  "url",
@@ -1510,7 +1539,7 @@ version = "25.7.1"
 name = "helix-stdx"
 version = "25.7.1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "dunce",
  "etcetera",
  "once_cell",
@@ -1558,6 +1587,7 @@ dependencies = [
  "open",
  "parking_lot",
  "pulldown-cmark",
+ "rust-i18n",
  "same-file",
  "serde",
  "serde_json",
@@ -1570,7 +1600,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 1.1.1+spec-1.1.0",
  "url",
 ]
 
@@ -1578,7 +1608,7 @@ dependencies = [
 name = "helix-tui"
 version = "25.7.1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cassowary",
  "crossterm",
  "helix-core",
@@ -1612,7 +1642,7 @@ version = "25.7.1"
 dependencies = [
  "anyhow",
  "arc-swap",
- "bitflags",
+ "bitflags 2.11.0",
  "chardetng",
  "clipboard-win",
  "crossterm",
@@ -1639,7 +1669,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 1.1.1+spec-1.1.0",
  "url",
 ]
 
@@ -1902,6 +1932,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,7 +2040,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "redox_syscall",
 ]
@@ -2097,6 +2142,15 @@ name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "normpath"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf23ab2b905654b4cb177e30b629937b3868311d4e1cba859f899c041046e69b"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "nucleo"
@@ -2265,7 +2319,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "memchr",
  "unicase",
 ]
@@ -2345,7 +2399,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -2456,12 +2510,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-i18n"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda2551fdfaf6cc5ee283adc15e157047b92ae6535cf80f6d4962d05717dc332"
+dependencies = [
+ "globwalk",
+ "once_cell",
+ "regex",
+ "rust-i18n-macro",
+ "rust-i18n-support",
+ "smallvec",
+]
+
+[[package]]
+name = "rust-i18n-macro"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22baf7d7f56656d23ebe24f6bb57a5d40d2bce2a5f1c503e692b5b2fa450f965"
+dependencies = [
+ "glob",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "rust-i18n-support",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "syn",
+]
+
+[[package]]
+name = "rust-i18n-support"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940ed4f52bba4c0152056d771e563b7133ad9607d4384af016a134b58d758f19"
+dependencies = [
+ "arc-swap",
+ "base62",
+ "globwalk",
+ "itertools",
+ "lazy_static",
+ "normpath",
+ "once_cell",
+ "proc-macro2",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "siphasher",
+ "toml 0.8.23",
+ "triomphe",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2474,7 +2582,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -2486,6 +2594,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2553,11 +2667,33 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2650,6 +2786,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -2800,7 +2942,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49b3d294d994319c4cd8c30f2172aab3217db673bb057912dc383677372830"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "futures-core",
  "parking_lot",
  "rustix 1.1.4",
@@ -2923,17 +3065,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "994b95d9e7bae62b34bab0e2a4510b801fa466066a6a8b2b57361fa1eba068ee"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2946,6 +3109,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.14",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,6 +3130,12 @@ checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
 dependencies = [
  "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -2988,6 +3171,17 @@ dependencies = [
  "regex-cursor",
  "ropey",
  "thiserror",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+dependencies = [
+ "arc-swap",
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3070,6 +3264,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -3241,7 +3441,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -3498,7 +3698,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3539,7 +3739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -3589,7 +3789,7 @@ dependencies = [
  "helix-loader",
  "helix-term",
  "helix-view",
- "toml",
+ "toml 1.1.1+spec-1.1.0",
 ]
 
 [[package]]

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -52,6 +52,7 @@ helix-loader = { path = "../helix-loader" }
 
 anyhow = "1"
 once_cell = "1.21"
+rust-i18n = "3"
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["termina", "crossterm"] }

--- a/helix-term/i18n/en.yml
+++ b/helix-term/i18n/en.yml
@@ -1,0 +1,935 @@
+' 1 sel ': ' 1 sel '
+' W ': ' W '
+' [readonly] ': ' [readonly] '
+' char': ' char'
+' chars': ' chars'
+' reg={} ': ' reg={} '
+' sel ': ' sel '
+' sels ': ' sels '
+' set to ': ' set to '
+' space': ' space'
+' spaces': ' spaces'
+' tabs ': ' tabs '
+'''{key}'' is now set to {value}': '''{key}'' is now set to {value}'
+'''{}'' not found in $PATH': '''{}'' not found in $PATH'
+'''{}'' written, {lines}L {size}': '''{}'' written, {lines}L {size}'
+(X)HTML element (tree-sitter): (X)HTML element (tree-sitter)
+'... or any character acting as a pair': '... or any character acting as a pair'
+1 space: 1 space
+<Binary file>: <Binary file>
+<File not found>: <File not found>
+<File too large to preview>: <File too large to preview>
+<Invalid directory location>: <Invalid directory location>
+<Invalid file location>: <Invalid file location>
+Add current workspace to the list of trusted workspaces.: Add current workspace to the list of trusted workspaces.
+Add newline above: Add newline above
+Add newline below: Add newline below
+Add next search match to selection: Add next search match to selection
+Add previous search match to selection: Add previous search match to selection
+Align selections in column: Align selections in column
+Align view bottom: Align view bottom
+Align view center: Align view center
+Align view middle: Align view middle
+Align view top: Align view top
+All registers cleared: All registers cleared
+Already at line end: Already at line end
+Already at line start: Already at line start
+Already at newest change: Already at newest change
+Already at oldest change: Already at oldest change
+Always: Always
+Append after selection: Append after selection
+Append an interactively-chosen char: Append an interactively-chosen char
+Append shell command output after selections: Append shell command output after selections
+Argument/parameter (tree-sitter): Argument/parameter (tree-sitter)
+Auto-save failed: Auto-save failed
+'Bad arguments. For boolean configurations use: `:toggle {key}`': 'Bad arguments. For boolean configurations use: `:toggle {key}`'
+'Bad arguments. For string configurations use: `:toggle {key} val1 val2 ...`': 'Bad arguments. For string configurations use: `:toggle {key} val1 val2 ...`'
+Block comment/uncomment selections: Block comment/uncomment selections
+Buffer not modified: Buffer not modified
+'Can''t set breakpoint: document has no path': 'Can''t set breakpoint: document has no path'
+Cannot abort: Cannot abort
+Cannot accept: Cannot accept
+Cannot access variables while target is running.: Cannot access variables while target is running.
+Cannot acquire: Cannot acquire
+Cannot add: Cannot add
+Cannot add hook: Cannot add hook
+Cannot allocate: Cannot allocate
+Cannot apply: Cannot apply
+Cannot authenticate: Cannot authenticate
+Cannot authorize: Cannot authorize
+Cannot backup: Cannot backup
+Cannot begin: Cannot begin
+Cannot benchmark: Cannot benchmark
+Cannot bind: Cannot bind
+Cannot blame: Cannot blame
+Cannot block: Cannot block
+Cannot branch: Cannot branch
+Cannot bridge: Cannot bridge
+Cannot broadcast: Cannot broadcast
+Cannot buffer: Cannot buffer
+Cannot calculate: Cannot calculate
+Cannot cancel: Cannot cancel
+Cannot capture: Cannot capture
+Cannot catch: Cannot catch
+Cannot change directory: Cannot change directory
+Cannot check: Cannot check
+Cannot checkout: Cannot checkout
+Cannot cherry-pick: Cannot cherry-pick
+Cannot clear state: Cannot clear state
+Cannot clock: Cannot clock
+Cannot clone: Cannot clone
+Cannot close: Cannot close
+Cannot close connection: Cannot close connection
+Cannot commit: Cannot commit
+Cannot complete: Cannot complete
+Cannot compress: Cannot compress
+Cannot compute: Cannot compute
+Cannot connect: Cannot connect
+Cannot connect to server: Cannot connect to server
+Cannot convert: Cannot convert
+Cannot create: Cannot create
+Cannot create directory: Cannot create directory
+Cannot deallocate: Cannot deallocate
+Cannot decode: Cannot decode
+Cannot decompress: Cannot decompress
+Cannot decrypt: Cannot decrypt
+Cannot default: Cannot default
+Cannot delete file: Cannot delete file
+Cannot deliver: Cannot deliver
+Cannot dequeue: Cannot dequeue
+Cannot describe: Cannot describe
+Cannot destroy: Cannot destroy
+Cannot detect: Cannot detect
+Cannot determine: Cannot determine
+Cannot diff: Cannot diff
+Cannot disconnect: Cannot disconnect
+Cannot disconnect from server: Cannot disconnect from server
+Cannot dispatch: Cannot dispatch
+Cannot download: Cannot download
+Cannot emit hook: Cannot emit hook
+Cannot encode: Cannot encode
+Cannot encrypt: Cannot encrypt
+Cannot end: Cannot end
+Cannot enqueue: Cannot enqueue
+Cannot epoll: Cannot epoll
+Cannot evaluate: Cannot evaluate
+Cannot eventfd: Cannot eventfd
+Cannot exec: Cannot exec
+Cannot execute: Cannot execute
+Cannot execute command: Cannot execute command
+Cannot execute macro because the [@] register is already playing a macro: Cannot execute macro because the [@] register is already playing a macro
+Cannot fetch: Cannot fetch
+Cannot finalize: Cannot finalize
+Cannot find: Cannot find
+Cannot find current stack frame to access variables: Cannot find current stack frame to access variables
+Cannot find current stack frame to access variables.: Cannot find current stack frame to access variables.
+Cannot finish: Cannot finish
+Cannot fire hook: Cannot fire hook
+Cannot flush connection: Cannot flush connection
+Cannot fork: Cannot fork
+Cannot format: Cannot format
+Cannot forward: Cannot forward
+Cannot free: Cannot free
+Cannot fsevents: Cannot fsevents
+Cannot get handler: Cannot get handler
+Cannot grep: Cannot grep
+Cannot handle: Cannot handle
+Cannot handle notification: Cannot handle notification
+Cannot handle request: Cannot handle request
+Cannot identify: Cannot identify
+Cannot ignore: Cannot ignore
+Cannot init: Cannot init
+Cannot initialize: Cannot initialize
+Cannot initialize connection: Cannot initialize connection
+Cannot inotify: Cannot inotify
+Cannot invoke hook: Cannot invoke hook
+Cannot iocp: Cannot iocp
+Cannot kill: Cannot kill
+Cannot kqueue: Cannot kqueue
+Cannot lex: Cannot lex
+Cannot listen: Cannot listen
+Cannot listen hook: Cannot listen hook
+Cannot load state: Cannot load state
+Cannot locate: Cannot locate
+Cannot lock: Cannot lock
+Cannot log: Cannot log
+Cannot lookup: Cannot lookup
+Cannot match: Cannot match
+Cannot measure: Cannot measure
+Cannot merge: Cannot merge
+Cannot monitor: Cannot monitor
+Cannot notify: Cannot notify
+Cannot notify hook: Cannot notify hook
+Cannot observe: Cannot observe
+Cannot open: Cannot open
+Cannot open connection: Cannot open connection
+Cannot open document: Cannot open document
+Cannot parse: Cannot parse
+Cannot parse response: Cannot parse response
+Cannot pause: Cannot pause
+Cannot peek: Cannot peek
+Cannot play: Cannot play
+Cannot poll: Cannot poll
+Cannot pop: Cannot pop
+Cannot process response: Cannot process response
+Cannot profile: Cannot profile
+Cannot proxy: Cannot proxy
+Cannot publish hook: Cannot publish hook
+Cannot pull: Cannot pull
+Cannot push: Cannot push
+Cannot query: Cannot query
+Cannot queue: Cannot queue
+Cannot raise: Cannot raise
+Cannot read connection: Cannot read connection
+Cannot read file: Cannot read file
+Cannot rebase: Cannot rebase
+Cannot receive: Cannot receive
+Cannot receive response: Cannot receive response
+Cannot reconnect: Cannot reconnect
+Cannot record: Cannot record
+Cannot recover: Cannot recover
+Cannot redirect: Cannot redirect
+Cannot register handler: Cannot register handler
+Cannot relay: Cannot relay
+Cannot release: Cannot release
+Cannot remove: Cannot remove
+Cannot remove hook: Cannot remove hook
+Cannot rename: Cannot rename
+Cannot repeat: Cannot repeat
+Cannot replace: Cannot replace
+Cannot replay: Cannot replay
+Cannot replay from register [: Cannot replay from register [
+Cannot reserve: Cannot reserve
+Cannot reset: Cannot reset
+Cannot reset connection: Cannot reset connection
+Cannot reset state: Cannot reset state
+Cannot resolve: Cannot resolve
+Cannot restore: Cannot restore
+Cannot resume: Cannot resume
+Cannot retry: Cannot retry
+Cannot revert: Cannot revert
+Cannot route: Cannot route
+Cannot run: Cannot run
+Cannot save: Cannot save
+Cannot save state: Cannot save state
+Cannot scan: Cannot scan
+Cannot schedule: Cannot schedule
+Cannot search: Cannot search
+Cannot select: Cannot select
+Cannot send: Cannot send
+Cannot send notification: Cannot send notification
+Cannot send request: Cannot send request
+Cannot send response: Cannot send response
+Cannot serialize request: Cannot serialize request
+Cannot set handler: Cannot set handler
+Cannot show: Cannot show
+Cannot shutdown connection: Cannot shutdown connection
+Cannot sign: Cannot sign
+Cannot signal: Cannot signal
+Cannot signalfd: Cannot signalfd
+Cannot spawn: Cannot spawn
+Cannot split: Cannot split
+Cannot start: Cannot start
+Cannot stash: Cannot stash
+Cannot status: Cannot status
+Cannot stop: Cannot stop
+Cannot stream: Cannot stream
+Cannot subscribe hook: Cannot subscribe hook
+Cannot substitute: Cannot substitute
+Cannot sync: Cannot sync
+Cannot tag: Cannot tag
+Cannot terminate: Cannot terminate
+Cannot terminate connection: Cannot terminate connection
+Cannot test: Cannot test
+Cannot time: Cannot time
+Cannot timerfd: Cannot timerfd
+Cannot tokenize: Cannot tokenize
+Cannot trace: Cannot trace
+Cannot track: Cannot track
+Cannot transform: Cannot transform
+Cannot translate: Cannot translate
+Cannot transmit: Cannot transmit
+Cannot trigger hook: Cannot trigger hook
+Cannot tunnel: Cannot tunnel
+Cannot unblock: Cannot unblock
+Cannot unlock: Cannot unlock
+Cannot unregister handler: Cannot unregister handler
+Cannot unsubscribe hook: Cannot unsubscribe hook
+Cannot unwatch: Cannot unwatch
+Cannot upload: Cannot upload
+Cannot validate: Cannot validate
+Cannot validate response: Cannot validate response
+Cannot verify: Cannot verify
+Cannot wait: Cannot wait
+Cannot waitpid: Cannot waitpid
+Cannot watch: Cannot watch
+Cannot write connection: Cannot write connection
+Cannot write file: Cannot write file
+Cannot write to file: Cannot write to file
+Cannot yield: Cannot yield
+Change: Change
+Change selection: Change selection
+Change selection without yanking: Change selection without yanking
+Change the current working directory.: Change the current working directory.
+Change the editor theme (show current theme if no name specified).: Change the editor theme (show current theme if no name specified).
+Checking config: Checking config
+'Checking language: {lang}': 'Checking language: {lang}'
+Clear and re-render the whole UI: Clear and re-render the whole UI
+Clear given register. If no argument is provided, clear all registers.: Clear given register. If no argument is provided, clear all registers.
+Close all buffers but the currently focused one.: Close all buffers but the currently focused one.
+Close all buffers without quitting.: Close all buffers without quitting.
+Close all views.: Close all views.
+Close the current buffer forcefully, ignoring unsaved changes.: Close the current buffer forcefully, ignoring unsaved changes.
+Close the current buffer.: Close the current buffer.
+Close the current view.: Close the current view.
+Close window: Close window
+Close windows except current: Close windows except current
+Closest surrounding pair (tree-sitter): Closest surrounding pair (tree-sitter)
+Collapse selection into single cursor: Collapse selection into single cursor
+Command run: Command run
+Comment (tree-sitter): Comment (tree-sitter)
+Comment/uncomment selections: Comment/uncomment selections
+Commit changes to new checkpoint: Commit changes to new checkpoint
+'Config directory: {path}': 'Config directory: {path}'
+'Config file: default': 'Config file: default'
+'Config file: {path}': 'Config file: {path}'
+Config refreshed: Config refreshed
+Configuration file malformed: Configuration file malformed
+'Configured language server: {name}': 'Configured language server: {name}'
+Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters.: Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters.
+Continue program execution: Continue program execution
+Copy between two registers: Copy between two registers
+Copy selection on next line: Copy selection on next line
+Copy selection on previous line: Copy selection on previous line
+'Could not change working directory to ''{}'': {err}': 'Could not change working directory to ''{}'': {err}'
+Could not parse field `{}`: Could not parse field `{}`
+Create a new scratch buffer.: Create a new scratch buffer.
+Current buffer has no parent and current working directory does not exist: Current buffer has no parent and current working directory does not exist
+Current buffer has no parent, opening file explorer in current working directory: Current buffer has no parent, opening file explorer in current working directory
+Current buffer has no parent, opening file picker in current working directory: Current buffer has no parent, opening file picker in current working directory
+Current working directory does not exist: Current working directory does not exist
+Current working directory is now {}: Current working directory is now {}
+Current working directory is {}: Current working directory is {}
+Currently active thread is not stopped. Switch the thread.: Currently active thread is not stopped. Switch the thread.
+'Data directory: {path}': 'Data directory: {path}'
+Data structure entry (tree-sitter): Data structure entry (tree-sitter)
+Debug (experimental): Debug (experimental)
+Debug session failed: Debug session failed
+Debugger does not support session restarts: Debugger does not support session restarts
+Debugger is already running: Debugger is already running
+Debugger is not running: Debugger is not running
+Debugging session restarted: Debugging session restarted
+Dec {}: Dec {}
+Decrement item under cursor: Decrement item under cursor
+Delete next char: Delete next char
+Delete next word: Delete next word
+Delete previous char: Delete previous char
+Delete previous word: Delete previous word
+Delete selection: Delete selection
+Delete selection without yanking: Delete selection without yanking
+Delete surrounding pair of: Delete surrounding pair of
+Delete till end of line: Delete till end of line
+Delete till start of line: Delete till start of line
+'Diagnostic provider: {provider}': 'Diagnostic provider: {provider}'
+'Did you mean one of these: {} ?': 'Did you mean one of these: {} ?'
+Diff is not available in current buffer: Diff is not available in current buffer
+Diff is not available in the current buffer: Diff is not available in the current buffer
+Directory not found: Directory not found
+Disable exception breakpoints: Disable exception breakpoints
+Discard changes and reload all documents from the source files.: Discard changes and reload all documents from the source files.
+Discard changes and reload from the source file.: Discard changes and reload from the source file.
+Display language names of tree-sitter injection layers under the cursor.: Display language names of tree-sitter injection layers under the cursor.
+Display name of tree-sitter highlight scope under the cursor.: Display name of tree-sitter highlight scope under the cursor.
+Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.: Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.
+Display tree sitter scopes, primarily for theming and development.: Display tree sitter scopes, primarily for theming and development.
+Do nothing: Do nothing
+Does nothing.: Does nothing.
+Edit breakpoint condition on current line: Edit breakpoint condition on current line
+Edit breakpoint log message on current line: Edit breakpoint log message on current line
+Enable exception breakpoints: Enable exception breakpoints
+End debug session: End debug session
+Ensure all selections face forward: Ensure all selections face forward
+Enter command mode: Enter command mode
+Enter normal mode: Enter normal mode
+Enter selection extend mode: Enter selection extend mode
+Error parsing user language config: Error parsing user language config
+Error saving: Error saving
+Evaluate expression in current debug context.: Evaluate expression in current debug context.
+Exit selection mode: Exit selection mode
+Expand selection to parent syntax node: Expand selection to parent syntax node
+Extend down: Extend down
+Extend left: Extend left
+Extend right: Extend right
+Extend selection to line bounds: Extend selection to line bounds
+Extend till next occurrence of char: Extend till next occurrence of char
+Extend till previous occurrence of char: Extend till previous occurrence of char
+Extend to a two-character label: Extend to a two-character label
+Extend to beginning of the parent node: Extend to beginning of the parent node
+Extend to column: Extend to column
+Extend to end of next long word: Extend to end of next long word
+Extend to end of next sub word: Extend to end of next sub word
+Extend to end of next word: Extend to end of next word
+Extend to end of prev long word: Extend to end of prev long word
+Extend to end of prev sub word: Extend to end of prev sub word
+Extend to end of previous word: Extend to end of previous word
+Extend to end of the parent node: Extend to end of the parent node
+Extend to file end: Extend to file end
+Extend to first non-blank in line: Extend to first non-blank in line
+Extend to last line: Extend to last line
+Extend to line end: Extend to line end
+Extend to line number <n> else file start: Extend to line number <n> else file start
+Extend to line start: Extend to line start
+Extend to next occurrence of char: Extend to next occurrence of char
+Extend to previous occurrence of char: Extend to previous occurrence of char
+Extend to start of next long word: Extend to start of next long word
+Extend to start of next sub word: Extend to start of next sub word
+Extend to start of next word: Extend to start of next word
+Extend to start of previous long word: Extend to start of previous long word
+Extend to start of previous sub word: Extend to start of previous sub word
+Extend to start of previous word: Extend to start of previous word
+Extend up: Extend up
+'Failed to get scopes: {}': 'Failed to get scopes: {}'
+'Failed to get stack frame for thread: {thread_id}': 'Failed to get stack frame for thread: {thread_id}'
+'Failed to open file ': 'Failed to open file '
+'Failed to open file ''{uri:?}'': {e}': 'Failed to open file ''{uri:?}'': {e}'
+'Failed to pause: {}': 'Failed to pause: {}'
+'Failed to set breakpoints: {}': 'Failed to set breakpoints: {}'
+File not found: File not found
+Filter selections with shell predicate: Filter selections with shell predicate
+Flip selection cursor and anchor: Flip selection cursor and anchor
+For troubleshooting system clipboard issues, refer: For troubleshooting system clipboard issues, refer
+Force close all buffers but the currently focused one.: Force close all buffers but the currently focused one.
+Force close all buffers ignoring unsaved changes without quitting.: Force close all buffers ignoring unsaved changes without quitting.
+Force close all views ignoring unsaved changes.: Force close all views ignoring unsaved changes.
+Force close the current view, ignoring unsaved changes.: Force close the current view, ignoring unsaved changes.
+Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2).: Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2).
+? Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt)
+: Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt)
+Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt): Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt)
+? Force write changes to disk, creating necessary subdirectories, if the buffer is modified and then quit. Accepts an optional path (:exit! some/path.txt).
+: Force write changes to disk, creating necessary subdirectories, if the buffer is modified and then quit. Accepts an optional path (:exit! some/path.txt).
+Forcefully write changes from all buffers to disk creating necessary subdirectories.: Forcefully write changes from all buffers to disk creating necessary subdirectories.
+? Forcefully write changes from all buffers to disk, creating necessary subdirectories, and close all views (ignoring unsaved changes).
+: Forcefully write changes from all buffers to disk, creating necessary subdirectories, and close all views (ignoring unsaved changes).
+Format failed: Format failed
+Format selection: Format selection
+Format the file using an external formatter or language server.: Format the file using an external formatter or language server.
+'Found language server: {name}': 'Found language server: {name}'
+Function (tree-sitter): Function (tree-sitter)
+Get info about the character under the primary cursor.: Get info about the character under the primary cursor.
+Get the current value of a config option.: Get the current value of a config option.
+Global search in workspace folder: Global search in workspace folder
+Goto: Goto
+Goto column: Goto column
+Goto declaration: Goto declaration
+Goto definition: Goto definition
+Goto file end: Goto file end
+Goto files in selections (hsplit): Goto files in selections (hsplit)
+Goto files in selections (vsplit): Goto files in selections (vsplit)
+Goto files/URLs in selections: Goto files/URLs in selections
+Goto first change: Goto first change
+Goto first diagnostic: Goto first diagnostic
+Goto first non-blank in line: Goto first non-blank in line
+Goto implementation: Goto implementation
+Goto last accessed file: Goto last accessed file
+Goto last change: Goto last change
+Goto last diagnostic: Goto last diagnostic
+Goto last line: Goto last line
+Goto last modification: Goto last modification
+Goto last modified file: Goto last modified file
+Goto line: Goto line
+Goto line end: Goto line end
+Goto line number <n> else file start: Goto line number <n> else file start
+Goto line number.: Goto line number.
+Goto line start: Goto line start
+Goto matching bracket: Goto matching bracket
+Goto newline at line end: Goto newline at line end
+Goto next (X)HTML element: Goto next (X)HTML element
+Goto next buffer: Goto next buffer
+Goto next buffer.: Goto next buffer.
+Goto next change: Goto next change
+Goto next comment: Goto next comment
+Goto next diagnostic: Goto next diagnostic
+Goto next function: Goto next function
+Goto next pairing: Goto next pairing
+Goto next paragraph: Goto next paragraph
+Goto next parameter: Goto next parameter
+Goto next snippet placeholder: Goto next snippet placeholder
+Goto next test: Goto next test
+Goto next type definition: Goto next type definition
+Goto next window: Goto next window
+Goto previous (X)HTML element: Goto previous (X)HTML element
+Goto previous buffer: Goto previous buffer
+Goto previous buffer.: Goto previous buffer.
+Goto previous change: Goto previous change
+Goto previous comment: Goto previous comment
+Goto previous diagnostic: Goto previous diagnostic
+Goto previous function: Goto previous function
+Goto previous pairing: Goto previous pairing
+Goto previous paragraph: Goto previous paragraph
+Goto previous parameter: Goto previous parameter
+Goto previous test: Goto previous test
+Goto previous type definition: Goto previous type definition
+Goto previous window: Goto previous window
+Goto references: Goto references
+Goto type definition: Goto type definition
+Goto window bottom: Goto window bottom
+Goto window center: Goto window center
+Goto window top: Goto window top
+Hard-wrap the current selection of lines to a given width.: Hard-wrap the current selection of lines to a given width.
+'Highlight provider: {name}': 'Highlight provider: {name}'
+Horizontal bottom split: Horizontal bottom split
+Horizontal bottom split scratch buffer: Horizontal bottom split scratch buffer
+Increment item under cursor: Increment item under cursor
+Indent selection: Indent selection
+Insert an interactively-chosen char: Insert an interactively-chosen char
+Insert at end of line: Insert at end of line
+Insert at start of line: Insert at start of line
+Insert before selection: Insert before selection
+Insert mode: Insert mode
+Insert newline char: Insert newline char
+Insert register: Insert register
+Insert shell command output before selections: Insert shell command output before selections
+Insert tab char: Insert tab char
+Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.: Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.
+Invalid encoding: Invalid encoding
+Invalid indent style: Invalid indent style
+Invalid language: Invalid language
+Invalid line ending: Invalid line ending
+Invalid macro: Invalid macro
+Invalid option: Invalid option
+Invalid register: Invalid register
+Invalid register {s}: Invalid register {s}
+Invalid register {}: Invalid register {}
+Invalid theme: Invalid theme
+Invalid value: Invalid value
+Invoke completion popup: Invoke completion popup
+Join and yank selections: Join and yank selections
+Join and yank selections to clipboard: Join and yank selections to clipboard
+Join and yank selections to primary clipboard: Join and yank selections to primary clipboard
+Join lines inside selection: Join lines inside selection
+Join lines inside selection and select spaces: Join lines inside selection and select spaces
+Jump back to an earlier point in edit history. Accepts a number of steps or a time span.: Jump back to an earlier point in edit history. Accepts a number of steps or a time span.
+Jump backward on jumplist: Jump backward on jumplist
+Jump forward on jumplist: Jump forward on jumplist
+Jump to a later point in edit history. Accepts a number of steps or a time span.: Jump to a later point in edit history. Accepts a number of steps or a time span.
+Jump to a two-character label: Jump to a two-character label
+Jump to left split: Jump to left split
+Jump to right split: Jump to right split
+Jump to split above: Jump to split above
+Jump to split below: Jump to split below
+Keep primary selection: Keep primary selection
+Keep selections matching regex: Keep selections matching regex
+Language '{lang}' not found: Language '{lang}' not found
+Language '{}' not found: Language '{}' not found
+Language Server disappeared: Language Server disappeared
+Language server exited: Language server exited
+'Language server not configured for: {lang}': 'Language server not configured for: {lang}'
+'Language server not found: {name}': 'Language server not found: {name}'
+'Language server not running: {name}': 'Language server not running: {name}'
+'Language server running: {name}': 'Language server running: {name}'
+Language servers: Language servers
+Launch debug target: Launch debug target
+Left bracket: Left bracket
+Line comment/uncomment selections: Line comment/uncomment selections
+List variables: List variables
+Load a file into buffer: Load a file into buffer
+Loaded {} file{}.: Loaded {} file{}.
+Make the first selection your primary one: Make the first selection your primary one
+Make the last selection your primary one: Make the last selection your primary one
+'Malformed method call: {}': 'Malformed method call: {}'
+Match: Match
+Match around: Match around
+Match inside: Match inside
+Merge consecutive selections: Merge consecutive selections
+Merge selections: Merge selections
+'Method not found: {}': 'Method not found: {}'
+Modify current search to make it word bounded: Modify current search to make it word bounded
+Move backward in history: Move backward in history
+Move down: Move down
+Move forward in history: Move forward in history
+Move half page down: Move half page down
+Move half page up: Move half page up
+Move left: Move left
+Move page and cursor down: Move page and cursor down
+Move page and cursor half down: Move page and cursor half down
+Move page and cursor half up: Move page and cursor half up
+Move page and cursor up: Move page and cursor up
+Move page down: Move page down
+Move page up: Move page up
+Move right: Move right
+Move the current buffer and its corresponding file to a different path: Move the current buffer and its corresponding file to a different path
+Move the current buffer and its corresponding file to a different path creating necessary subdirectories: Move the current buffer and its corresponding file to a different path creating necessary subdirectories
+Move till next occurrence of char: Move till next occurrence of char
+Move till previous occurrence of char: Move till previous occurrence of char
+Move to beginning of the parent node: Move to beginning of the parent node
+Move to end of next long word: Move to end of next long word
+Move to end of next sub word: Move to end of next sub word
+Move to end of next word: Move to end of next word
+Move to end of previous long word: Move to end of previous long word
+Move to end of previous sub word: Move to end of previous sub word
+Move to end of previous word: Move to end of previous word
+Move to end of the parent node: Move to end of the parent node
+Move to next occurrence of char: Move to next occurrence of char
+Move to previous occurrence of char: Move to previous occurrence of char
+Move to start of next long word: Move to start of next long word
+Move to start of next sub word: Move to start of next sub word
+Move to start of next word: Move to start of next word
+Move to start of previous long word: Move to start of previous long word
+Move to start of previous sub word: Move to start of previous sub word
+Move to start of previous word: Move to start of previous word
+Move up: Move up
+Neither a dir, nor a file: Neither a dir, nor a file
+Never: Never
+New split scratch buffer: New split scratch buffer
+No LSP server for this document: No LSP server for this document
+No arguments found with which to restart the sessions: No arguments found with which to restart the sessions
+No breakpoints: No breakpoints
+No changes to save: No changes to save
+No code actions available: No code actions available
+No completions: No completions
+No configured language server supports code actions: No configured language server supports code actions
+No configured language server supports document symbols: No configured language server supports document symbols
+No configured language server supports hover: No configured language server supports hover
+No configured language server supports range formatting: No configured language server supports range formatting
+No configured language server supports signature-help: No configured language server supports signature-help
+No configured language server supports symbol renaming: No configured language server supports symbol renaming
+No configured language server supports workspace symbols: No configured language server supports workspace symbols
+No configured language server supports {}: No configured language server supports {}
+No configured languages: No configured languages
+No debug adapter: No debug adapter
+No debug adapter available for language: No debug adapter available for language
+No declaration found: No declaration found
+No declaration found.: No declaration found.
+No definition found: No definition found
+No definition found.: No definition found.
+No diagnostics: No diagnostics
+No diagnostics under primary selection: No diagnostics under primary selection
+No hover information: No hover information
+No hover results available.: No hover results available.
+No implementation found: No implementation found
+No implementation found.: No implementation found.
+No language server: No language server
+No language server supporting document symbols or syntax info available: No language server supporting document symbols or syntax info available
+No location found.: No location found.
+No more buffers: No more buffers
+No more files: No more files
+No more jumps: No more jumps
+No more matches: No more matches
+No previous working directory: No previous working directory
+No references found: No references found
+No references found.: No references found.
+No selections remaining: No selections remaining
+No signature help: No signature help
+No stack frames: No stack frames
+No symbol found: No symbol found
+No threads: No threads
+No type definition found: No type definition found
+No type definition found.: No type definition found.
+No variables: No variables
+Normal mode: Normal mode
+Not now: Not now
+Open a file from disk into the current view.: Open a file from disk into the current view.
+Open a scratch buffer in a horizontal split.: Open a scratch buffer in a horizontal split.
+Open a scratch buffer in a vertical split.: Open a scratch buffer in a vertical split.
+Open buffer picker: Open buffer picker
+Open changed file picker: Open changed file picker
+Open command palette: Open command palette
+Open diagnostic picker: Open diagnostic picker
+Open file explorer at current buffer's directory: Open file explorer at current buffer's directory
+Open file explorer at current working directory: Open file explorer at current working directory
+Open file explorer in workspace root: Open file explorer in workspace root
+Open file failed: Open file failed
+Open file picker: Open file picker
+Open file picker at current buffer's directory: Open file picker at current buffer's directory
+Open file picker at current working directory: Open file picker at current working directory
+Open jumplist picker: Open jumplist picker
+Open last picker: Open last picker
+Open new line above selection: Open new line above selection
+Open new line below selection: Open new line below selection
+Open symbol picker: Open symbol picker
+Open symbol picker from LSP or syntax information: Open symbol picker from LSP or syntax information
+Open symbol picker from syntax information: Open symbol picker from syntax information
+Open the file in a horizontal split.: Open the file in a horizontal split.
+Open the file in a vertical split.: Open the file in a vertical split.
+Open the helix log file.: Open the helix log file.
+Open the tutorial.: Open the tutorial.
+Open the user config.toml file.: Open the user config.toml file.
+Open the workspace config.toml file.: Open the workspace config.toml file.
+Open workspace command picker: Open workspace command picker
+Open workspace diagnostic picker: Open workspace diagnostic picker
+Open workspace symbol picker: Open workspace symbol picker
+Open workspace symbol picker from LSP or syntax information: Open workspace symbol picker from LSP or syntax information
+Open workspace symbol picker from syntax information: Open workspace symbol picker from syntax information
+Opening URL in external program failed: Opening URL in external program failed
+Paragraph: Paragraph
+Paste after selection: Paste after selection
+Paste before selection: Paste before selection
+Paste clipboard after selections: Paste clipboard after selections
+Paste clipboard before selections: Paste clipboard before selections
+Paste primary clipboard after selections: Paste primary clipboard after selections
+Paste primary clipboard after selections.: Paste primary clipboard after selections.
+Paste primary clipboard before selections: Paste primary clipboard before selections
+Paste primary clipboard before selections.: Paste primary clipboard before selections.
+Paste system clipboard after selections.: Paste system clipboard after selections.
+Paste system clipboard before selections.: Paste system clipboard before selections.
+Pause program execution: Pause program execution
+Perform code action: Perform code action
+Pipe each selection to the shell command, ignoring output.: Pipe each selection to the shell command, ignoring output.
+Pipe each selection to the shell command.: Pipe each selection to the shell command.
+Pipe selections into shell command ignoring output: Pipe selections into shell command ignoring output
+Pipe selections through shell command: Pipe selections through shell command
+Press <ENTER> to continue with default config: Press <ENTER> to continue with default config
+Prints the given arguments to the statusline.: Prints the given arguments to the statusline.
+Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).: Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).
+Record macro: Record macro
+Recorded to register [: Recorded to register [
+Recording to register [: Recording to register [
+Redo change: Redo change
+Refresh user config.: Refresh user config.
+Register [: Register [
+Register {} cleared: Register {} cleared
+Register {} not found: Register {} not found
+Remove current workspace from the list of trusted workspaces.: Remove current workspace from the list of trusted workspaces.
+Remove primary selection: Remove primary selection
+Remove selections matching regex: Remove selections matching regex
+Remove the top entry from the directory stack, and cd to the new top directory..: Remove the top entry from the directory stack, and cd to the new top directory..
+Rename failed: Rename failed
+Rename symbol: Rename symbol
+Repeat last motion: Repeat last motion
+Replace selections by clipboard content: Replace selections by clipboard content
+Replace selections by primary clipboard: Replace selections by primary clipboard
+Replace selections with content of system clipboard.: Replace selections with content of system clipboard.
+Replace selections with content of system primary clipboard.: Replace selections with content of system primary clipboard.
+Replace surrounding pair of: Replace surrounding pair of
+Replace with a pair of: Replace with a pair of
+Replace with new char: Replace with new char
+Replace with yanked text: Replace with yanked text
+Replay macro: Replay macro
+Reset the diff change at the cursor position.: Reset the diff change at the cursor position.
+Reset {changes} change{}: Reset {changes} change{}
+Restart debugging session: Restart debugging session
+? Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied
+: Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied
+Reverse search for regex pattern: Reverse search for regex pattern
+Reverse selections contents: Reverse selections contents
+Right bracket: Right bracket
+Rotate selection contents forward: Rotate selection contents forward
+Rotate selections backward: Rotate selections backward
+Rotate selections contents backward: Rotate selections contents backward
+Rotate selections forward: Rotate selections forward
+Run a shell command: Run a shell command
+Run shell command, appending output after each selection.: Run shell command, appending output after each selection.
+Run shell command, inserting output before each selection.: Run shell command, inserting output before each selection.
+Runtime directory: Runtime directory
+Runtime directory does not exist: Runtime directory does not exist
+Runtime directory is empty: Runtime directory is empty
+'Runtime directory: {path}': 'Runtime directory: {path}'
+Save and then change the current directory.: Save and then change the current directory.
+Save current selection to jumplist: Save current selection to jumplist
+Scroll view down: Scroll view down
+Scroll view up: Scroll view up
+Search for regex pattern: Search for regex pattern
+Select all children of the current node: Select all children of the current node
+Select all regex matches inside selections: Select all regex matches inside selections
+Select all siblings of the current node: Select all siblings of the current node
+Select around object: Select around object
+Select current line, if already selected, extend or shrink line above based on the anchor: Select current line, if already selected, extend or shrink line above based on the anchor
+Select current line, if already selected, extend or shrink line below based on the anchor: Select current line, if already selected, extend or shrink line below based on the anchor
+Select current line, if already selected, extend to another line based on the anchor: Select current line, if already selected, extend to another line based on the anchor
+Select current line, if already selected, extend to next line: Select current line, if already selected, extend to next line
+Select current line, if already selected, extend to previous line: Select current line, if already selected, extend to previous line
+Select inside object: Select inside object
+Select mode: Select mode
+Select next search match: Select next search match
+Select next sibling in the syntax tree: Select next sibling in the syntax tree
+Select previous search match: Select previous search match
+Select previous sibling the in syntax tree: Select previous sibling the in syntax tree
+Select register: Select register
+Select symbol references: Select symbol references
+Select whole document: Select whole document
+Selection saved to jumplist: Selection saved to jumplist
+? 'Set a config option at runtime.
+
+  For example to disable smart case search, use `:set search.smart-case false`.'
+: 'Set a config option at runtime.
+
+  For example to disable smart case search, use `:set search.smart-case false`.'
+Set contents of the given register.: Set contents of the given register.
+Set encoding. Based on https://encoding.spec.whatwg.org: Set encoding. Based on https://encoding.spec.whatwg.org
+'Set the document''s default line ending. Options: crlf, lf, cr, ff, nel.': 'Set the document''s default line ending. Options: crlf, lf, cr, ff, nel.'
+'Set the document''s default line ending. Options: crlf, lf.': 'Set the document''s default line ending. Options: crlf, lf.'
+Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.): Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.)
+Set the language of current buffer (show current language if no value specified).: Set the language of current buffer (show current language if no value specified).
+Shell command failed: Shell command failed
+Show clipboard provider name in status bar.: Show clipboard provider name in status bar.
+Show docs for item under cursor: Show docs for item under cursor
+Show signature help: Show signature help
+Show the current working directory.: Show the current working directory.
+Show the directory stack as a <space> delimited string.: Show the directory stack as a <space> delimited string.
+Shrink selection to line bounds: Shrink selection to line bounds
+Shrink selection to previously expanded syntax node: Shrink selection to previously expanded syntax node
+Sort ranges in selection.: Sort ranges in selection.
+'Sorting requires multiple selections. Hint: split selection first': 'Sorting requires multiple selections. Hint: split selection first'
+Space: Space
+Split selection on newlines: Split selection on newlines
+Split selections on regex matches: Split selections on regex matches
+Stack is empty: Stack is empty
+Start a debug session from a given template with given parameters.: Start a debug session from a given template with given parameters.
+Step in: Step in
+Step out: Step out
+Step to next: Step to next
+Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied: Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied
+Surround add: Surround add
+Surround delete: Surround delete
+Surround replace: Surround replace
+Suspend and return to shell: Suspend and return to shell
+Swap with left split: Swap with left split
+Swap with right split: Swap with right split
+Swap with split above: Swap with split above
+Swap with split below: Swap with split below
+Switch: Switch
+Switch (toggle) case: Switch (toggle) case
+Switch current thread: Switch current thread
+Switch stack frame: Switch stack frame
+Switch to lowercase: Switch to lowercase
+Switch to uppercase: Switch to uppercase
+Syntax tree is not available on this buffer: Syntax tree is not available on this buffer
+Syntax-tree is not available in current buffer: Syntax-tree is not available in current buffer
+'System clipboard provider: Not installed': 'System clipboard provider: Not installed'
+Terminating debug session...: Terminating debug session...
+Test (tree-sitter): Test (tree-sitter)
+'Text doc sync: {sync}': 'Text doc sync: {sync}'
+The line you jumped to does not exist anymore because the file has changed.: The line you jumped to does not exist anymore because the file has changed.
+The location you jumped to does not exist anymore because the file has changed.: The location you jumped to does not exist anymore because the file has changed.
+There are no changes under any selection: There are no changes under any selection
+This list is filtered according to the 'use-grammars' option in languages.toml file.: This list is filtered according to the 'use-grammars' option in languages.toml file.
+To see the full list, use the '--health all' or '--health all-languages' option.: To see the full list, use the '--health all' or '--health all-languages' option.
+? 'Toggle a config option at runtime.
+
+  For example to toggle smart case search, use `:toggle search.smart-case`.'
+: 'Toggle a config option at runtime.
+
+  For example to toggle smart case search, use `:toggle search.smart-case`.'
+Toggle breakpoint: Toggle breakpoint
+Transpose splits: Transpose splits
+Trim whitespace from selections: Trim whitespace from selections
+Trust this workspace?: Trust this workspace?
+Type definition (tree-sitter): Type definition (tree-sitter)
+Undo change: Undo change
+Unindent selection: Unindent selection
+Unknown key `{}`: Unknown key `{}`
+'Unknown language server{s}: {}': 'Unknown language server{s}: {}'
+'Unsupported theme: theme requires true color support': 'Unsupported theme: theme requires true color support'
+Use current selection as search pattern: Use current selection as search pattern
+Use current selection as the search pattern, automatically wrapping with \b on word boundaries: Use current selection as the search pattern, automatically wrapping with \b on word boundaries
+Using default language config: Using default language config
+Vertical right split: Vertical right split
+Vertical right split scratch buffer: Vertical right split scratch buffer
+View: View
+WORD: WORD
+Window: Window
+Word: Word
+Workspace directory does not exist: Workspace directory does not exist
+Wrapped around document: Wrapped around document
+Write changes from all buffers to disk and close all views.: Write changes from all buffers to disk and close all views.
+Write changes from all buffers to disk.: Write changes from all buffers to disk.
+Write changes only if the file has been modified.: Write changes only if the file has been modified.
+Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt): Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt)
+Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt): Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt)
+Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt): Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt)
+Write changes to disk if the buffer is modified and then quit. Accepts an optional path (:exit some/path.txt).: Write changes to disk if the buffer is modified and then quit. Accepts an optional path (:exit some/path.txt).
+Write changes to disk. Accepts an optional path (:write some/path.txt): Write changes to disk. Accepts an optional path (:write some/path.txt)
+Yank diagnostic(s) under primary cursor to register, or clipboard by default: Yank diagnostic(s) under primary cursor to register, or clipboard by default
+Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline.: Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline.
+? Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline.
+: Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline.
+Yank joined selections. A separator can be provided as first argument. Default value is newline.: Yank joined selections. A separator can be provided as first argument. Default value is newline.
+Yank main selection into system clipboard.: Yank main selection into system clipboard.
+Yank main selection into system primary clipboard.: Yank main selection into system primary clipboard.
+Yank main selection to clipboard: Yank main selection to clipboard
+Yank main selection to primary clipboard: Yank main selection to primary clipboard
+Yank selection: Yank selection
+Yank selections to clipboard: Yank selections to clipboard
+Yank selections to primary clipboard: Yank selections to primary clipboard
+Yanked {n} diagnostic{} to register {reg}: Yanked {n} diagnostic{} to register {reg}
+'[+]': '[+]'
+'] because already replaying from same register': '] because already replaying from same register'
+'] empty': '] empty'
+'`{command}` is not supported for any language server': '`{command}` is not supported for any language server'
+'`{command}` supported by multiple language servers': '`{command}` supported by multiple language servers'
+align cannot work with multi line selections: align cannot work with multi line selections
+can't move file, parent directory does not exist (use :mv! to create it): can't move file, parent directory does not exist (use :mv! to create it)
+'cannot close non-existent buffers: {}': 'cannot close non-existent buffers: {}'
+carriage return: carriage return
+class: class
+color: color
+'color ': 'color '
+conflict: conflict
+constant: constant
+constructor: constructor
+crlf: crlf
+deleted: deleted
+enum: enum
+enum member: enum member
+error: error
+'error opening file: {}': 'error opening file: {}'
+'error reading file: {}': 'error reading file: {}'
+event: event
+field: field
+file: file
+folder: folder
+form feed: form feed
+format_selections only supports a single selection for now: format_selections only supports a single selection for now
+from register: from register
+function: function
+inserting multiple newlines not yet supported: inserting multiple newlines not yet supported
+interface: interface
+is empty: is empty
+'is symlinked to: {}': 'is symlinked to: {}'
+joined and: joined and
+keyword: keyword
+line feed: line feed
+method: method
+modified: modified
+module: module
+next line: next line
+no last accessed buffer: no last accessed buffer
+no last modified buffer: no last modified buffer
+no last picker: no last picker
+no selections remaining: no selections remaining
+no snippet is currently active: no snippet is currently active
+'no such command: ''{cmd}''': 'no such command: ''{cmd}'''
+nothing selected: nothing selected
+operator: operator
+'path is not a file: {:?}': 'path is not a file: {:?}'
+primary selection: primary selection
+property: property
+reference: reference
+register: register
+'register ': 'register '
+renamed: renamed
+selection: selection
+skip auto-formatting: skip auto-formatting
+snippet: snippet
+sort ranges in reverse order: sort ranges in reverse order
+sort the ranges case-insensitively: sort the ranges case-insensitively
+struct: struct
+tabs: tabs
+text: text
+to: to
+to register: to register
+type parameter: type parameter
+'unable to convert URI to filepath: {:?}': 'unable to convert URI to filepath: {:?}'
+unable to open: unable to open
+unit: unit
+untracked: untracked
+value: value
+variable: variable
+version: 1
+yanked: yanked
+'{:?} cannot be mapped to {}': '{:?} cannot be mapped to {}'
+'{} (deleted)': '{} (deleted)'
+'{} spaces': '{} spaces'
+'{} unsaved buffer{} remaining: {:?}': '{} unsaved buffer{} remaining: {:?}'
+▸ {}: ▸ {}

--- a/helix-term/i18n/zh-CN.yml
+++ b/helix-term/i18n/zh-CN.yml
@@ -1,0 +1,935 @@
+' 1 sel ': ' 1 个选区 '
+' W ': ' W '
+' [readonly] ': ' [只读] '
+' char': ' 字符'
+' chars': ' 字符'
+' reg={} ': ' 寄存器={} '
+' sel ': ' 选区 '
+' sels ': ' 选区 '
+' set to ': ' 设为 '
+' space': ' 空格'
+' spaces': ' 空格'
+' tabs ': ' 制表符 '
+'''{key}'' is now set to {value}': '''{key}'' 现已设为 {value}'
+'''{}'' not found in $PATH': '''{}'' 未在 $PATH 中找到'
+'''{}'' written, {lines}L {size}': '''{}'' 已写入，{lines} 行 {size}'
+(X)HTML element (tree-sitter): (X)HTML 元素 (tree-sitter)
+'... or any character acting as a pair': '... 或任何作为配对符的字符'
+1 space: 1 个空格
+<Binary file>: <二进制文件>
+<File not found>: <文件未找到>
+<File too large to preview>: <文件太大无法预览>
+<Invalid directory location>: <无效目录位置>
+<Invalid file location>: <无效文件位置>
+Add current workspace to the list of trusted workspaces.: 将当前工作空间添加到受信任工作空间列表。
+Add newline above: 在上方添加换行
+Add newline below: 在下方添加换行
+Add next search match to selection: 添加下一个搜索结果到选区
+Add previous search match to selection: 添加上一个搜索结果到选区
+Align selections in column: 对齐选区到列
+Align view bottom: 视图底部对齐
+Align view center: 视图居中对齐
+Align view middle: 视图居中对齐
+Align view top: 视图顶部对齐
+All registers cleared: 所有寄存器已清除
+Already at line end: 已在行尾
+Already at line start: 已在行首
+Already at newest change: 已在最新的更改处
+Already at oldest change: 已在最旧的更改处
+Always: 始终
+Append after selection: 在选区后追加
+Append an interactively-chosen char: 交互式追加字符
+Append shell command output after selections: 在选区后追加 shell 命令输出
+Argument/parameter (tree-sitter): 参数 (tree-sitter)
+Auto-save failed: 自动保存失败
+'Bad arguments. For boolean configurations use: `:toggle {key}`': 参数错误。布尔配置请使用：`:toggle {key}`
+'Bad arguments. For string configurations use: `:toggle {key} val1 val2 ...`': 参数错误。字符串配置请使用：`:toggle {key} val1 val2 ...`
+Block comment/uncomment selections: 块注释/取消注释选区
+Buffer not modified: 缓冲区未修改
+'Can''t set breakpoint: document has no path': 无法设置断点：文档没有路径
+Cannot abort: 无法中止
+Cannot accept: 无法接受
+Cannot access variables while target is running.: 目标运行时无法访问变量。
+Cannot acquire: 无法获取
+Cannot add: 无法添加
+Cannot add hook: 无法添加钩子
+Cannot allocate: 无法分配
+Cannot apply: 无法应用
+Cannot authenticate: 无法认证
+Cannot authorize: 无法授权
+Cannot backup: 无法备份
+Cannot begin: 无法开始
+Cannot benchmark: 无法基准测试
+Cannot bind: 无法绑定
+Cannot blame: 无法追溯
+Cannot block: 无法阻塞
+Cannot branch: 无法创建分支
+Cannot bridge: 无法桥接
+Cannot broadcast: 无法广播
+Cannot buffer: 无法缓冲
+Cannot calculate: 无法计算
+Cannot cancel: 无法取消
+Cannot capture: 无法捕获
+Cannot catch: 无法捕获
+Cannot change directory: 无法更改目录
+Cannot check: 无法检查
+Cannot checkout: 无法检出
+Cannot cherry-pick: 无法拣选
+Cannot clear state: 无法清除状态
+Cannot clock: 无法时钟
+Cannot clone: 无法克隆
+Cannot close: 无法关闭
+Cannot close connection: 无法关闭连接
+Cannot commit: 无法提交
+Cannot complete: 无法完成
+Cannot compress: 无法压缩
+Cannot compute: 无法计算
+Cannot connect: 无法连接
+Cannot connect to server: 无法连接到服务器
+Cannot convert: 无法转换
+Cannot create: 无法创建
+Cannot create directory: 无法创建目录
+Cannot deallocate: 无法释放
+Cannot decode: 无法解码
+Cannot decompress: 无法解压缩
+Cannot decrypt: 无法解密
+Cannot default: 无法默认
+Cannot delete file: 无法删除文件
+Cannot deliver: 无法投递
+Cannot dequeue: 无法出队
+Cannot describe: 无法描述
+Cannot destroy: 无法销毁
+Cannot detect: 无法检测
+Cannot determine: 无法确定
+Cannot diff: 无法比较
+Cannot disconnect: 无法断开
+Cannot disconnect from server: 无法断开服务器连接
+Cannot dispatch: 无法分发
+Cannot download: 无法下载
+Cannot emit hook: 无法发射钩子
+Cannot encode: 无法编码
+Cannot encrypt: 无法加密
+Cannot end: 无法结束
+Cannot enqueue: 无法入队
+Cannot epoll: 无法 epoll
+Cannot evaluate: 无法评估
+Cannot eventfd: 无法 eventfd
+Cannot exec: 无法 exec
+Cannot execute: 无法执行
+Cannot execute command: 无法执行命令
+Cannot execute macro because the [@] register is already playing a macro: 无法执行宏，因为 [@] 寄存器已在回放宏
+Cannot fetch: 无法获取
+Cannot finalize: 无法完成
+Cannot find: 无法查找
+Cannot find current stack frame to access variables: 找不到当前栈帧来访问变量
+Cannot find current stack frame to access variables.: 找不到当前栈帧来访问变量。
+Cannot finish: 无法完成
+Cannot fire hook: 无法触发钩子
+Cannot flush connection: 无法刷新连接
+Cannot fork: 无法 fork
+Cannot format: 无法格式化
+Cannot forward: 无法转发
+Cannot free: 无法释放
+Cannot fsevents: 无法 fsevents
+Cannot get handler: 无法获取处理器
+Cannot grep: 无法搜索
+Cannot handle: 无法处理
+Cannot handle notification: 无法处理通知
+Cannot handle request: 无法处理请求
+Cannot identify: 无法识别
+Cannot ignore: 无法忽略
+Cannot init: 无法初始化
+Cannot initialize: 无法初始化
+Cannot initialize connection: 无法初始化连接
+Cannot inotify: 无法 inotify
+Cannot invoke hook: 无法调用钩子
+Cannot iocp: 无法 iocp
+Cannot kill: 无法 kill
+Cannot kqueue: 无法 kqueue
+Cannot lex: 无法词法分析
+Cannot listen: 无法监听
+Cannot listen hook: 无法监听钩子
+Cannot load state: 无法加载状态
+Cannot locate: 无法定位
+Cannot lock: 无法锁定
+Cannot log: 无法查看日志
+Cannot lookup: 无法查找
+Cannot match: 无法匹配
+Cannot measure: 无法测量
+Cannot merge: 无法合并
+Cannot monitor: 无法监控
+Cannot notify: 无法通知
+Cannot notify hook: 无法通知钩子
+Cannot observe: 无法观察
+Cannot open: 无法打开
+Cannot open connection: 无法打开连接
+Cannot open document: 无法打开文档
+Cannot parse: 无法解析
+Cannot parse response: 无法解析响应
+Cannot pause: 无法暂停
+Cannot peek: 无法查看
+Cannot play: 无法播放
+Cannot poll: 无法轮询
+Cannot pop: 无法弹出
+Cannot process response: 无法处理响应
+Cannot profile: 无法分析
+Cannot proxy: 无法代理
+Cannot publish hook: 无法发布钩子
+Cannot pull: 无法拉取
+Cannot push: 无法推入
+Cannot query: 无法查询
+Cannot queue: 无法入队
+Cannot raise: 无法 raise
+Cannot read connection: 无法读取连接
+Cannot read file: 无法读取文件
+Cannot rebase: 无法变基
+Cannot receive: 无法接收
+Cannot receive response: 无法接收响应
+Cannot reconnect: 无法重新连接
+Cannot record: 无法录制
+Cannot recover: 无法恢复
+Cannot redirect: 无法重定向
+Cannot register handler: 无法注册处理器
+Cannot relay: 无法中继
+Cannot release: 无法释放
+Cannot remove: 无法移除
+Cannot remove hook: 无法移除钩子
+Cannot rename: 无法重命名
+Cannot repeat: 无法重复
+Cannot replace: 无法替换
+Cannot replay: 无法重播
+Cannot replay from register [: 无法从寄存器 [ 回放
+Cannot reserve: 无法预留
+Cannot reset: 无法重置
+Cannot reset connection: 无法重置连接
+Cannot reset state: 无法重置状态
+Cannot resolve: 无法解析
+Cannot restore: 无法还原
+Cannot resume: 无法恢复
+Cannot retry: 无法重试
+Cannot revert: 无法还原
+Cannot route: 无法路由
+Cannot run: 无法运行
+Cannot save: 无法保存
+Cannot save state: 无法保存状态
+Cannot scan: 无法扫描
+Cannot schedule: 无法调度
+Cannot search: 无法搜索
+Cannot select: 无法选择
+Cannot send: 无法发送
+Cannot send notification: 无法发送通知
+Cannot send request: 无法发送请求
+Cannot send response: 无法发送响应
+Cannot serialize request: 无法序列化请求
+Cannot set handler: 无法设置处理器
+Cannot show: 无法显示
+Cannot shutdown connection: 无法关闭连接
+Cannot sign: 无法签名
+Cannot signal: 无法发信号
+Cannot signalfd: 无法 signalfd
+Cannot spawn: 无法派生
+Cannot split: 无法分割
+Cannot start: 无法启动
+Cannot stash: 无法储藏
+Cannot status: 无法查看状态
+Cannot stop: 无法停止
+Cannot stream: 无法流式传输
+Cannot subscribe hook: 无法订阅钩子
+Cannot substitute: 无法替代
+Cannot sync: 无法同步
+Cannot tag: 无法打标签
+Cannot terminate: 无法终止
+Cannot terminate connection: 无法终止连接
+Cannot test: 无法测试
+Cannot time: 无法计时
+Cannot timerfd: 无法 timerfd
+Cannot tokenize: 无法分词
+Cannot trace: 无法追踪
+Cannot track: 无法跟踪
+Cannot transform: 无法转换
+Cannot translate: 无法翻译
+Cannot transmit: 无法传输
+Cannot trigger hook: 无法触发钩子
+Cannot tunnel: 无法隧道
+Cannot unblock: 无法解除阻塞
+Cannot unlock: 无法解锁
+Cannot unregister handler: 无法注销处理器
+Cannot unsubscribe hook: 无法取消订阅钩子
+Cannot unwatch: 无法取消监视
+Cannot upload: 无法上传
+Cannot validate: 无法验证
+Cannot validate response: 无法验证响应
+Cannot verify: 无法验证
+Cannot wait: 无法等待
+Cannot waitpid: 无法 waitpid
+Cannot watch: 无法监视
+Cannot write connection: 无法写入连接
+Cannot write file: 无法写入文件
+Cannot write to file: 无法写入文件
+Cannot yield: 无法让出
+Change: 更改
+Change selection: 修改选区
+Change selection without yanking: 修改选区（不复制）
+Change the current working directory.: 更改当前工作目录。
+Change the editor theme (show current theme if no name specified).: 更改编辑器主题（不指定名称则显示当前主题）。
+Checking config: 检查配置
+'Checking language: {lang}': 检查语言：{lang}
+Clear and re-render the whole UI: 清除并重新渲染整个 UI
+Clear given register. If no argument is provided, clear all registers.: 清除指定寄存器。如果不提供参数，清除所有寄存器。
+Close all buffers but the currently focused one.: 关闭除当前聚焦缓冲区外的所有缓冲区。
+Close all buffers without quitting.: 关闭所有缓冲区但不退出。
+Close all views.: 关闭所有视图。
+Close the current buffer forcefully, ignoring unsaved changes.: 强制关闭当前缓冲区，忽略未保存的更改。
+Close the current buffer.: 关闭当前缓冲区。
+Close the current view.: 关闭当前视图。
+Close window: 关闭窗口
+Close windows except current: 仅保留当前窗口
+Closest surrounding pair (tree-sitter): 最近的包围对 (tree-sitter)
+Collapse selection into single cursor: 折叠选区为单个光标
+Command run: 命令已执行
+Comment (tree-sitter): 注释 (tree-sitter)
+Comment/uncomment selections: 注释/取消注释选区
+Commit changes to new checkpoint: 提交更改到新检查点
+'Config directory: {path}': 配置目录：{path}
+'Config file: default': 配置文件：默认
+'Config file: {path}': 配置文件：{path}
+Config refreshed: 配置已刷新
+Configuration file malformed: 配置文件格式错误
+'Configured language server: {name}': 已配置的语言服务器：{name}
+Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters.: 通过 TCP 地址连接到调试适配器，并从给定模板和参数启动调试会话。
+Continue program execution: 继续执行程序
+Copy between two registers: 在两个寄存器之间复制
+Copy selection on next line: 在下一行复制选区
+Copy selection on previous line: 在上一行复制选区
+'Could not change working directory to ''{}'': {err}': '无法切换工作目录到 ''{}'': {err}'
+Could not parse field `{}`: 无法解析字段 `{}`
+Create a new scratch buffer.: 创建新的空白缓冲区。
+Current buffer has no parent and current working directory does not exist: 当前缓冲区没有父目录且当前工作目录不存在
+Current buffer has no parent, opening file explorer in current working directory: 当前缓冲区没有父目录，在当前工作目录打开文件浏览器
+Current buffer has no parent, opening file picker in current working directory: 当前缓冲区没有父目录，在当前工作目录打开文件选择器
+Current working directory does not exist: 当前工作目录不存在
+Current working directory is now {}: 当前工作目录现在是 {}
+Current working directory is {}: 当前工作目录是 {}
+Currently active thread is not stopped. Switch the thread.: 当前线程未停止。请切换线程。
+'Data directory: {path}': 数据目录：{path}
+Data structure entry (tree-sitter): 数据结构条目 (tree-sitter)
+Debug (experimental): 调试（实验性）
+Debug session failed: 调试会话失败
+Debugger does not support session restarts: 调试器不支持会话重启
+Debugger is already running: 调试器已在运行
+Debugger is not running: 调试器未运行
+Debugging session restarted: 调试会话已重启
+Dec {}: 十进制 {}
+Decrement item under cursor: 递减光标下的值
+Delete next char: 删除下一个字符
+Delete next word: 删除下一个词
+Delete previous char: 删除前一个字符
+Delete previous word: 删除前一个词
+Delete selection: 删除选区
+Delete selection without yanking: 删除选区（不复制）
+Delete surrounding pair of: 删除包围对
+Delete till end of line: 删除到行尾
+Delete till start of line: 删除到行首
+'Diagnostic provider: {provider}': 诊断提供者：{provider}
+'Did you mean one of these: {} ?': 你是指以下之一：{} ？
+Diff is not available in current buffer: 当前缓冲区没有差异信息
+Diff is not available in the current buffer: 当前缓冲区没有差异信息
+Directory not found: 目录未找到
+Disable exception breakpoints: 禁用异常断点
+Discard changes and reload all documents from the source files.: 丢弃所有更改并从源文件重新加载所有文档。
+Discard changes and reload from the source file.: 丢弃更改并从源文件重新加载。
+Display language names of tree-sitter injection layers under the cursor.: 显示光标下 tree-sitter 注入层的语言名称。
+Display name of tree-sitter highlight scope under the cursor.: 显示光标下 tree-sitter 高亮作用域的名称。
+Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.: 显示覆盖主选区的最小 tree-sitter 子树，主要用于调试查询。
+Display tree sitter scopes, primarily for theming and development.: 显示 tree-sitter 作用域，主要用于主题开发和调试。
+Do nothing: 无操作
+Does nothing.: 无操作。
+Edit breakpoint condition on current line: 编辑当前行断点条件
+Edit breakpoint log message on current line: 编辑当前行断点日志消息
+Enable exception breakpoints: 启用异常断点
+End debug session: 结束调试会话
+Ensure all selections face forward: 确保所有选区方向向前
+Enter command mode: 进入命令模式
+Enter normal mode: 进入普通模式
+Enter selection extend mode: 进入选择扩展模式
+Error parsing user language config: 解析用户语言配置出错
+Error saving: 保存出错
+Evaluate expression in current debug context.: 在当前调试上下文中计算表达式。
+Exit selection mode: 退出选择模式
+Expand selection to parent syntax node: 扩展到父语法节点
+Extend down: 向下扩展
+Extend left: 向左扩展
+Extend right: 向右扩展
+Extend selection to line bounds: 扩展到行边界
+Extend till next occurrence of char: 扩展到字符前
+Extend till previous occurrence of char: 扩展到前一个字符前
+Extend to a two-character label: 扩展到双字符标签
+Extend to beginning of the parent node: 扩展到父节点开头
+Extend to column: 扩展到指定列
+Extend to end of next long word: 扩展到下一个长词尾
+Extend to end of next sub word: 扩展到下一个子词尾
+Extend to end of next word: 扩展到下一个词尾
+Extend to end of prev long word: 扩展到上一个长词尾
+Extend to end of prev sub word: 扩展到上一个子词尾
+Extend to end of previous word: 扩展到上一个词尾
+Extend to end of the parent node: 扩展到父节点末尾
+Extend to file end: 扩展到文件末尾
+Extend to first non-blank in line: 扩展到行首第一个非空白字符
+Extend to last line: 扩展到最后一行
+Extend to line end: 扩展到行尾
+Extend to line number <n> else file start: 扩展到第 <n> 行或文件开头
+Extend to line start: 扩展到行首
+Extend to next occurrence of char: 扩展到下一个字符
+Extend to previous occurrence of char: 扩展到前一个字符
+Extend to start of next long word: 扩展到下一个长词首
+Extend to start of next sub word: 扩展到下一个子词首
+Extend to start of next word: 扩展到下一个词首
+Extend to start of previous long word: 扩展到上一个长词首
+Extend to start of previous sub word: 扩展到上一个子词首
+Extend to start of previous word: 扩展到上一个词首
+Extend up: 向上扩展
+'Failed to get scopes: {}': 获取作用域失败：{}
+'Failed to get stack frame for thread: {thread_id}': 获取线程 {thread_id} 的栈帧失败
+'Failed to open file ': '打开文件失败 '
+'Failed to open file ''{uri:?}'': {e}': 打开文件 '{uri:?}' 失败：{e}
+'Failed to pause: {}': 暂停失败：{}
+'Failed to set breakpoints: {}': 设置断点失败：{}
+File not found: 文件未找到
+Filter selections with shell predicate: 用 shell 谓词过滤选区
+Flip selection cursor and anchor: 翻转选区光标和锚点
+For troubleshooting system clipboard issues, refer: 排查系统剪贴板问题，请参考
+Force close all buffers but the currently focused one.: 强制关闭除当前聚焦缓冲区外的所有缓冲区。
+Force close all buffers ignoring unsaved changes without quitting.: 强制关闭所有缓冲区（忽略未保存的更改）但不退出。
+Force close all views ignoring unsaved changes.: 强制关闭所有视图，忽略未保存的更改。
+Force close the current view, ignoring unsaved changes.: 强制关闭当前视图，忽略未保存的更改。
+Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2).: 强制以退出码退出（默认 1），忽略未保存的更改。可接受可选整数退出码 (:cq! 2)。
+? Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt)
+: 强制写入磁盘（创建必要的子目录）并关闭缓冲区。可接受可选路径 (:write-buffer-close! some/path.txt)
+Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt): 强制写入磁盘（创建必要的子目录）。可接受可选路径 (:write! some/path.txt)
+? Force write changes to disk, creating necessary subdirectories, if the buffer is modified and then quit. Accepts an optional path (:exit! some/path.txt).
+: 强制写入磁盘（创建必要的子目录），如果缓冲区已修改则退出。可接受可选路径 (:exit! some/path.txt)。
+Forcefully write changes from all buffers to disk creating necessary subdirectories.: 强制将所有缓冲区的更改写入磁盘（创建必要的子目录）。
+? Forcefully write changes from all buffers to disk, creating necessary subdirectories, and close all views (ignoring unsaved changes).
+: 强制将所有缓冲区的更改写入磁盘（创建必要的子目录）并关闭所有视图（忽略未保存的更改）。
+Format failed: 格式化失败
+Format selection: 格式化选区
+Format the file using an external formatter or language server.: 使用外部格式化工具或语言服务器格式化文件。
+'Found language server: {name}': 找到语言服务器：{name}
+Function (tree-sitter): 函数 (tree-sitter)
+Get info about the character under the primary cursor.: 获取主光标下字符的信息。
+Get the current value of a config option.: 获取配置选项的当前值。
+Global search in workspace folder: 全局搜索工作区
+Goto: 跳转
+Goto column: 跳转到指定列
+Goto declaration: 跳转到声明
+Goto definition: 跳转到定义
+Goto file end: 跳转到文件末尾
+Goto files in selections (hsplit): 跳转到选区中的文件（水平分割）
+Goto files in selections (vsplit): 跳转到选区中的文件（垂直分割）
+Goto files/URLs in selections: 跳转到选区中的文件/URL
+Goto first change: 跳转到第一个更改
+Goto first diagnostic: 跳转到第一个诊断
+Goto first non-blank in line: 跳转到行首第一个非空白字符
+Goto implementation: 跳转到实现
+Goto last accessed file: 跳转到上次访问的文件
+Goto last change: 跳转到最后一个更改
+Goto last diagnostic: 跳转到最后一个诊断
+Goto last line: 跳转到最后一行
+Goto last modification: 跳转到上次修改位置
+Goto last modified file: 跳转到上次修改的文件
+Goto line: 跳转到指定行
+Goto line end: 跳转到行尾
+Goto line number <n> else file start: 跳转到第 <n> 行或文件开头
+Goto line number.: 跳转到行号。
+Goto line start: 跳转到行首
+Goto matching bracket: 跳转到匹配括号
+Goto newline at line end: 跳转到行尾换行符
+Goto next (X)HTML element: 跳转到下一个 (X)HTML 元素
+Goto next buffer: 跳转到下一个缓冲区
+Goto next buffer.: 跳转到下一个缓冲区。
+Goto next change: 跳转到下一个更改
+Goto next comment: 跳转到下一个注释
+Goto next diagnostic: 跳转到下一个诊断
+Goto next function: 跳转到下一个函数
+Goto next pairing: 跳转到下一个配对
+Goto next paragraph: 跳转到下一个段落
+Goto next parameter: 跳转到下一个参数
+Goto next snippet placeholder: 跳转到上一个代码片段占位符
+Goto next test: 跳转到下一个测试
+Goto next type definition: 跳转到下一个类型定义
+Goto next window: 跳转到下一个窗口
+Goto previous (X)HTML element: 跳转到上一个 (X)HTML 元素
+Goto previous buffer: 跳转到上一个缓冲区
+Goto previous buffer.: 跳转到上一个缓冲区。
+Goto previous change: 跳转到上一个更改
+Goto previous comment: 跳转到上一个注释
+Goto previous diagnostic: 跳转到上一个诊断
+Goto previous function: 跳转到上一个函数
+Goto previous pairing: 跳转到上一个配对
+Goto previous paragraph: 跳转到上一个段落
+Goto previous parameter: 跳转到上一个参数
+Goto previous test: 跳转到上一个测试
+Goto previous type definition: 跳转到上一个类型定义
+Goto previous window: 跳转到上一个窗口
+Goto references: 跳转到引用
+Goto type definition: 跳转到类型定义
+Goto window bottom: 跳转到窗口底部
+Goto window center: 跳转到窗口中部
+Goto window top: 跳转到窗口顶部
+Hard-wrap the current selection of lines to a given width.: 将当前选中的行硬包装到指定宽度。
+'Highlight provider: {name}': 高亮提供者：{name}
+Horizontal bottom split: 水平底部分割
+Horizontal bottom split scratch buffer: 水平底部分割新建缓冲区
+Increment item under cursor: 递增光标下的值
+Indent selection: 缩进选区
+Insert an interactively-chosen char: 交互式插入字符
+Insert at end of line: 在行尾插入
+Insert at start of line: 在行首插入
+Insert before selection: 在选区前插入
+Insert mode: 插入模式
+Insert newline char: 插入换行符
+Insert register: 插入寄存器
+Insert shell command output before selections: 在选区前插入 shell 命令输出
+Insert tab char: 插入制表符
+Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.: 如果所有光标左侧都是空白则插入制表符，否则执行单独的命令
+Invalid encoding: 无效编码
+Invalid indent style: 无效缩进样式
+Invalid language: 无效语言
+Invalid line ending: 无效行尾
+Invalid macro: 无效宏
+Invalid option: 无效选项
+Invalid register: 无效寄存器
+Invalid register {s}: 无效寄存器 {s}
+Invalid register {}: 无效寄存器 {}
+Invalid theme: 无效主题
+Invalid value: 无效值
+Invoke completion popup: 触发补全弹出
+Join and yank selections: 连接并复制选区
+Join and yank selections to clipboard: 连接并复制选区到剪贴板
+Join and yank selections to primary clipboard: 连接并复制选区到主剪贴板
+Join lines inside selection: 合并选区内的行
+Join lines inside selection and select spaces: 合并选区内的行并选择空格
+Jump back to an earlier point in edit history. Accepts a number of steps or a time span.: 回退到编辑历史的较早时间点。可接受步数或时间段。
+Jump backward on jumplist: 向后跳转
+Jump forward on jumplist: 向前跳转
+Jump to a later point in edit history. Accepts a number of steps or a time span.: 前进到编辑历史的较晚时间点。可接受步数或时间段。
+Jump to a two-character label: 跳转到双字符标签
+Jump to left split: 跳转到左侧分割
+Jump to right split: 跳转到右侧分割
+Jump to split above: 跳转到上方分割
+Jump to split below: 跳转到下方分割
+Keep primary selection: 保留主选区
+Keep selections matching regex: 保留匹配正则的选区
+Language '{lang}' not found: 未找到语言 '{lang}'
+Language '{}' not found: 语言 '{}' 未找到
+Language Server disappeared: 语言服务器已消失
+Language server exited: 语言服务器已退出
+'Language server not configured for: {lang}': 未配置语言服务器：{lang}
+'Language server not found: {name}': 未找到语言服务器：{name}
+'Language server not running: {name}': 语言服务器未运行：{name}
+'Language server running: {name}': 语言服务器运行中：{name}
+Language servers: 语言服务器
+Launch debug target: 启动调试目标
+Left bracket: 左括号
+Line comment/uncomment selections: 行注释/取消注释选区
+List variables: 列出变量
+Load a file into buffer: 将文件加载到缓冲区
+Loaded {} file{}.: 已加载 {} 个文件{}。
+Make the first selection your primary one: 将第一个选区设为主选区
+Make the last selection your primary one: 将最后一个选区设为主选区
+'Malformed method call: {}': 格式错误的方法调用：{}
+Match: 匹配
+Match around: 匹配外部
+Match inside: 匹配内部
+Merge consecutive selections: 合并连续选区
+Merge selections: 合并选区
+'Method not found: {}': 方法未找到：{}
+Modify current search to make it word bounded: 使当前搜索变为词边界匹配
+Move backward in history: 回退到历史
+Move down: 下移
+Move forward in history: 前进到历史
+Move half page down: 下翻半页
+Move half page up: 上翻半页
+Move left: 左移
+Move page and cursor down: 页面下移，光标跟随
+Move page and cursor half down: 页面下移半页，光标跟随
+Move page and cursor half up: 页面上移半页，光标跟随
+Move page and cursor up: 页面上移，光标跟随
+Move page down: 下翻一页
+Move page up: 上翻一页
+Move right: 右移
+Move the current buffer and its corresponding file to a different path: 将当前缓冲区及其对应文件移动到其他路径
+Move the current buffer and its corresponding file to a different path creating necessary subdirectories: 将当前缓冲区及其对应文件移动到其他路径（创建必要的子目录）
+Move till next occurrence of char: 移动到字符前
+Move till previous occurrence of char: 移动到前一个字符前
+Move to beginning of the parent node: 移到父节点开头
+Move to end of next long word: 移到下一个长词尾
+Move to end of next sub word: 移到下一个子词尾
+Move to end of next word: 移到下一个词尾
+Move to end of previous long word: 移到上一个长词尾
+Move to end of previous sub word: 移到上一个子词尾
+Move to end of previous word: 移到上一个词尾
+Move to end of the parent node: 移到父节点末尾
+Move to next occurrence of char: 移动到下一个字符
+Move to previous occurrence of char: 移动到前一个字符
+Move to start of next long word: 移到下一个长词首
+Move to start of next sub word: 移到下一个子词首
+Move to start of next word: 移到下一个词首
+Move to start of previous long word: 移到上一个长词首
+Move to start of previous sub word: 移到上一个子词首
+Move to start of previous word: 移到上一个词首
+Move up: 上移
+Neither a dir, nor a file: 既不是目录也不是文件
+Never: 从不
+New split scratch buffer: 新建分割空白缓冲区
+No LSP server for this document: 此文档没有 LSP 服务器
+No arguments found with which to restart the sessions: 找不到用于重启会话的参数
+No breakpoints: 没有断点
+No changes to save: 没有要保存的更改
+No code actions available: 没有可用的代码操作
+No completions: 没有补全
+No configured language server supports code actions: 没有已配置的语言服务器支持代码操作
+No configured language server supports document symbols: 没有已配置的语言服务器支持文档符号
+No configured language server supports hover: 没有已配置的语言服务器支持悬停
+No configured language server supports range formatting: 没有已配置的语言服务器支持范围格式化
+No configured language server supports signature-help: 没有已配置的语言服务器支持签名帮助
+No configured language server supports symbol renaming: 没有已配置的语言服务器支持符号重命名
+No configured language server supports workspace symbols: 没有已配置的语言服务器支持工作区符号
+No configured language server supports {}: 没有已配置的语言服务器支持 {}
+No configured languages: 没有已配置的语言
+No debug adapter: 没有调试适配器
+No debug adapter available for language: 没有可用于该语言的调试适配器
+No declaration found: 未找到声明
+No declaration found.: 未找到声明。
+No definition found: 未找到定义
+No definition found.: 未找到定义。
+No diagnostics: 没有诊断信息
+No diagnostics under primary selection: 主选区下没有诊断信息
+No hover information: 没有悬停信息
+No hover results available.: 没有可用的悬停结果。
+No implementation found: 未找到实现
+No implementation found.: 未找到实现。
+No language server: 没有语言服务器
+No language server supporting document symbols or syntax info available: 没有支持文档符号或语法信息的语言服务器
+No location found.: 未找到位置。
+No more buffers: 没有更多缓冲区
+No more files: 没有更多文件
+No more jumps: 没有更多跳转
+No more matches: 没有更多匹配
+No previous working directory: 没有上一个工作目录
+No references found: 未找到引用
+No references found.: 未找到引用。
+No selections remaining: 没有剩余选区
+No signature help: 没有签名帮助
+No stack frames: 没有堆栈帧
+No symbol found: 未找到符号
+No threads: 没有线程
+No type definition found: 未找到类型定义
+No type definition found.: 未找到类型定义。
+No variables: 没有变量
+Normal mode: 普通模式
+Not now: 暂不
+Open a file from disk into the current view.: 从磁盘打开文件到当前视图。
+Open a scratch buffer in a horizontal split.: 在水平分割中打开空白缓冲区。
+Open a scratch buffer in a vertical split.: 在垂直分割中打开空白缓冲区。
+Open buffer picker: 打开缓冲区选择器
+Open changed file picker: 打开已更改文件选择器
+Open command palette: 打开命令面板
+Open diagnostic picker: 打开诊断选择器
+Open file explorer at current buffer's directory: 在当前缓冲区目录打开文件浏览器
+Open file explorer at current working directory: 在当前工作目录打开文件浏览器
+Open file explorer in workspace root: 在工作区根目录打开文件浏览器
+Open file failed: 打开文件失败
+Open file picker: 打开文件选择器
+Open file picker at current buffer's directory: 在当前缓冲区目录打开文件选择器
+Open file picker at current working directory: 在当前工作目录打开文件选择器
+Open jumplist picker: 打开跳转列表选择器
+Open last picker: 打开上次选择器
+Open new line above selection: 在选区上方打开新行
+Open new line below selection: 在选区下方打开新行
+Open symbol picker: 打开符号选择器
+Open symbol picker from LSP or syntax information: 从 LSP 或语法信息打开符号选择器
+Open symbol picker from syntax information: 从语法信息打开符号选择器
+Open the file in a horizontal split.: 在水平分割中打开文件。
+Open the file in a vertical split.: 在垂直分割中打开文件。
+Open the helix log file.: 打开 helix 日志文件。
+Open the tutorial.: 打开教程。
+Open the user config.toml file.: 打开用户 config.toml 文件。
+Open the workspace config.toml file.: 打开工作区 config.toml 文件。
+Open workspace command picker: 打开工作区命令选择器
+Open workspace diagnostic picker: 打开工作区诊断选择器
+Open workspace symbol picker: 打开工作区符号选择器
+Open workspace symbol picker from LSP or syntax information: 从 LSP 或语法信息打开工作区符号选择器
+Open workspace symbol picker from syntax information: 从语法信息打开工作区符号选择器
+Opening URL in external program failed: 在外部程序中打开 URL 失败
+Paragraph: 段落
+Paste after selection: 在选区后粘贴
+Paste before selection: 在选区前粘贴
+Paste clipboard after selections: 在选区后粘贴剪贴板
+Paste clipboard before selections: 在选区前粘贴剪贴板
+Paste primary clipboard after selections: 在选区后粘贴主剪贴板
+Paste primary clipboard after selections.: 在选区后粘贴主剪贴板。
+Paste primary clipboard before selections: 在选区前粘贴主剪贴板
+Paste primary clipboard before selections.: 在选区前粘贴主剪贴板。
+Paste system clipboard after selections.: 在选区后粘贴系统剪贴板。
+Paste system clipboard before selections.: 在选区前粘贴系统剪贴板。
+Pause program execution: 暂停程序执行
+Perform code action: 执行代码操作
+Pipe each selection to the shell command, ignoring output.: 将每个选区管道到 shell 命令，忽略输出。
+Pipe each selection to the shell command.: 将每个选区管道到 shell 命令。
+Pipe selections into shell command ignoring output: 将选区输入 shell 命令并忽略输出
+Pipe selections through shell command: 通过 shell 命令管道选区
+Press <ENTER> to continue with default config: 按 <ENTER> 继续使用默认配置
+Prints the given arguments to the statusline.: 将给定的参数打印到状态栏。
+Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).: 以退出码退出（默认 1）。可接受可选整数退出码 (:cq 2)。
+Record macro: 录制宏
+Recorded to register [: 已录制到寄存器 [
+Recording to register [: 正在录制到寄存器 [
+Redo change: 重做
+Refresh user config.: 刷新用户配置。
+Register [: 寄存器 [
+Register {} cleared: 寄存器 {} 已清除
+Register {} not found: 寄存器 {} 未找到
+Remove current workspace from the list of trusted workspaces.: 从受信任工作空间列表中移除当前工作空间。
+Remove primary selection: 移除主选区
+Remove selections matching regex: 移除匹配正则的选区
+Remove the top entry from the directory stack, and cd to the new top directory..: 从目录栈中移除顶部条目，并跳转到新的顶部目录。
+Rename failed: 重命名失败
+Rename symbol: 重命名符号
+Repeat last motion: 重复上次动作
+Replace selections by clipboard content: 用剪贴板内容替换选区
+Replace selections by primary clipboard: 用主剪贴板内容替换选区
+Replace selections with content of system clipboard.: 用系统剪贴板内容替换选区。
+Replace selections with content of system primary clipboard.: 用系统主剪贴板内容替换选区。
+Replace surrounding pair of: 替换包围对
+Replace with a pair of: 替换为一对
+Replace with new char: 替换为新字符
+Replace with yanked text: 用复制的文本替换
+Replay macro: 回放宏
+Reset the diff change at the cursor position.: 重置光标位置的 diff 更改。
+Reset {changes} change{}: 已重置 {changes} 个更改{}
+Restart debugging session: 重新启动调试会话
+? Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied
+: 重启指定的语言服务器，或在不提供参数时重启当前文件使用的所有语言服务器
+Reverse search for regex pattern: 反向搜索正则表达式
+Reverse selections contents: 反转选区内容
+Right bracket: 右括号
+Rotate selection contents forward: 向前轮换选区内容
+Rotate selections backward: 向后轮换选区
+Rotate selections contents backward: 向后轮换选区内容
+Rotate selections forward: 向前轮换选区
+Run a shell command: 运行 shell 命令
+Run shell command, appending output after each selection.: 运行 shell 命令，在每个选区后追加输出。
+Run shell command, inserting output before each selection.: 运行 shell 命令，在每个选区前插入输出。
+Runtime directory: 运行时目录
+Runtime directory does not exist: 运行时目录不存在
+Runtime directory is empty: 运行时目录为空
+'Runtime directory: {path}': 运行时目录：{path}
+Save and then change the current directory.: 保存并更改当前目录。
+Save current selection to jumplist: 保存当前选区到跳转列表
+Scroll view down: 向下滚动视图
+Scroll view up: 向上滚动视图
+Search for regex pattern: 搜索正则表达式
+Select all children of the current node: 选择当前节点的所有子节点
+Select all regex matches inside selections: 选择所有正则匹配
+Select all siblings of the current node: 选择当前节点的所有兄弟节点
+Select around object: 选择外部对象
+Select current line, if already selected, extend or shrink line above based on the anchor: 选择当前行，已选则根据锚点扩展或收缩到上一行
+Select current line, if already selected, extend or shrink line below based on the anchor: 选择当前行，已选则根据锚点扩展或收缩到下一行
+Select current line, if already selected, extend to another line based on the anchor: 选择当前行，已选则根据锚点扩展
+Select current line, if already selected, extend to next line: 选择当前行，已选则扩展到下一行
+Select current line, if already selected, extend to previous line: 选择当前行，已选则扩展到上一行
+Select inside object: 选择内部对象
+Select mode: 选择模式
+Select next search match: 选择下一个搜索结果
+Select next sibling in the syntax tree: 选择语法树中的下一个兄弟节点
+Select previous search match: 选择上一个搜索结果
+Select previous sibling the in syntax tree: 选择语法树中的上一个兄弟节点
+Select register: 选择寄存器
+Select symbol references: 选择符号引用
+Select whole document: 全选文档
+Selection saved to jumplist: 选区已保存到跳转列表
+? 'Set a config option at runtime.
+
+  For example to disable smart case search, use `:set search.smart-case false`.'
+: '在运行时设置配置选项。
+
+  例如要禁用智能大小写搜索，使用 `:set search.smart-case false`。'
+Set contents of the given register.: 设置指定寄存器的内容。
+Set encoding. Based on https://encoding.spec.whatwg.org: 设置编码。基于 https://encoding.spec.whatwg.org
+'Set the document''s default line ending. Options: crlf, lf, cr, ff, nel.': 设置文档的默认行尾。选项：crlf, lf, cr, ff, nel。
+'Set the document''s default line ending. Options: crlf, lf.': 设置文档的默认行尾。选项：crlf, lf。
+Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.): 设置缩进样式。（'t' 表示制表符，1-16 表示空格数。）
+Set the language of current buffer (show current language if no value specified).: 设置当前缓冲区的语言（不指定值则显示当前语言）。
+Shell command failed: Shell 命令失败
+Show clipboard provider name in status bar.: 在状态栏显示剪贴板提供者名称。
+Show docs for item under cursor: 显示光标下项目的文档
+Show signature help: 显示签名帮助
+Show the current working directory.: 显示当前工作目录。
+Show the directory stack as a <space> delimited string.: 显示目录栈。
+Shrink selection to line bounds: 收缩到行边界
+Shrink selection to previously expanded syntax node: 收缩到上次扩展的语法节点
+Sort ranges in selection.: 对选区中的范围进行排序。
+'Sorting requires multiple selections. Hint: split selection first': 排序需要多个选区。提示：先分割选区
+Space: 空格
+Split selection on newlines: 按换行符分割选区
+Split selections on regex matches: 按正则分割选区
+Stack is empty: 栈为空
+Start a debug session from a given template with given parameters.: 从给定模板和参数启动调试会话。
+Step in: 步入
+Step out: 步出
+Step to next: 步过
+Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied: 停止指定的语言服务器，或在不提供参数时停止当前文件使用的所有语言服务器
+Surround add: 添加包围符
+Surround delete: 删除包围符
+Surround replace: 替换包围符
+Suspend and return to shell: 挂起并返回 shell
+Swap with left split: 与左侧分割交换
+Swap with right split: 与右侧分割交换
+Swap with split above: 与上方分割交换
+Swap with split below: 与下方分割交换
+Switch: 切换
+Switch (toggle) case: 切换大小写
+Switch current thread: 切换当前线程
+Switch stack frame: 切换堆栈帧
+Switch to lowercase: 转为小写
+Switch to uppercase: 转为大写
+Syntax tree is not available on this buffer: 此缓冲区没有语法树
+Syntax-tree is not available in current buffer: 当前缓冲区没有语法树
+'System clipboard provider: Not installed': 系统剪贴板提供者：未安装
+Terminating debug session...: 正在终止调试会话...
+Test (tree-sitter): 测试 (tree-sitter)
+'Text doc sync: {sync}': 文本文档同步：{sync}
+The line you jumped to does not exist anymore because the file has changed.: 你跳转到的行已不存在，因为文件已更改。
+The location you jumped to does not exist anymore because the file has changed.: 你跳转到的位置已不存在，因为文件已更改。
+There are no changes under any selection: 任何选区下都没有更改
+This list is filtered according to the 'use-grammars' option in languages.toml file.: 此列表根据 languages.toml 文件中的 'use-grammars' 选项进行了过滤。
+To see the full list, use the '--health all' or '--health all-languages' option.: 查看完整列表，请使用 '--health all' 或 '--health all-languages' 选项。
+? 'Toggle a config option at runtime.
+
+  For example to toggle smart case search, use `:toggle search.smart-case`.'
+: '在运行时切换配置选项。
+
+  例如要切换智能大小写搜索，使用 `:toggle search.smart-case`。'
+Toggle breakpoint: 切换断点
+Transpose splits: 转置分割
+Trim whitespace from selections: 修剪选区中的空白
+Trust this workspace?: 信任此工作空间？
+Type definition (tree-sitter): 类型定义 (tree-sitter)
+Undo change: 撤销
+Unindent selection: 减少缩进
+Unknown key `{}`: 未知键 `{}`
+'Unknown language server{s}: {}': 未知语言服务器{s}：{}
+'Unsupported theme: theme requires true color support': 不支持的主题：主题需要真彩色支持
+Use current selection as search pattern: 使用当前选区作为搜索模式
+Use current selection as the search pattern, automatically wrapping with \b on word boundaries: 使用当前选区作为搜索模式，自动添加词边界 \b
+Using default language config: 使用默认语言配置
+Vertical right split: 垂直右分割
+Vertical right split scratch buffer: 垂直右分割新建缓冲区
+View: 视图
+WORD: 大词
+Window: 窗口
+Word: 词
+Workspace directory does not exist: 工作区目录不存在
+Wrapped around document: 已环绕文档
+Write changes from all buffers to disk and close all views.: 将所有缓冲区的更改写入磁盘并关闭所有视图。
+Write changes from all buffers to disk.: 将所有缓冲区的更改写入磁盘。
+Write changes only if the file has been modified.: 仅在文件已修改时写入更改。
+Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt): 写入磁盘并强制关闭当前视图。可接受可选路径 (:wq! some/path.txt)
+Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt): 写入磁盘并关闭当前视图。可接受可选路径 (:wq some/path.txt)
+Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt): 写入磁盘并关闭缓冲区。可接受可选路径 (:write-buffer-close some/path.txt)
+Write changes to disk if the buffer is modified and then quit. Accepts an optional path (:exit some/path.txt).: 如果缓冲区已修改则写入磁盘并退出。可接受可选路径 (:exit some/path.txt)。
+Write changes to disk. Accepts an optional path (:write some/path.txt): 写入更改到磁盘。可接受可选路径 (:write some/path.txt)
+Yank diagnostic(s) under primary cursor to register, or clipboard by default: 复制主光标下的诊断信息到寄存器，默认为剪贴板
+Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline.: 复制连接的选区到系统剪贴板。可将分隔符作为第一个参数提供。默认值为换行符。
+? Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline.
+: 复制连接的选区到系统主剪贴板。可将分隔符作为第一个参数提供。默认值为换行符。
+Yank joined selections. A separator can be provided as first argument. Default value is newline.: 复制连接的选区。可将分隔符作为第一个参数提供。默认值为换行符。
+Yank main selection into system clipboard.: 复制主选区到系统剪贴板。
+Yank main selection into system primary clipboard.: 复制主选区到系统主剪贴板。
+Yank main selection to clipboard: 复制主选区到剪贴板
+Yank main selection to primary clipboard: 复制主选区到主剪贴板
+Yank selection: 复制选区
+Yank selections to clipboard: 复制选区到剪贴板
+Yank selections to primary clipboard: 复制选区到主剪贴板
+Yanked {n} diagnostic{} to register {reg}: 已复制 {n} 个诊断{}到寄存器 {reg}
+'[+]': '[+]'
+'] because already replaying from same register': '] 因为已在从同一寄存器回放'
+'] empty': '] 为空'
+'`{command}` is not supported for any language server': '`{command}` 不被任何语言服务器支持'
+'`{command}` supported by multiple language servers': '`{command}` 被多个语言服务器支持'
+align cannot work with multi line selections: align 不能处理多行选区
+can't move file, parent directory does not exist (use :mv! to create it): 无法移动文件，父目录不存在（使用 :mv! 创建）
+'cannot close non-existent buffers: {}': 无法关闭不存在的缓冲区：{}
+carriage return: 回车
+class: 类
+color: '颜色 '
+'color ': '颜色 '
+conflict: 冲突
+constant: 常量
+constructor: 构造函数
+crlf: crlf
+deleted: 已删除
+enum: 枚举
+enum member: 枚举成员
+error: 错误
+'error opening file: {}': 打开文件出错：{}
+'error reading file: {}': 读取文件出错：{}
+event: 事件
+field: 字段
+file: 文件
+folder: 文件夹
+form feed: 换页
+format_selections only supports a single selection for now: format_selections 目前只支持单个选区
+from register: 从寄存器
+function: 函数
+inserting multiple newlines not yet supported: 尚不支持插入多个换行
+interface: 接口
+is empty: 为空
+'is symlinked to: {}': 符号链接到：{}
+joined and: 连接并
+keyword: 关键字
+line feed: 换行
+method: 方法
+modified: 已修改
+module: 模块
+next line: 下一行
+no last accessed buffer: 没有上次访问的缓冲区
+no last modified buffer: 没有上次修改的缓冲区
+no last picker: 没有上次选择器
+no selections remaining: 没有剩余选区
+no snippet is currently active: 当前没有活动的代码片段
+'no such command: ''{cmd}''': 没有此命令：'{cmd}'
+nothing selected: 没有选中任何内容
+operator: 运算符
+'path is not a file: {:?}': 路径不是文件：{:?}
+primary selection: 主选区
+property: 属性
+reference: 引用
+register: 寄存器
+'register ': '寄存器 '
+renamed: 已重命名
+selection: 选区
+skip auto-formatting: 跳过自动格式化
+snippet: 代码片段
+sort ranges in reverse order: 反向排序
+sort the ranges case-insensitively: 不区分大小写排序
+struct: 结构体
+tabs: 制表符
+text: 文本
+to: 到
+to register: 到寄存器
+type parameter: 类型参数
+'unable to convert URI to filepath: {:?}': 无法将 URI 转换为文件路径：{:?}
+unable to open: 无法打开
+unit: 单位
+untracked: 未跟踪
+value: 值
+variable: 变量
+version: 1
+yanked: 已复制
+'{:?} cannot be mapped to {}': '{:?} 无法映射到 {}'
+'{} (deleted)': '{}（已删除）'
+'{} spaces': '{} 个空格'
+'{} unsaved buffer{} remaining: {:?}': 剩余 {} 个未保存的缓冲区{}：{:?}
+▸ {}: ▸ {}

--- a/helix-term/i18n/zh-TW.yml
+++ b/helix-term/i18n/zh-TW.yml
@@ -1,0 +1,935 @@
+' 1 sel ': ' 1 個選區 '
+' W ': ' W '
+' [readonly] ': ' [只讀] '
+' char': ' 字符'
+' chars': ' 字符'
+' reg={} ': ' 寄存器={} '
+' sel ': ' 選區 '
+' sels ': ' 選區 '
+' set to ': ' 設爲 '
+' space': ' 空格'
+' spaces': ' 空格'
+' tabs ': ' 製表符 '
+'''{key}'' is now set to {value}': '''{key}'' 現已設爲 {value}'
+'''{}'' not found in $PATH': '''{}'' 未在 $PATH 中找到'
+'''{}'' written, {lines}L {size}': '''{}'' 已寫入，{lines} 行 {size}'
+(X)HTML element (tree-sitter): (X)HTML 元素 (tree-sitter)
+'... or any character acting as a pair': '... 或任何作爲配對符的字符'
+1 space: 1 個空格
+<Binary file>: <二進制文件>
+<File not found>: <文件未找到>
+<File too large to preview>: <文件太大無法預覽>
+<Invalid directory location>: <無效目錄位置>
+<Invalid file location>: <無效文件位置>
+Add current workspace to the list of trusted workspaces.: 將當前工作空間添加到受信任工作空間列表。
+Add newline above: 在上方添加換行
+Add newline below: 在下方添加換行
+Add next search match to selection: 添加下一個搜索結果到選區
+Add previous search match to selection: 添加上一個搜索結果到選區
+Align selections in column: 對齊選區到列
+Align view bottom: 視圖底部對齊
+Align view center: 視圖居中對齊
+Align view middle: 視圖居中對齊
+Align view top: 視圖頂部對齊
+All registers cleared: 所有寄存器已清除
+Already at line end: 已在行尾
+Already at line start: 已在行首
+Already at newest change: 已在最新的更改處
+Already at oldest change: 已在最舊的更改處
+Always: 始終
+Append after selection: 在選區後追加
+Append an interactively-chosen char: 交互式追加字符
+Append shell command output after selections: 在選區後追加 shell 命令輸出
+Argument/parameter (tree-sitter): 參數 (tree-sitter)
+Auto-save failed: 自動保存失敗
+'Bad arguments. For boolean configurations use: `:toggle {key}`': 參數錯誤。布爾配置請使用：`:toggle {key}`
+'Bad arguments. For string configurations use: `:toggle {key} val1 val2 ...`': 參數錯誤。字符串配置請使用：`:toggle {key} val1 val2 ...`
+Block comment/uncomment selections: 塊註釋/取消註釋選區
+Buffer not modified: 緩衝區未修改
+'Can''t set breakpoint: document has no path': 無法設置斷點：文檔沒有路徑
+Cannot abort: 無法中止
+Cannot accept: 無法接受
+Cannot access variables while target is running.: 目標運行時無法訪問變量。
+Cannot acquire: 無法獲取
+Cannot add: 無法添加
+Cannot add hook: 無法添加鉤子
+Cannot allocate: 無法分配
+Cannot apply: 無法應用
+Cannot authenticate: 無法認證
+Cannot authorize: 無法授權
+Cannot backup: 無法備份
+Cannot begin: 無法開始
+Cannot benchmark: 無法基準測試
+Cannot bind: 無法綁定
+Cannot blame: 無法追溯
+Cannot block: 無法阻塞
+Cannot branch: 無法創建分支
+Cannot bridge: 無法橋接
+Cannot broadcast: 無法廣播
+Cannot buffer: 無法緩衝
+Cannot calculate: 無法計算
+Cannot cancel: 無法取消
+Cannot capture: 無法捕獲
+Cannot catch: 無法捕獲
+Cannot change directory: 無法更改目錄
+Cannot check: 無法檢查
+Cannot checkout: 無法檢出
+Cannot cherry-pick: 無法揀選
+Cannot clear state: 無法清除狀態
+Cannot clock: 無法時鐘
+Cannot clone: 無法克隆
+Cannot close: 無法關閉
+Cannot close connection: 無法關閉連接
+Cannot commit: 無法提交
+Cannot complete: 無法完成
+Cannot compress: 無法壓縮
+Cannot compute: 無法計算
+Cannot connect: 無法連接
+Cannot connect to server: 無法連接到服務器
+Cannot convert: 無法轉換
+Cannot create: 無法創建
+Cannot create directory: 無法創建目錄
+Cannot deallocate: 無法釋放
+Cannot decode: 無法解碼
+Cannot decompress: 無法解壓縮
+Cannot decrypt: 無法解密
+Cannot default: 無法默認
+Cannot delete file: 無法刪除文件
+Cannot deliver: 無法投遞
+Cannot dequeue: 無法出隊
+Cannot describe: 無法描述
+Cannot destroy: 無法銷燬
+Cannot detect: 無法檢測
+Cannot determine: 無法確定
+Cannot diff: 無法比較
+Cannot disconnect: 無法斷開
+Cannot disconnect from server: 無法斷開服務器連接
+Cannot dispatch: 無法分發
+Cannot download: 無法下載
+Cannot emit hook: 無法發射鉤子
+Cannot encode: 無法編碼
+Cannot encrypt: 無法加密
+Cannot end: 無法結束
+Cannot enqueue: 無法入隊
+Cannot epoll: 無法 epoll
+Cannot evaluate: 無法評估
+Cannot eventfd: 無法 eventfd
+Cannot exec: 無法 exec
+Cannot execute: 無法執行
+Cannot execute command: 無法執行命令
+Cannot execute macro because the [@] register is already playing a macro: 無法執行宏，因爲 [@] 寄存器已在回放宏
+Cannot fetch: 無法獲取
+Cannot finalize: 無法完成
+Cannot find: 無法查找
+Cannot find current stack frame to access variables: 找不到當前棧幀來訪問變量
+Cannot find current stack frame to access variables.: 找不到當前棧幀來訪問變量。
+Cannot finish: 無法完成
+Cannot fire hook: 無法觸發鉤子
+Cannot flush connection: 無法刷新連接
+Cannot fork: 無法 fork
+Cannot format: 無法格式化
+Cannot forward: 無法轉發
+Cannot free: 無法釋放
+Cannot fsevents: 無法 fsevents
+Cannot get handler: 無法獲取處理器
+Cannot grep: 無法搜索
+Cannot handle: 無法處理
+Cannot handle notification: 無法處理通知
+Cannot handle request: 無法處理請求
+Cannot identify: 無法識別
+Cannot ignore: 無法忽略
+Cannot init: 無法初始化
+Cannot initialize: 無法初始化
+Cannot initialize connection: 無法初始化連接
+Cannot inotify: 無法 inotify
+Cannot invoke hook: 無法調用鉤子
+Cannot iocp: 無法 iocp
+Cannot kill: 無法 kill
+Cannot kqueue: 無法 kqueue
+Cannot lex: 無法詞法分析
+Cannot listen: 無法監聽
+Cannot listen hook: 無法監聽鉤子
+Cannot load state: 無法加載狀態
+Cannot locate: 無法定位
+Cannot lock: 無法鎖定
+Cannot log: 無法查看日誌
+Cannot lookup: 無法查找
+Cannot match: 無法匹配
+Cannot measure: 無法測量
+Cannot merge: 無法合併
+Cannot monitor: 無法監控
+Cannot notify: 無法通知
+Cannot notify hook: 無法通知鉤子
+Cannot observe: 無法觀察
+Cannot open: 無法打開
+Cannot open connection: 無法打開連接
+Cannot open document: 無法打開文檔
+Cannot parse: 無法解析
+Cannot parse response: 無法解析響應
+Cannot pause: 無法暫停
+Cannot peek: 無法查看
+Cannot play: 無法播放
+Cannot poll: 無法輪詢
+Cannot pop: 無法彈出
+Cannot process response: 無法處理響應
+Cannot profile: 無法分析
+Cannot proxy: 無法代理
+Cannot publish hook: 無法發佈鉤子
+Cannot pull: 無法拉取
+Cannot push: 無法推入
+Cannot query: 無法查詢
+Cannot queue: 無法入隊
+Cannot raise: 無法 raise
+Cannot read connection: 無法讀取連接
+Cannot read file: 無法讀取文件
+Cannot rebase: 無法變基
+Cannot receive: 無法接收
+Cannot receive response: 無法接收響應
+Cannot reconnect: 無法重新連接
+Cannot record: 無法錄製
+Cannot recover: 無法恢復
+Cannot redirect: 無法重定向
+Cannot register handler: 無法註冊處理器
+Cannot relay: 無法中繼
+Cannot release: 無法釋放
+Cannot remove: 無法移除
+Cannot remove hook: 無法移除鉤子
+Cannot rename: 無法重命名
+Cannot repeat: 無法重複
+Cannot replace: 無法替換
+Cannot replay: 無法重播
+Cannot replay from register [: 無法從寄存器 [ 回放
+Cannot reserve: 無法預留
+Cannot reset: 無法重置
+Cannot reset connection: 無法重置連接
+Cannot reset state: 無法重置狀態
+Cannot resolve: 無法解析
+Cannot restore: 無法還原
+Cannot resume: 無法恢復
+Cannot retry: 無法重試
+Cannot revert: 無法還原
+Cannot route: 無法路由
+Cannot run: 無法運行
+Cannot save: 無法保存
+Cannot save state: 無法保存狀態
+Cannot scan: 無法掃描
+Cannot schedule: 無法調度
+Cannot search: 無法搜索
+Cannot select: 無法選擇
+Cannot send: 無法發送
+Cannot send notification: 無法發送通知
+Cannot send request: 無法發送請求
+Cannot send response: 無法發送響應
+Cannot serialize request: 無法序列化請求
+Cannot set handler: 無法設置處理器
+Cannot show: 無法顯示
+Cannot shutdown connection: 無法關閉連接
+Cannot sign: 無法簽名
+Cannot signal: 無法發信號
+Cannot signalfd: 無法 signalfd
+Cannot spawn: 無法派生
+Cannot split: 無法分割
+Cannot start: 無法啓動
+Cannot stash: 無法儲藏
+Cannot status: 無法查看狀態
+Cannot stop: 無法停止
+Cannot stream: 無法流式傳輸
+Cannot subscribe hook: 無法訂閱鉤子
+Cannot substitute: 無法替代
+Cannot sync: 無法同步
+Cannot tag: 無法打標籤
+Cannot terminate: 無法終止
+Cannot terminate connection: 無法終止連接
+Cannot test: 無法測試
+Cannot time: 無法計時
+Cannot timerfd: 無法 timerfd
+Cannot tokenize: 無法分詞
+Cannot trace: 無法追蹤
+Cannot track: 無法跟蹤
+Cannot transform: 無法轉換
+Cannot translate: 無法翻譯
+Cannot transmit: 無法傳輸
+Cannot trigger hook: 無法觸發鉤子
+Cannot tunnel: 無法隧道
+Cannot unblock: 無法解除阻塞
+Cannot unlock: 無法解鎖
+Cannot unregister handler: 無法註銷處理器
+Cannot unsubscribe hook: 無法取消訂閱鉤子
+Cannot unwatch: 無法取消監視
+Cannot upload: 無法上傳
+Cannot validate: 無法驗證
+Cannot validate response: 無法驗證響應
+Cannot verify: 無法驗證
+Cannot wait: 無法等待
+Cannot waitpid: 無法 waitpid
+Cannot watch: 無法監視
+Cannot write connection: 無法寫入連接
+Cannot write file: 無法寫入文件
+Cannot write to file: 無法寫入文件
+Cannot yield: 無法讓出
+Change: 更改
+Change selection: 修改選區
+Change selection without yanking: 修改選區（不復制）
+Change the current working directory.: 更改當前工作目錄。
+Change the editor theme (show current theme if no name specified).: 更改編輯器主題（不指定名稱則顯示當前主題）。
+Checking config: 檢查配置
+'Checking language: {lang}': 檢查語言：{lang}
+Clear and re-render the whole UI: 清除並重新渲染整個 UI
+Clear given register. If no argument is provided, clear all registers.: 清除指定寄存器。如果不提供參數，清除所有寄存器。
+Close all buffers but the currently focused one.: 關閉除當前聚焦緩衝區外的所有緩衝區。
+Close all buffers without quitting.: 關閉所有緩衝區但不退出。
+Close all views.: 關閉所有視圖。
+Close the current buffer forcefully, ignoring unsaved changes.: 強制關閉當前緩衝區，忽略未保存的更改。
+Close the current buffer.: 關閉當前緩衝區。
+Close the current view.: 關閉當前視圖。
+Close window: 關閉窗口
+Close windows except current: 僅保留當前窗口
+Closest surrounding pair (tree-sitter): 最近的包圍對 (tree-sitter)
+Collapse selection into single cursor: 摺疊選區爲單個光標
+Command run: 命令已執行
+Comment (tree-sitter): 註釋 (tree-sitter)
+Comment/uncomment selections: 註釋/取消註釋選區
+Commit changes to new checkpoint: 提交更改到新檢查點
+'Config directory: {path}': 配置目錄：{path}
+'Config file: default': 配置文件：默認
+'Config file: {path}': 配置文件：{path}
+Config refreshed: 配置已刷新
+Configuration file malformed: 配置文件格式錯誤
+'Configured language server: {name}': 已配置的語言服務器：{name}
+Connect to a debug adapter by TCP address and start a debugging session from a given template with given parameters.: 通過 TCP 地址連接到調試適配器，並從給定模板和參數啓動調試會話。
+Continue program execution: 繼續執行程序
+Copy between two registers: 在兩個寄存器之間複製
+Copy selection on next line: 在下一行復制選區
+Copy selection on previous line: 在上一行復制選區
+'Could not change working directory to ''{}'': {err}': '無法切換工作目錄到 ''{}'': {err}'
+Could not parse field `{}`: 無法解析字段 `{}`
+Create a new scratch buffer.: 創建新的空白緩衝區。
+Current buffer has no parent and current working directory does not exist: 當前緩衝區沒有父目錄且當前工作目錄不存在
+Current buffer has no parent, opening file explorer in current working directory: 當前緩衝區沒有父目錄，在當前工作目錄打開文件瀏覽器
+Current buffer has no parent, opening file picker in current working directory: 當前緩衝區沒有父目錄，在當前工作目錄打開文件選擇器
+Current working directory does not exist: 當前工作目錄不存在
+Current working directory is now {}: 當前工作目錄現在是 {}
+Current working directory is {}: 當前工作目錄是 {}
+Currently active thread is not stopped. Switch the thread.: 當前線程未停止。請切換線程。
+'Data directory: {path}': 數據目錄：{path}
+Data structure entry (tree-sitter): 數據結構條目 (tree-sitter)
+Debug (experimental): 調試（實驗性）
+Debug session failed: 調試會話失敗
+Debugger does not support session restarts: 調試器不支持會話重啓
+Debugger is already running: 調試器已在運行
+Debugger is not running: 調試器未運行
+Debugging session restarted: 調試會話已重啓
+Dec {}: 十進制 {}
+Decrement item under cursor: 遞減光標下的值
+Delete next char: 刪除下一個字符
+Delete next word: 刪除下一個詞
+Delete previous char: 刪除前一個字符
+Delete previous word: 刪除前一個詞
+Delete selection: 刪除選區
+Delete selection without yanking: 刪除選區（不復制）
+Delete surrounding pair of: 刪除包圍對
+Delete till end of line: 刪除到行尾
+Delete till start of line: 刪除到行首
+'Diagnostic provider: {provider}': 診斷提供者：{provider}
+'Did you mean one of these: {} ?': 你是指以下之一：{} ？
+Diff is not available in current buffer: 當前緩衝區沒有差異信息
+Diff is not available in the current buffer: 當前緩衝區沒有差異信息
+Directory not found: 目錄未找到
+Disable exception breakpoints: 禁用異常斷點
+Discard changes and reload all documents from the source files.: 丟棄所有更改並從源文件重新加載所有文檔。
+Discard changes and reload from the source file.: 丟棄更改並從源文件重新加載。
+Display language names of tree-sitter injection layers under the cursor.: 顯示光標下 tree-sitter 注入層的語言名稱。
+Display name of tree-sitter highlight scope under the cursor.: 顯示光標下 tree-sitter 高亮作用域的名稱。
+Display the smallest tree-sitter subtree that spans the primary selection, primarily for debugging queries.: 顯示覆蓋主選區的最小 tree-sitter 子樹，主要用於調試查詢。
+Display tree sitter scopes, primarily for theming and development.: 顯示 tree-sitter 作用域，主要用於主題開發和調試。
+Do nothing: 無操作
+Does nothing.: 無操作。
+Edit breakpoint condition on current line: 編輯當前行斷點條件
+Edit breakpoint log message on current line: 編輯當前行斷點日誌消息
+Enable exception breakpoints: 啓用異常斷點
+End debug session: 結束調試會話
+Ensure all selections face forward: 確保所有選區方向向前
+Enter command mode: 進入命令模式
+Enter normal mode: 進入普通模式
+Enter selection extend mode: 進入選擇擴展模式
+Error parsing user language config: 解析用戶語言配置出錯
+Error saving: 保存出錯
+Evaluate expression in current debug context.: 在當前調試上下文中計算表達式。
+Exit selection mode: 退出選擇模式
+Expand selection to parent syntax node: 擴展到父語法節點
+Extend down: 向下擴展
+Extend left: 向左擴展
+Extend right: 向右擴展
+Extend selection to line bounds: 擴展到行邊界
+Extend till next occurrence of char: 擴展到字符前
+Extend till previous occurrence of char: 擴展到前一個字符前
+Extend to a two-character label: 擴展到雙字符標籤
+Extend to beginning of the parent node: 擴展到父節點開頭
+Extend to column: 擴展到指定列
+Extend to end of next long word: 擴展到下一個長詞尾
+Extend to end of next sub word: 擴展到下一個子詞尾
+Extend to end of next word: 擴展到下一個詞尾
+Extend to end of prev long word: 擴展到上一個長詞尾
+Extend to end of prev sub word: 擴展到上一個子詞尾
+Extend to end of previous word: 擴展到上一個詞尾
+Extend to end of the parent node: 擴展到父節點末尾
+Extend to file end: 擴展到文件末尾
+Extend to first non-blank in line: 擴展到行首第一個非空白字符
+Extend to last line: 擴展到最後一行
+Extend to line end: 擴展到行尾
+Extend to line number <n> else file start: 擴展到第 <n> 行或文件開頭
+Extend to line start: 擴展到行首
+Extend to next occurrence of char: 擴展到下一個字符
+Extend to previous occurrence of char: 擴展到前一個字符
+Extend to start of next long word: 擴展到下一個長詞首
+Extend to start of next sub word: 擴展到下一個子詞首
+Extend to start of next word: 擴展到下一個詞首
+Extend to start of previous long word: 擴展到上一個長詞首
+Extend to start of previous sub word: 擴展到上一個子詞首
+Extend to start of previous word: 擴展到上一個詞首
+Extend up: 向上擴展
+'Failed to get scopes: {}': 獲取作用域失敗：{}
+'Failed to get stack frame for thread: {thread_id}': 獲取線程 {thread_id} 的棧幀失敗
+'Failed to open file ': '打開文件失敗 '
+'Failed to open file ''{uri:?}'': {e}': 打開文件 '{uri:?}' 失敗：{e}
+'Failed to pause: {}': 暫停失敗：{}
+'Failed to set breakpoints: {}': 設置斷點失敗：{}
+File not found: 文件未找到
+Filter selections with shell predicate: 用 shell 謂詞過濾選區
+Flip selection cursor and anchor: 翻轉選區光標和錨點
+For troubleshooting system clipboard issues, refer: 排查系統剪貼板問題，請參考
+Force close all buffers but the currently focused one.: 強制關閉除當前聚焦緩衝區外的所有緩衝區。
+Force close all buffers ignoring unsaved changes without quitting.: 強制關閉所有緩衝區（忽略未保存的更改）但不退出。
+Force close all views ignoring unsaved changes.: 強制關閉所有視圖，忽略未保存的更改。
+Force close the current view, ignoring unsaved changes.: 強制關閉當前視圖，忽略未保存的更改。
+Force quit with exit code (default 1) ignoring unsaved changes. Accepts an optional integer exit code (:cq! 2).: 強制以退出碼退出（默認 1），忽略未保存的更改。可接受可選整數退出碼 (:cq! 2)。
+? Force write changes to disk creating necessary subdirectories and closes the buffer. Accepts an optional path (:write-buffer-close! some/path.txt)
+: 強制寫入磁盤（創建必要的子目錄）並關閉緩衝區。可接受可選路徑 (:write-buffer-close! some/path.txt)
+Force write changes to disk creating necessary subdirectories. Accepts an optional path (:write! some/path.txt): 強制寫入磁盤（創建必要的子目錄）。可接受可選路徑 (:write! some/path.txt)
+? Force write changes to disk, creating necessary subdirectories, if the buffer is modified and then quit. Accepts an optional path (:exit! some/path.txt).
+: 強制寫入磁盤（創建必要的子目錄），如果緩衝區已修改則退出。可接受可選路徑 (:exit! some/path.txt)。
+Forcefully write changes from all buffers to disk creating necessary subdirectories.: 強制將所有緩衝區的更改寫入磁盤（創建必要的子目錄）。
+? Forcefully write changes from all buffers to disk, creating necessary subdirectories, and close all views (ignoring unsaved changes).
+: 強制將所有緩衝區的更改寫入磁盤（創建必要的子目錄）並關閉所有視圖（忽略未保存的更改）。
+Format failed: 格式化失敗
+Format selection: 格式化選區
+Format the file using an external formatter or language server.: 使用外部格式化工具或語言服務器格式化文件。
+'Found language server: {name}': 找到語言服務器：{name}
+Function (tree-sitter): 函數 (tree-sitter)
+Get info about the character under the primary cursor.: 獲取主光標下字符的信息。
+Get the current value of a config option.: 獲取配置選項的當前值。
+Global search in workspace folder: 全局搜索工作區
+Goto: 跳轉
+Goto column: 跳轉到指定列
+Goto declaration: 跳轉到聲明
+Goto definition: 跳轉到定義
+Goto file end: 跳轉到文件末尾
+Goto files in selections (hsplit): 跳轉到選區中的文件（水平分割）
+Goto files in selections (vsplit): 跳轉到選區中的文件（垂直分割）
+Goto files/URLs in selections: 跳轉到選區中的文件/URL
+Goto first change: 跳轉到第一個更改
+Goto first diagnostic: 跳轉到第一個診斷
+Goto first non-blank in line: 跳轉到行首第一個非空白字符
+Goto implementation: 跳轉到實現
+Goto last accessed file: 跳轉到上次訪問的文件
+Goto last change: 跳轉到最後一個更改
+Goto last diagnostic: 跳轉到最後一個診斷
+Goto last line: 跳轉到最後一行
+Goto last modification: 跳轉到上次修改位置
+Goto last modified file: 跳轉到上次修改的文件
+Goto line: 跳轉到指定行
+Goto line end: 跳轉到行尾
+Goto line number <n> else file start: 跳轉到第 <n> 行或文件開頭
+Goto line number.: 跳轉到行號。
+Goto line start: 跳轉到行首
+Goto matching bracket: 跳轉到匹配括號
+Goto newline at line end: 跳轉到行尾換行符
+Goto next (X)HTML element: 跳轉到下一個 (X)HTML 元素
+Goto next buffer: 跳轉到下一個緩衝區
+Goto next buffer.: 跳轉到下一個緩衝區。
+Goto next change: 跳轉到下一個更改
+Goto next comment: 跳轉到下一個註釋
+Goto next diagnostic: 跳轉到下一個診斷
+Goto next function: 跳轉到下一個函數
+Goto next pairing: 跳轉到下一個配對
+Goto next paragraph: 跳轉到下一個段落
+Goto next parameter: 跳轉到下一個參數
+Goto next snippet placeholder: 跳轉到上一個代碼片段佔位符
+Goto next test: 跳轉到下一個測試
+Goto next type definition: 跳轉到下一個類型定義
+Goto next window: 跳轉到下一個窗口
+Goto previous (X)HTML element: 跳轉到上一個 (X)HTML 元素
+Goto previous buffer: 跳轉到上一個緩衝區
+Goto previous buffer.: 跳轉到上一個緩衝區。
+Goto previous change: 跳轉到上一個更改
+Goto previous comment: 跳轉到上一個註釋
+Goto previous diagnostic: 跳轉到上一個診斷
+Goto previous function: 跳轉到上一個函數
+Goto previous pairing: 跳轉到上一個配對
+Goto previous paragraph: 跳轉到上一個段落
+Goto previous parameter: 跳轉到上一個參數
+Goto previous test: 跳轉到上一個測試
+Goto previous type definition: 跳轉到上一個類型定義
+Goto previous window: 跳轉到上一個窗口
+Goto references: 跳轉到引用
+Goto type definition: 跳轉到類型定義
+Goto window bottom: 跳轉到窗口底部
+Goto window center: 跳轉到窗口中部
+Goto window top: 跳轉到窗口頂部
+Hard-wrap the current selection of lines to a given width.: 將當前選中的行硬包裝到指定寬度。
+'Highlight provider: {name}': 高亮提供者：{name}
+Horizontal bottom split: 水平底部分割
+Horizontal bottom split scratch buffer: 水平底部分割新建緩衝區
+Increment item under cursor: 遞增光標下的值
+Indent selection: 縮進選區
+Insert an interactively-chosen char: 交互式插入字符
+Insert at end of line: 在行尾插入
+Insert at start of line: 在行首插入
+Insert before selection: 在選區前插入
+Insert mode: 插入模式
+Insert newline char: 插入換行符
+Insert register: 插入寄存器
+Insert shell command output before selections: 在選區前插入 shell 命令輸出
+Insert tab char: 插入製表符
+Insert tab if all cursors have all whitespace to their left; otherwise, run a separate command.: 如果所有光標左側都是空白則插入製表符，否則執行單獨的命令
+Invalid encoding: 無效編碼
+Invalid indent style: 無效縮進樣式
+Invalid language: 無效語言
+Invalid line ending: 無效行尾
+Invalid macro: 無效宏
+Invalid option: 無效選項
+Invalid register: 無效寄存器
+Invalid register {s}: 無效寄存器 {s}
+Invalid register {}: 無效寄存器 {}
+Invalid theme: 無效主題
+Invalid value: 無效值
+Invoke completion popup: 觸發補全彈出
+Join and yank selections: 連接並複製選區
+Join and yank selections to clipboard: 連接並複製選區到剪貼板
+Join and yank selections to primary clipboard: 連接並複製選區到主剪貼板
+Join lines inside selection: 合併選區內的行
+Join lines inside selection and select spaces: 合併選區內的行並選擇空格
+Jump back to an earlier point in edit history. Accepts a number of steps or a time span.: 回退到編輯歷史的較早時間點。可接受步數或時間段。
+Jump backward on jumplist: 向後跳轉
+Jump forward on jumplist: 向前跳轉
+Jump to a later point in edit history. Accepts a number of steps or a time span.: 前進到編輯歷史的較晚時間點。可接受步數或時間段。
+Jump to a two-character label: 跳轉到雙字符標籤
+Jump to left split: 跳轉到左側分割
+Jump to right split: 跳轉到右側分割
+Jump to split above: 跳轉到上方分割
+Jump to split below: 跳轉到下方分割
+Keep primary selection: 保留主選區
+Keep selections matching regex: 保留匹配正則的選區
+Language '{lang}' not found: 未找到語言 '{lang}'
+Language '{}' not found: 語言 '{}' 未找到
+Language Server disappeared: 語言服務器已消失
+Language server exited: 語言服務器已退出
+'Language server not configured for: {lang}': 未配置語言服務器：{lang}
+'Language server not found: {name}': 未找到語言服務器：{name}
+'Language server not running: {name}': 語言服務器未運行：{name}
+'Language server running: {name}': 語言服務器運行中：{name}
+Language servers: 語言服務器
+Launch debug target: 啓動調試目標
+Left bracket: 左括號
+Line comment/uncomment selections: 行註釋/取消註釋選區
+List variables: 列出變量
+Load a file into buffer: 將文件加載到緩衝區
+Loaded {} file{}.: 已加載 {} 個文件{}。
+Make the first selection your primary one: 將第一個選區設爲主選區
+Make the last selection your primary one: 將最後一個選區設爲主選區
+'Malformed method call: {}': 格式錯誤的方法調用：{}
+Match: 匹配
+Match around: 匹配外部
+Match inside: 匹配內部
+Merge consecutive selections: 合併連續選區
+Merge selections: 合併選區
+'Method not found: {}': 方法未找到：{}
+Modify current search to make it word bounded: 使當前搜索變爲詞邊界匹配
+Move backward in history: 回退到歷史
+Move down: 下移
+Move forward in history: 前進到歷史
+Move half page down: 下翻半頁
+Move half page up: 上翻半頁
+Move left: 左移
+Move page and cursor down: 頁面下移，光標跟隨
+Move page and cursor half down: 頁面下移半頁，光標跟隨
+Move page and cursor half up: 頁面上移半頁，光標跟隨
+Move page and cursor up: 頁面上移，光標跟隨
+Move page down: 下翻一頁
+Move page up: 上翻一頁
+Move right: 右移
+Move the current buffer and its corresponding file to a different path: 將當前緩衝區及其對應文件移動到其他路徑
+Move the current buffer and its corresponding file to a different path creating necessary subdirectories: 將當前緩衝區及其對應文件移動到其他路徑（創建必要的子目錄）
+Move till next occurrence of char: 移動到字符前
+Move till previous occurrence of char: 移動到前一個字符前
+Move to beginning of the parent node: 移到父節點開頭
+Move to end of next long word: 移到下一個長詞尾
+Move to end of next sub word: 移到下一個子詞尾
+Move to end of next word: 移到下一個詞尾
+Move to end of previous long word: 移到上一個長詞尾
+Move to end of previous sub word: 移到上一個子詞尾
+Move to end of previous word: 移到上一個詞尾
+Move to end of the parent node: 移到父節點末尾
+Move to next occurrence of char: 移動到下一個字符
+Move to previous occurrence of char: 移動到前一個字符
+Move to start of next long word: 移到下一個長詞首
+Move to start of next sub word: 移到下一個子詞首
+Move to start of next word: 移到下一個詞首
+Move to start of previous long word: 移到上一個長詞首
+Move to start of previous sub word: 移到上一個子詞首
+Move to start of previous word: 移到上一個詞首
+Move up: 上移
+Neither a dir, nor a file: 既不是目錄也不是文件
+Never: 從不
+New split scratch buffer: 新建分割空白緩衝區
+No LSP server for this document: 此文檔沒有 LSP 服務器
+No arguments found with which to restart the sessions: 找不到用於重啓會話的參數
+No breakpoints: 沒有斷點
+No changes to save: 沒有要保存的更改
+No code actions available: 沒有可用的代碼操作
+No completions: 沒有補全
+No configured language server supports code actions: 沒有已配置的語言服務器支持代碼操作
+No configured language server supports document symbols: 沒有已配置的語言服務器支持文檔符號
+No configured language server supports hover: 沒有已配置的語言服務器支持懸停
+No configured language server supports range formatting: 沒有已配置的語言服務器支持範圍格式化
+No configured language server supports signature-help: 沒有已配置的語言服務器支持簽名幫助
+No configured language server supports symbol renaming: 沒有已配置的語言服務器支持符號重命名
+No configured language server supports workspace symbols: 沒有已配置的語言服務器支持工作區符號
+No configured language server supports {}: 沒有已配置的語言服務器支持 {}
+No configured languages: 沒有已配置的語言
+No debug adapter: 沒有調試適配器
+No debug adapter available for language: 沒有可用於該語言的調試適配器
+No declaration found: 未找到聲明
+No declaration found.: 未找到聲明。
+No definition found: 未找到定義
+No definition found.: 未找到定義。
+No diagnostics: 沒有診斷信息
+No diagnostics under primary selection: 主選區下沒有診斷信息
+No hover information: 沒有懸停信息
+No hover results available.: 沒有可用的懸停結果。
+No implementation found: 未找到實現
+No implementation found.: 未找到實現。
+No language server: 沒有語言服務器
+No language server supporting document symbols or syntax info available: 沒有支持文檔符號或語法信息的語言服務器
+No location found.: 未找到位置。
+No more buffers: 沒有更多緩衝區
+No more files: 沒有更多文件
+No more jumps: 沒有更多跳轉
+No more matches: 沒有更多匹配
+No previous working directory: 沒有上一個工作目錄
+No references found: 未找到引用
+No references found.: 未找到引用。
+No selections remaining: 沒有剩餘選區
+No signature help: 沒有簽名幫助
+No stack frames: 沒有堆棧幀
+No symbol found: 未找到符號
+No threads: 沒有線程
+No type definition found: 未找到類型定義
+No type definition found.: 未找到類型定義。
+No variables: 沒有變量
+Normal mode: 普通模式
+Not now: 暫不
+Open a file from disk into the current view.: 從磁盤打開文件到當前視圖。
+Open a scratch buffer in a horizontal split.: 在水平分割中打開空白緩衝區。
+Open a scratch buffer in a vertical split.: 在垂直分割中打開空白緩衝區。
+Open buffer picker: 打開緩衝區選擇器
+Open changed file picker: 打開已更改文件選擇器
+Open command palette: 打開命令面板
+Open diagnostic picker: 打開診斷選擇器
+Open file explorer at current buffer's directory: 在當前緩衝區目錄打開文件瀏覽器
+Open file explorer at current working directory: 在當前工作目錄打開文件瀏覽器
+Open file explorer in workspace root: 在工作區根目錄打開文件瀏覽器
+Open file failed: 打開文件失敗
+Open file picker: 打開文件選擇器
+Open file picker at current buffer's directory: 在當前緩衝區目錄打開文件選擇器
+Open file picker at current working directory: 在當前工作目錄打開文件選擇器
+Open jumplist picker: 打開跳轉列表選擇器
+Open last picker: 打開上次選擇器
+Open new line above selection: 在選區上方打開新行
+Open new line below selection: 在選區下方打開新行
+Open symbol picker: 打開符號選擇器
+Open symbol picker from LSP or syntax information: 從 LSP 或語法信息打開符號選擇器
+Open symbol picker from syntax information: 從語法信息打開符號選擇器
+Open the file in a horizontal split.: 在水平分割中打開文件。
+Open the file in a vertical split.: 在垂直分割中打開文件。
+Open the helix log file.: 打開 helix 日誌文件。
+Open the tutorial.: 打開教程。
+Open the user config.toml file.: 打開用戶 config.toml 文件。
+Open the workspace config.toml file.: 打開工作區 config.toml 文件。
+Open workspace command picker: 打開工作區命令選擇器
+Open workspace diagnostic picker: 打開工作區診斷選擇器
+Open workspace symbol picker: 打開工作區符號選擇器
+Open workspace symbol picker from LSP or syntax information: 從 LSP 或語法信息打開工作區符號選擇器
+Open workspace symbol picker from syntax information: 從語法信息打開工作區符號選擇器
+Opening URL in external program failed: 在外部程序中打開 URL 失敗
+Paragraph: 段落
+Paste after selection: 在選區後粘貼
+Paste before selection: 在選區前粘貼
+Paste clipboard after selections: 在選區後粘貼剪貼板
+Paste clipboard before selections: 在選區前粘貼剪貼板
+Paste primary clipboard after selections: 在選區後粘貼主剪貼板
+Paste primary clipboard after selections.: 在選區後粘貼主剪貼板。
+Paste primary clipboard before selections: 在選區前粘貼主剪貼板
+Paste primary clipboard before selections.: 在選區前粘貼主剪貼板。
+Paste system clipboard after selections.: 在選區後粘貼系統剪貼板。
+Paste system clipboard before selections.: 在選區前粘貼系統剪貼板。
+Pause program execution: 暫停程序執行
+Perform code action: 執行代碼操作
+Pipe each selection to the shell command, ignoring output.: 將每個選區管道到 shell 命令，忽略輸出。
+Pipe each selection to the shell command.: 將每個選區管道到 shell 命令。
+Pipe selections into shell command ignoring output: 將選區輸入 shell 命令並忽略輸出
+Pipe selections through shell command: 通過 shell 命令管道選區
+Press <ENTER> to continue with default config: 按 <ENTER> 繼續使用默認配置
+Prints the given arguments to the statusline.: 將給定的參數打印到狀態欄。
+Quit with exit code (default 1). Accepts an optional integer exit code (:cq 2).: 以退出碼退出（默認 1）。可接受可選整數退出碼 (:cq 2)。
+Record macro: 錄製宏
+Recorded to register [: 已錄製到寄存器 [
+Recording to register [: 正在錄製到寄存器 [
+Redo change: 重做
+Refresh user config.: 刷新用戶配置。
+Register [: 寄存器 [
+Register {} cleared: 寄存器 {} 已清除
+Register {} not found: 寄存器 {} 未找到
+Remove current workspace from the list of trusted workspaces.: 從受信任工作空間列表中移除當前工作空間。
+Remove primary selection: 移除主選區
+Remove selections matching regex: 移除匹配正則的選區
+Remove the top entry from the directory stack, and cd to the new top directory..: 從目錄棧中移除頂部條目，並跳轉到新的頂部目錄。
+Rename failed: 重命名失敗
+Rename symbol: 重命名符號
+Repeat last motion: 重複上次動作
+Replace selections by clipboard content: 用剪貼板內容替換選區
+Replace selections by primary clipboard: 用主剪貼板內容替換選區
+Replace selections with content of system clipboard.: 用系統剪貼板內容替換選區。
+Replace selections with content of system primary clipboard.: 用系統主剪貼板內容替換選區。
+Replace surrounding pair of: 替換包圍對
+Replace with a pair of: 替換爲一對
+Replace with new char: 替換爲新字符
+Replace with yanked text: 用複製的文本替換
+Replay macro: 回放宏
+Reset the diff change at the cursor position.: 重置光標位置的 diff 更改。
+Reset {changes} change{}: 已重置 {changes} 個更改{}
+Restart debugging session: 重新啓動調試會話
+? Restarts the given language servers, or all language servers that are used by the current file if no arguments are supplied
+: 重啓指定的語言服務器，或在不提供參數時重啓當前文件使用的所有語言服務器
+Reverse search for regex pattern: 反向搜索正則表達式
+Reverse selections contents: 反轉選區內容
+Right bracket: 右括號
+Rotate selection contents forward: 向前輪換選區內容
+Rotate selections backward: 向後輪換選區
+Rotate selections contents backward: 向後輪換選區內容
+Rotate selections forward: 向前輪換選區
+Run a shell command: 運行 shell 命令
+Run shell command, appending output after each selection.: 運行 shell 命令，在每個選區後追加輸出。
+Run shell command, inserting output before each selection.: 運行 shell 命令，在每個選區前插入輸出。
+Runtime directory: 運行時目錄
+Runtime directory does not exist: 運行時目錄不存在
+Runtime directory is empty: 運行時目錄爲空
+'Runtime directory: {path}': 運行時目錄：{path}
+Save and then change the current directory.: 保存並更改當前目錄。
+Save current selection to jumplist: 保存當前選區到跳轉列表
+Scroll view down: 向下滾動視圖
+Scroll view up: 向上滾動視圖
+Search for regex pattern: 搜索正則表達式
+Select all children of the current node: 選擇當前節點的所有子節點
+Select all regex matches inside selections: 選擇所有正則匹配
+Select all siblings of the current node: 選擇當前節點的所有兄弟節點
+Select around object: 選擇外部對象
+Select current line, if already selected, extend or shrink line above based on the anchor: 選擇當前行，已選則根據錨點擴展或收縮到上一行
+Select current line, if already selected, extend or shrink line below based on the anchor: 選擇當前行，已選則根據錨點擴展或收縮到下一行
+Select current line, if already selected, extend to another line based on the anchor: 選擇當前行，已選則根據錨點擴展
+Select current line, if already selected, extend to next line: 選擇當前行，已選則擴展到下一行
+Select current line, if already selected, extend to previous line: 選擇當前行，已選則擴展到上一行
+Select inside object: 選擇內部對象
+Select mode: 選擇模式
+Select next search match: 選擇下一個搜索結果
+Select next sibling in the syntax tree: 選擇語法樹中的下一個兄弟節點
+Select previous search match: 選擇上一個搜索結果
+Select previous sibling the in syntax tree: 選擇語法樹中的上一個兄弟節點
+Select register: 選擇寄存器
+Select symbol references: 選擇符號引用
+Select whole document: 全選文檔
+Selection saved to jumplist: 選區已保存到跳轉列表
+? 'Set a config option at runtime.
+
+  For example to disable smart case search, use `:set search.smart-case false`.'
+: '在運行時設置配置選項。
+
+  例如要禁用智能大小寫搜索，使用 `:set search.smart-case false`。'
+Set contents of the given register.: 設置指定寄存器的內容。
+Set encoding. Based on https://encoding.spec.whatwg.org: 設置編碼。基於 https://encoding.spec.whatwg.org
+'Set the document''s default line ending. Options: crlf, lf, cr, ff, nel.': 設置文檔的默認行尾。選項：crlf, lf, cr, ff, nel。
+'Set the document''s default line ending. Options: crlf, lf.': 設置文檔的默認行尾。選項：crlf, lf。
+Set the indentation style for editing. ('t' for tabs or 1-16 for number of spaces.): 設置縮進樣式。（'t' 表示製表符，1-16 表示空格數。）
+Set the language of current buffer (show current language if no value specified).: 設置當前緩衝區的語言（不指定值則顯示當前語言）。
+Shell command failed: Shell 命令失敗
+Show clipboard provider name in status bar.: 在狀態欄顯示剪貼板提供者名稱。
+Show docs for item under cursor: 顯示光標下項目的文檔
+Show signature help: 顯示簽名幫助
+Show the current working directory.: 顯示當前工作目錄。
+Show the directory stack as a <space> delimited string.: 顯示目錄棧。
+Shrink selection to line bounds: 收縮到行邊界
+Shrink selection to previously expanded syntax node: 收縮到上次擴展的語法節點
+Sort ranges in selection.: 對選區中的範圍進行排序。
+'Sorting requires multiple selections. Hint: split selection first': 排序需要多個選區。提示：先分割選區
+Space: 空格
+Split selection on newlines: 按換行符分割選區
+Split selections on regex matches: 按正則分割選區
+Stack is empty: 棧爲空
+Start a debug session from a given template with given parameters.: 從給定模板和參數啓動調試會話。
+Step in: 步入
+Step out: 步出
+Step to next: 步過
+Stops the given language servers, or all language servers that are used by the current file if no arguments are supplied: 停止指定的語言服務器，或在不提供參數時停止當前文件使用的所有語言服務器
+Surround add: 添加包圍符
+Surround delete: 刪除包圍符
+Surround replace: 替換包圍符
+Suspend and return to shell: 掛起並返回 shell
+Swap with left split: 與左側分割交換
+Swap with right split: 與右側分割交換
+Swap with split above: 與上方分割交換
+Swap with split below: 與下方分割交換
+Switch: 切換
+Switch (toggle) case: 切換大小寫
+Switch current thread: 切換當前線程
+Switch stack frame: 切換堆棧幀
+Switch to lowercase: 轉爲小寫
+Switch to uppercase: 轉爲大寫
+Syntax tree is not available on this buffer: 此緩衝區沒有語法樹
+Syntax-tree is not available in current buffer: 當前緩衝區沒有語法樹
+'System clipboard provider: Not installed': 系統剪貼板提供者：未安裝
+Terminating debug session...: 正在終止調試會話...
+Test (tree-sitter): 測試 (tree-sitter)
+'Text doc sync: {sync}': 文本文檔同步：{sync}
+The line you jumped to does not exist anymore because the file has changed.: 你跳轉到的行已不存在，因爲文件已更改。
+The location you jumped to does not exist anymore because the file has changed.: 你跳轉到的位置已不存在，因爲文件已更改。
+There are no changes under any selection: 任何選區下都沒有更改
+This list is filtered according to the 'use-grammars' option in languages.toml file.: 此列表根據 languages.toml 文件中的 'use-grammars' 選項進行了過濾。
+To see the full list, use the '--health all' or '--health all-languages' option.: 查看完整列表，請使用 '--health all' 或 '--health all-languages' 選項。
+? 'Toggle a config option at runtime.
+
+  For example to toggle smart case search, use `:toggle search.smart-case`.'
+: '在運行時切換配置選項。
+
+  例如要切換智能大小寫搜索，使用 `:toggle search.smart-case`。'
+Toggle breakpoint: 切換斷點
+Transpose splits: 轉置分割
+Trim whitespace from selections: 修剪選區中的空白
+Trust this workspace?: 信任此工作空間？
+Type definition (tree-sitter): 類型定義 (tree-sitter)
+Undo change: 撤銷
+Unindent selection: 減少縮進
+Unknown key `{}`: 未知鍵 `{}`
+'Unknown language server{s}: {}': 未知語言服務器{s}：{}
+'Unsupported theme: theme requires true color support': 不支持的主題：主題需要真彩色支持
+Use current selection as search pattern: 使用當前選區作爲搜索模式
+Use current selection as the search pattern, automatically wrapping with \b on word boundaries: 使用當前選區作爲搜索模式，自動添加詞邊界 \b
+Using default language config: 使用默認語言配置
+Vertical right split: 垂直右分割
+Vertical right split scratch buffer: 垂直右分割新建緩衝區
+View: 視圖
+WORD: 大詞
+Window: 窗口
+Word: 詞
+Workspace directory does not exist: 工作區目錄不存在
+Wrapped around document: 已環繞文檔
+Write changes from all buffers to disk and close all views.: 將所有緩衝區的更改寫入磁盤並關閉所有視圖。
+Write changes from all buffers to disk.: 將所有緩衝區的更改寫入磁盤。
+Write changes only if the file has been modified.: 僅在文件已修改時寫入更改。
+Write changes to disk and close the current view forcefully. Accepts an optional path (:wq! some/path.txt): 寫入磁盤並強制關閉當前視圖。可接受可選路徑 (:wq! some/path.txt)
+Write changes to disk and close the current view. Accepts an optional path (:wq some/path.txt): 寫入磁盤並關閉當前視圖。可接受可選路徑 (:wq some/path.txt)
+Write changes to disk and closes the buffer. Accepts an optional path (:write-buffer-close some/path.txt): 寫入磁盤並關閉緩衝區。可接受可選路徑 (:write-buffer-close some/path.txt)
+Write changes to disk if the buffer is modified and then quit. Accepts an optional path (:exit some/path.txt).: 如果緩衝區已修改則寫入磁盤並退出。可接受可選路徑 (:exit some/path.txt)。
+Write changes to disk. Accepts an optional path (:write some/path.txt): 寫入更改到磁盤。可接受可選路徑 (:write some/path.txt)
+Yank diagnostic(s) under primary cursor to register, or clipboard by default: 複製主光標下的診斷信息到寄存器，默認爲剪貼板
+Yank joined selections into system clipboard. A separator can be provided as first argument. Default value is newline.: 複製連接的選區到系統剪貼板。可將分隔符作爲第一個參數提供。默認值爲換行符。
+? Yank joined selections into system primary clipboard. A separator can be provided as first argument. Default value is newline.
+: 複製連接的選區到系統主剪貼板。可將分隔符作爲第一個參數提供。默認值爲換行符。
+Yank joined selections. A separator can be provided as first argument. Default value is newline.: 複製連接的選區。可將分隔符作爲第一個參數提供。默認值爲換行符。
+Yank main selection into system clipboard.: 複製主選區到系統剪貼板。
+Yank main selection into system primary clipboard.: 複製主選區到系統主剪貼板。
+Yank main selection to clipboard: 複製主選區到剪貼板
+Yank main selection to primary clipboard: 複製主選區到主剪貼板
+Yank selection: 複製選區
+Yank selections to clipboard: 複製選區到剪貼板
+Yank selections to primary clipboard: 複製選區到主剪貼板
+Yanked {n} diagnostic{} to register {reg}: 已複製 {n} 個診斷{}到寄存器 {reg}
+'[+]': '[+]'
+'] because already replaying from same register': '] 因爲已在從同一寄存器回放'
+'] empty': '] 爲空'
+'`{command}` is not supported for any language server': '`{command}` 不被任何語言服務器支持'
+'`{command}` supported by multiple language servers': '`{command}` 被多個語言服務器支持'
+align cannot work with multi line selections: align 不能處理多行選區
+can't move file, parent directory does not exist (use :mv! to create it): 無法移動文件，父目錄不存在（使用 :mv! 創建）
+'cannot close non-existent buffers: {}': 無法關閉不存在的緩衝區：{}
+carriage return: 回車
+class: 類
+color: '顏色 '
+'color ': '顏色 '
+conflict: 衝突
+constant: 常量
+constructor: 構造函數
+crlf: crlf
+deleted: 已刪除
+enum: 枚舉
+enum member: 枚舉成員
+error: 錯誤
+'error opening file: {}': 打開文件出錯：{}
+'error reading file: {}': 讀取文件出錯：{}
+event: 事件
+field: 字段
+file: 文件
+folder: 文件夾
+form feed: 換頁
+format_selections only supports a single selection for now: format_selections 目前只支持單個選區
+from register: 從寄存器
+function: 函數
+inserting multiple newlines not yet supported: 尚不支持插入多個換行
+interface: 接口
+is empty: 爲空
+'is symlinked to: {}': 符號鏈接到：{}
+joined and: 連接並
+keyword: 關鍵字
+line feed: 換行
+method: 方法
+modified: 已修改
+module: 模塊
+next line: 下一行
+no last accessed buffer: 沒有上次訪問的緩衝區
+no last modified buffer: 沒有上次修改的緩衝區
+no last picker: 沒有上次選擇器
+no selections remaining: 沒有剩餘選區
+no snippet is currently active: 當前沒有活動的代碼片段
+'no such command: ''{cmd}''': 沒有此命令：'{cmd}'
+nothing selected: 沒有選中任何內容
+operator: 運算符
+'path is not a file: {:?}': 路徑不是文件：{:?}
+primary selection: 主選區
+property: 屬性
+reference: 引用
+register: 寄存器
+'register ': '寄存器 '
+renamed: 已重命名
+selection: 選區
+skip auto-formatting: 跳過自動格式化
+snippet: 代碼片段
+sort ranges in reverse order: 反向排序
+sort the ranges case-insensitively: 不區分大小寫排序
+struct: 結構體
+tabs: 製表符
+text: 文本
+to: 到
+to register: 到寄存器
+type parameter: 類型參數
+'unable to convert URI to filepath: {:?}': 無法將 URI 轉換爲文件路徑：{:?}
+unable to open: 無法打開
+unit: 單位
+untracked: 未跟蹤
+value: 值
+variable: 變量
+version: 1
+yanked: 已複製
+'{:?} cannot be mapped to {}': '{:?} 無法映射到 {}'
+'{} (deleted)': '{}（已刪除）'
+'{} spaces': '{} 個空格'
+'{} unsaved buffer{} remaining: {:?}': 剩餘 {} 個未保存的緩衝區{}：{:?}
+▸ {}: ▸ {}

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -108,6 +108,9 @@ impl Application {
         #[cfg(feature = "integration")]
         setup_integration_logging();
 
+        // Initialize i18n
+        crate::i18n::init(&config.editor);
+
         use helix_view::editor::Action;
 
         let mut theme_parent_dirs = vec![helix_loader::config_dir()];
@@ -218,11 +221,10 @@ impl Application {
                 if nr_of_files == 0 {
                     editor.new_file(Action::VerticalSplit);
                 } else {
-                    editor.set_status(format!(
-                        "Loaded {} file{}.",
-                        nr_of_files,
-                        if nr_of_files == 1 { "" } else { "s" } // avoid "Loaded 1 files." grammo
-                    ));
+                    let suffix = if nr_of_files == 1 { "" } else { "s" };
+                    editor.set_status(crate::i18n::tr("Loaded {} file{}.")
+                        .replacen("{}", &nr_of_files.to_string(), 1)
+                        .replacen("{}", suffix, 1));
                     // align the view to center after all files are loaded,
                     // does not affect views without pos since it is at the top
                     let (view, doc) = current!(editor);
@@ -445,6 +447,8 @@ impl Application {
             }
 
             self.terminal.reconfigure((&default_config.editor).into())?;
+            // Re-init i18n in case ui_language changed
+            crate::i18n::init(&default_config.editor);
             // Store new config
             self.config.store(Arc::new(default_config));
             Ok(())
@@ -452,7 +456,7 @@ impl Application {
 
         match refresh_config() {
             Ok(_) => {
-                self.editor.set_status("Config refreshed");
+                self.editor.set_status(crate::i18n::tr("Config refreshed"));
             }
             Err(err) => {
                 self.editor.set_error(err.to_string());
@@ -644,10 +648,10 @@ impl Application {
         self.editor
             .set_doc_path(doc_save_event.doc_id, &doc_save_event.path);
         // TODO: fix being overwritten by lsp
-        self.editor.set_status(format!(
-            "'{}' written, {lines}L {size}",
-            get_relative_path(&doc_save_event.path).to_string_lossy(),
-        ));
+        self.editor.set_status(crate::i18n::tr("'{}' written, {lines}L {size}")
+            .replacen("{}", &get_relative_path(&doc_save_event.path).to_string_lossy(), 1)
+            .replace("{lines}", &lines.to_string())
+            .replace("{size}", &size.to_string()));
     }
 
     #[inline(always)]
@@ -927,7 +931,7 @@ impl Application {
                         // do nothing
                     }
                     Notification::Exit => {
-                        self.editor.set_status("Language server exited");
+                        self.editor.set_status(crate::i18n::tr("Language server exited"));
 
                         // LSPs may produce diagnostics for files that haven't been opened in helix,
                         // we need to clear those and remove the entries from the list if this leads to
@@ -966,7 +970,7 @@ impl Application {
                         );
                         Err(helix_lsp::jsonrpc::Error {
                             code: helix_lsp::jsonrpc::ErrorCode::MethodNotFound,
-                            message: format!("Method not found: {}", method),
+                            message: crate::i18n::tr("Method not found: {}").replace("{}", &method),
                             data: None,
                         })
                     }
@@ -979,7 +983,7 @@ impl Application {
                         );
                         Err(helix_lsp::jsonrpc::Error {
                             code: helix_lsp::jsonrpc::ErrorCode::ParseError,
-                            message: format!("Malformed method call: {}", method),
+                            message: crate::i18n::tr("Malformed method call: {}").replace("{}", &method),
                             data: None,
                         })
                     }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -269,7 +269,7 @@ impl MappableCommand {
                 // Protect against recursive macros.
                 if cx.editor.macro_replaying.contains(&'@') {
                     cx.editor.set_error(
-                        "Cannot execute macro because the [@] register is already playing a macro",
+                        crate::i18n::tr("Cannot execute macro because the [@] register is already playing a macro"),
                     );
                     return;
                 }
@@ -293,11 +293,11 @@ impl MappableCommand {
         }
     }
 
-    pub fn doc(&self) -> &str {
+    pub fn doc(&self) -> std::borrow::Cow<'static, str> {
         match &self {
-            Self::Typable { doc, .. } => doc,
-            Self::Static { doc, .. } => doc,
-            Self::Macro { name, .. } => name,
+            Self::Typable { doc, .. } => std::borrow::Cow::Owned(doc.clone()),
+            Self::Static { doc, .. } => crate::i18n::tr(*doc),
+            Self::Macro { name, .. } => std::borrow::Cow::Owned(name.clone()),
         }
     }
 
@@ -1078,7 +1078,7 @@ fn align_selections(cx: &mut Context) {
 
         if coords.row != anchor_coords.row {
             cx.editor
-                .set_error("align cannot work with multi line selections");
+                .set_error(crate::i18n::tr("align cannot work with multi line selections"));
             return;
         }
 
@@ -1456,7 +1456,7 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
             let picker = ui::file_picker(cx.editor, path.into());
             cx.push_layer(Box::new(overlaid(picker)));
         } else if let Err(e) = cx.editor.open(path, action) {
-            cx.editor.set_error(format!("Open file failed: {:?}", e));
+                cx.editor.set_error(format!("{}: {:?}", crate::i18n::tr("Open file failed"), e));
         }
     }
 }
@@ -1493,7 +1493,7 @@ fn open_url(cx: &mut Context, url: Url, action: Action) {
                 let picker = ui::file_picker(cx.editor, path.into());
                 cx.push_layer(Box::new(overlaid(picker)));
             } else if let Err(e) = cx.editor.open(path, action) {
-                cx.editor.set_error(format!("Open file failed: {:?}", e));
+            cx.editor.set_error(format!("{}: {:?}", crate::i18n::tr("Open file failed"), e));
             }
         }
     }
@@ -2120,7 +2120,7 @@ fn select_regex(cx: &mut Context) {
             {
                 doc.set_selection(view.id, selection);
             } else if event == PromptEvent::Validate {
-                cx.editor.set_error("nothing selected");
+                cx.editor.set_error(crate::i18n::tr("nothing selected"));
             }
         },
     );
@@ -2213,9 +2213,9 @@ fn search_impl(
         }
         if show_warnings {
             if wrap_around && mat.is_some() {
-                editor.set_status("Wrapped around document");
+                editor.set_status(crate::i18n::tr("Wrapped around document"));
             } else {
-                editor.set_error("No more matches");
+                editor.set_error(crate::i18n::tr("No more matches"));
             }
         }
     }
@@ -2423,7 +2423,7 @@ fn search_selection_impl(cx: &mut Context, detect_word_boundaries: bool) {
         .collect::<Vec<_>>()
         .join("|");
 
-    let msg = format!("register '{}' set to '{}'", register, &regex);
+    let msg = format!("{}'{}'{}'{}'", crate::i18n::tr("register "), register, crate::i18n::tr(" set to "), &regex);
     match cx.editor.registers.push(register, regex) {
         Ok(_) => {
             cx.editor.registers.last_search_register = register;
@@ -2463,7 +2463,7 @@ fn make_search_word_bounded(cx: &mut Context) {
         new_regex.push_str("\\b");
     }
 
-    let msg = format!("register '{}' set to '{}'", register, &new_regex);
+    let msg = format!("{}'{}'{}'{}'", crate::i18n::tr("register "), register, crate::i18n::tr(" set to "), &new_regex);
     match cx.editor.registers.push(register, new_regex) {
         Ok(_) => {
             cx.editor.registers.last_search_register = register;
@@ -2683,7 +2683,7 @@ fn global_search(cx: &mut Context) {
                 Ok(id) => doc_mut!(cx.editor, &id),
                 Err(e) => {
                     cx.editor
-                        .set_error(format!("Failed to open file '{}': {}", path.display(), e));
+                        .set_error(format!("{}'{}': {}", crate::i18n::tr("Failed to open file "), path.display(), e));
                     return;
                 }
             };
@@ -2694,7 +2694,7 @@ fn global_search(cx: &mut Context) {
             let text = doc.text();
             if line_start >= text.len_lines() {
                 cx.editor.set_error(
-                    "The line you jumped to does not exist anymore because the file has changed.",
+                    crate::i18n::tr("The line you jumped to does not exist anymore because the file has changed."),
                 );
                 return;
             }
@@ -3103,7 +3103,7 @@ fn append_mode(cx: &mut Context) {
 fn file_picker(cx: &mut Context) {
     let root = find_workspace().0;
     if !root.exists() {
-        cx.editor.set_error("Workspace directory does not exist");
+        cx.editor.set_error(crate::i18n::tr("Workspace directory does not exist"));
         return;
     }
     let picker = ui::file_picker(cx.editor, root);
@@ -3121,12 +3121,12 @@ fn file_picker_in_current_buffer_directory(cx: &mut Context) {
             let cwd = helix_stdx::env::current_working_dir();
             if !cwd.exists() {
                 cx.editor.set_error(
-                    "Current buffer has no parent and current working directory does not exist",
+                    crate::i18n::tr("Current buffer has no parent and current working directory does not exist"),
                 );
                 return;
             }
             cx.editor.set_error(
-                "Current buffer has no parent, opening file picker in current working directory",
+                crate::i18n::tr("Current buffer has no parent, opening file picker in current working directory"),
             );
             cwd
         }
@@ -3140,7 +3140,7 @@ fn file_picker_in_current_directory(cx: &mut Context) {
     let cwd = helix_stdx::env::current_working_dir();
     if !cwd.exists() {
         cx.editor
-            .set_error("Current working directory does not exist");
+            .set_error(crate::i18n::tr("Current working directory does not exist"));
         return;
     }
     let picker = ui::file_picker(cx.editor, cwd);
@@ -3150,7 +3150,7 @@ fn file_picker_in_current_directory(cx: &mut Context) {
 fn file_explorer(cx: &mut Context) {
     let root = find_workspace().0;
     if !root.exists() {
-        cx.editor.set_error("Workspace directory does not exist");
+        cx.editor.set_error(crate::i18n::tr("Workspace directory does not exist"));
         return;
     }
 
@@ -3170,12 +3170,12 @@ fn file_explorer_in_current_buffer_directory(cx: &mut Context) {
             let cwd = helix_stdx::env::current_working_dir();
             if !cwd.exists() {
                 cx.editor.set_error(
-                    "Current buffer has no parent and current working directory does not exist",
+                    crate::i18n::tr("Current buffer has no parent and current working directory does not exist"),
                 );
                 return;
             }
             cx.editor.set_error(
-                "Current buffer has no parent, opening file explorer in current working directory",
+                crate::i18n::tr("Current buffer has no parent, opening file explorer in current working directory"),
             );
             cwd
         }
@@ -3190,7 +3190,7 @@ fn file_explorer_in_current_directory(cx: &mut Context) {
     let cwd = helix_stdx::env::current_working_dir();
     if !cwd.exists() {
         cx.editor
-            .set_error("Current working directory does not exist");
+            .set_error(crate::i18n::tr("Current working directory does not exist"));
         return;
     }
 
@@ -3385,7 +3385,7 @@ fn changed_file_picker(cx: &mut Context) {
     let cwd = helix_stdx::env::current_working_dir();
     if !cwd.exists() {
         cx.editor
-            .set_error("Current working directory does not exist");
+            .set_error(crate::i18n::tr("Current working directory does not exist"));
         return;
     }
 
@@ -3398,11 +3398,11 @@ fn changed_file_picker(cx: &mut Context) {
     let columns = [
         PickerColumn::new("change", |change: &FileChange, data: &FileChangeData| {
             match change {
-                FileChange::Untracked { .. } => Span::styled("+ untracked", data.style_untracked),
-                FileChange::Modified { .. } => Span::styled("~ modified", data.style_modified),
-                FileChange::Conflict { .. } => Span::styled("x conflict", data.style_conflict),
-                FileChange::Deleted { .. } => Span::styled("- deleted", data.style_deleted),
-                FileChange::Renamed { .. } => Span::styled("> renamed", data.style_renamed),
+                FileChange::Untracked { .. } => Span::styled(format!("+ {}", crate::i18n::tr("untracked")), data.style_untracked),
+                FileChange::Modified { .. } => Span::styled(format!("~ {}", crate::i18n::tr("modified")), data.style_modified),
+                FileChange::Conflict { .. } => Span::styled(format!("x {}", crate::i18n::tr("conflict")), data.style_conflict),
+                FileChange::Deleted { .. } => Span::styled(format!("- {}", crate::i18n::tr("deleted")), data.style_deleted),
+                FileChange::Renamed { .. } => Span::styled(format!("> {}", crate::i18n::tr("renamed")), data.style_renamed),
             }
             .into()
         }),
@@ -3444,7 +3444,7 @@ fn changed_file_picker(cx: &mut Context) {
                 let err = if let Some(err) = e.source() {
                     format!("{}", err)
                 } else {
-                    format!("unable to open \"{}\"", path_to_open.display())
+                    format!("{} \"{}\"", crate::i18n::tr("unable to open"), path_to_open.display())
                 };
                 cx.editor.set_error(err);
             }
@@ -3482,7 +3482,7 @@ pub fn command_palette(cx: &mut Context) {
                     .map(|cmd| MappableCommand::Typable {
                         name: cmd.name.to_owned(),
                         args: String::new(),
-                        doc: cmd.doc.to_owned(),
+                        doc: crate::i18n::tr(cmd.doc).into_owned(),
                     }),
             );
 
@@ -3554,7 +3554,7 @@ fn last_picker(cx: &mut Context) {
         if let Some(picker) = compositor.last_picker.take() {
             compositor.push(picker);
         } else {
-            cx.editor.set_error("no last picker")
+            cx.editor.set_error(crate::i18n::tr("no last picker"))
         }
     }));
 }
@@ -3689,7 +3689,7 @@ async fn make_format_callback(
         if let Some((path, force)) = write {
             let id = doc.id();
             if let Err(err) = editor.save(id, path, force) {
-                editor.set_error(format!("Error saving: {}", err));
+                editor.set_error(format!("{}: {}", crate::i18n::tr("Error saving"), err));
             }
         }
     }));
@@ -3943,7 +3943,7 @@ fn goto_last_accessed_file(cx: &mut Context) {
     if let Some(alt) = view.docs_access_history.pop() {
         cx.editor.switch(alt, Action::Replace);
     } else {
-        cx.editor.set_error("no last accessed buffer")
+        cx.editor.set_error(crate::i18n::tr("no last accessed buffer"))
     }
 }
 
@@ -3971,7 +3971,7 @@ fn goto_last_modified_file(cx: &mut Context) {
     if let Some(alt) = alternate_file {
         cx.editor.switch(alt, Action::Replace);
     } else {
-        cx.editor.set_error("no last modified buffer")
+        cx.editor.set_error(crate::i18n::tr("no last modified buffer"))
     }
 }
 
@@ -4319,7 +4319,7 @@ pub mod insert {
                 key!(Enter) => {
                     if count != 1 {
                         cx.editor
-                            .set_error("inserting multiple newlines not yet supported");
+                            .set_error(crate::i18n::tr("inserting multiple newlines not yet supported"));
                         return;
                     }
                     insert_newline(cx)
@@ -4626,7 +4626,7 @@ fn undo(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     for _ in 0..count {
         if !doc.undo(view) {
-            cx.editor.set_status("Already at oldest change");
+            cx.editor.set_status(crate::i18n::tr("Already at oldest change"));
             break;
         }
     }
@@ -4637,7 +4637,7 @@ fn redo(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     for _ in 0..count {
         if !doc.redo(view) {
-            cx.editor.set_status("Already at newest change");
+            cx.editor.set_status(crate::i18n::tr("Already at newest change"));
             break;
         }
     }
@@ -4649,7 +4649,7 @@ fn earlier(cx: &mut Context) {
     for _ in 0..count {
         // rather than doing in batch we do this so get error halfway
         if !doc.earlier(view, UndoKind::Steps(1)) {
-            cx.editor.set_status("Already at oldest change");
+            cx.editor.set_status(crate::i18n::tr("Already at oldest change"));
             break;
         }
     }
@@ -4661,7 +4661,7 @@ fn later(cx: &mut Context) {
     for _ in 0..count {
         // rather than doing in batch we do this so get error halfway
         if !doc.later(view, UndoKind::Steps(1)) {
-            cx.editor.set_status("Already at newest change");
+            cx.editor.set_status(crate::i18n::tr("Already at newest change"));
             break;
         }
     }
@@ -4706,8 +4706,11 @@ fn yank_impl(editor: &mut Editor, register: char) {
 
     match editor.registers.write(register, values) {
         Ok(_) => editor.set_status(format!(
-            "yanked {selections} selection{} to register {register}",
-            if selections == 1 { "" } else { "s" }
+            "{} {selections} {}{}{} {register}",
+            crate::i18n::tr("yanked"),
+            crate::i18n::tr("selection"),
+            if selections == 1 { "" } else { "s" },
+            crate::i18n::tr("to register"),
         )),
         Err(err) => editor.set_error(err.to_string()),
     }
@@ -4731,8 +4734,12 @@ fn yank_joined_impl(editor: &mut Editor, separator: &str, register: char) {
 
     match editor.registers.write(register, vec![joined]) {
         Ok(_) => editor.set_status(format!(
-            "joined and yanked {selections} selection{} to register {register}",
-            if selections == 1 { "" } else { "s" }
+            "{}{} {selections} {}{}{} {register}",
+            crate::i18n::tr("joined and"),
+            crate::i18n::tr("yanked"),
+            crate::i18n::tr("selection"),
+            if selections == 1 { "" } else { "s" },
+            crate::i18n::tr("to register"),
         )),
         Err(err) => editor.set_error(err.to_string()),
     }
@@ -4768,7 +4775,7 @@ pub(crate) fn yank_main_selection_to_register(editor: &mut Editor, register: cha
     let selection = doc.selection(view.id).primary().fragment(text).to_string();
 
     match editor.registers.write(register, vec![selection]) {
-        Ok(_) => editor.set_status(format!("yanked primary selection to register {register}",)),
+        Ok(_) => editor.set_status(format!("{} {} {} {register}", crate::i18n::tr("yanked"), crate::i18n::tr("primary selection"), crate::i18n::tr("to register"))),
         Err(err) => editor.set_error(err.to_string()),
     }
 }
@@ -5100,7 +5107,7 @@ fn format_selections(cx: &mut Context) {
 
     if doc.selection(view_id).len() != 1 {
         cx.editor
-            .set_error("format_selections only supports a single selection for now");
+            .set_error(crate::i18n::tr("format_selections only supports a single selection for now"));
         return;
     }
 
@@ -5116,7 +5123,7 @@ fn format_selections(cx: &mut Context) {
         })
     else {
         cx.editor
-            .set_error("No configured language server supports range formatting");
+            .set_error(crate::i18n::tr("No configured language server supports range formatting"));
         return;
     };
 
@@ -5291,7 +5298,7 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
             {
                 doc.set_selection(view.id, selection);
             } else if event == PromptEvent::Validate {
-                cx.editor.set_error("no selections remaining");
+                cx.editor.set_error(crate::i18n::tr("no selections remaining"));
             }
         },
     )
@@ -5327,7 +5334,7 @@ fn remove_primary_selection(cx: &mut Context) {
 
     let selection = doc.selection(view.id);
     if selection.len() == 1 {
-        cx.editor.set_error("no selections remaining");
+        cx.editor.set_error(crate::i18n::tr("no selections remaining"));
         return;
     }
     let index = selection.primary_index();
@@ -5746,7 +5753,7 @@ fn jump_backward(cx: &mut Context) {
 fn save_selection(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     push_jump(view, doc);
-    cx.editor.set_status("Selection saved to jumplist");
+    cx.editor.set_status(crate::i18n::tr("Selection saved to jumplist"));
 }
 
 fn rotate_view(cx: &mut Context) {
@@ -5900,7 +5907,7 @@ fn copy_between_registers(cx: &mut Context) {
         };
 
         let Some(values) = cx.editor.registers.read(source, cx.editor) else {
-            cx.editor.set_error(format!("register {source} is empty"));
+            cx.editor.set_error(format!("{} {source} {}", crate::i18n::tr("register"), crate::i18n::tr("is empty")));
             return;
         };
         let values: Vec<_> = values.map(|value| value.to_string()).collect();
@@ -5919,8 +5926,12 @@ fn copy_between_registers(cx: &mut Context) {
             let n_values = values.len();
             match cx.editor.registers.write(dest, values) {
                 Ok(_) => cx.editor.set_status(format!(
-                    "yanked {n_values} value{} from register {source} to {dest}",
-                    if n_values == 1 { "" } else { "s" }
+                    "{} {n_values} {}{} {} {source} {} {dest}",
+                    crate::i18n::tr("yanked"),
+                    crate::i18n::tr("value"),
+                    if n_values == 1 { "" } else { "s" },
+                    crate::i18n::tr("from register"),
+                    crate::i18n::tr("to"),
                 )),
                 Err(err) => cx.editor.set_error(err.to_string()),
             }
@@ -6007,7 +6018,7 @@ fn goto_ts_object_impl(cx: &mut Context, object: &'static str, direction: Direct
             push_jump(view, doc);
             doc.set_selection(view.id, selection);
         } else {
-            editor.set_status("Syntax-tree is not available in current buffer");
+            editor.set_status(crate::i18n::tr("Syntax-tree is not available in current buffer"));
         }
     };
     cx.editor.apply_motion(motion);
@@ -6098,7 +6109,7 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 };
 
                 if ch == 'g' && doc.diff_handle().is_none() {
-                    editor.set_status("Diff is not available in current buffer");
+                    editor.set_status(crate::i18n::tr("Diff is not available in current buffer"));
                     return;
                 }
 
@@ -6157,24 +6168,24 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
     });
 
     let title = match objtype {
-        textobject::TextObject::Inside => "Match inside",
-        textobject::TextObject::Around => "Match around",
+        textobject::TextObject::Inside => crate::i18n::tr("Match inside"),
+        textobject::TextObject::Around => crate::i18n::tr("Match around"),
         _ => return,
     };
     let help_text = [
-        ("w", "Word"),
-        ("W", "WORD"),
-        ("p", "Paragraph"),
-        ("t", "Type definition (tree-sitter)"),
-        ("f", "Function (tree-sitter)"),
-        ("a", "Argument/parameter (tree-sitter)"),
-        ("c", "Comment (tree-sitter)"),
-        ("T", "Test (tree-sitter)"),
-        ("e", "Data structure entry (tree-sitter)"),
-        ("m", "Closest surrounding pair (tree-sitter)"),
-        ("g", "Change"),
-        ("x", "(X)HTML element (tree-sitter)"),
-        (" ", "... or any character acting as a pair"),
+        ("w", crate::i18n::tr("Word")),
+        ("W", crate::i18n::tr("WORD")),
+        ("p", crate::i18n::tr("Paragraph")),
+        ("t", crate::i18n::tr("Type definition (tree-sitter)")),
+        ("f", crate::i18n::tr("Function (tree-sitter)")),
+        ("a", crate::i18n::tr("Argument/parameter (tree-sitter)")),
+        ("c", crate::i18n::tr("Comment (tree-sitter)")),
+        ("T", crate::i18n::tr("Test (tree-sitter)")),
+        ("e", crate::i18n::tr("Data structure entry (tree-sitter)")),
+        ("m", crate::i18n::tr("Closest surrounding pair (tree-sitter)")),
+        ("g", crate::i18n::tr("Change")),
+        ("x", crate::i18n::tr("(X)HTML element (tree-sitter)")),
+        (" ", crate::i18n::tr("... or any character acting as a pair")),
     ];
 
     cx.editor.autoinfo = Some(Info::new(title, &help_text));
@@ -6188,6 +6199,20 @@ static SURROUND_HELP_TEXT: [(&str, &str); 6] = [
     ("[ or ]", "Square brackets"),
     (" ", "... or any character"),
 ];
+
+fn surround_help_text() -> Vec<(&'static str, Cow<'static, str>)> {
+    SURROUND_HELP_TEXT
+        .iter()
+        .map(|(key, val)| (*key, crate::i18n::tr(*val)))
+        .collect()
+}
+
+fn surround_help_text_without_m() -> Vec<(&'static str, Cow<'static, str>)> {
+    SURROUND_HELP_TEXT[1..]
+        .iter()
+        .map(|(key, val)| (*key, crate::i18n::tr(*val)))
+        .collect()
+}
 
 fn surround_add(cx: &mut Context) {
     cx.on_next_key(move |cx, event| {
@@ -6300,14 +6325,14 @@ fn surround_replace(cx: &mut Context) {
         });
 
         cx.editor.autoinfo = Some(Info::new(
-            "Replace with a pair of",
-            &SURROUND_HELP_TEXT[1..],
+            crate::i18n::tr("Replace with a pair of"),
+            &surround_help_text_without_m(),
         ));
     });
 
     cx.editor.autoinfo = Some(Info::new(
-        "Replace surrounding pair of",
-        &SURROUND_HELP_TEXT,
+        crate::i18n::tr("Replace surrounding pair of"),
+        &surround_help_text(),
     ));
 }
 
@@ -6339,7 +6364,7 @@ fn surround_delete(cx: &mut Context) {
         exit_select_mode(cx);
     });
 
-    cx.editor.autoinfo = Some(Info::new("Delete surrounding pair of", &SURROUND_HELP_TEXT));
+    cx.editor.autoinfo = Some(Info::new(crate::i18n::tr("Delete surrounding pair of"), &surround_help_text()));
 }
 
 #[derive(Eq, PartialEq)]
@@ -6390,7 +6415,7 @@ fn shell_keep_pipe(cx: &mut Context) {
         }
 
         if ranges.is_empty() {
-            cx.editor.set_error("No selections remaining");
+            cx.editor.set_error(crate::i18n::tr("No selections remaining"));
             return;
         }
 
@@ -6710,7 +6735,7 @@ fn goto_next_tabstop_impl(cx: &mut Context, direction: Direction) {
     let (view, doc) = current!(cx.editor);
     let view_id = view.id;
     let Some(mut snippet) = doc.active_snippet.take() else {
-        cx.editor.set_error("no snippet is currently active");
+        cx.editor.set_error(crate::i18n::tr("no snippet is currently active"));
         return;
     };
     let tabstop = match direction {
@@ -6757,14 +6782,14 @@ fn record_macro(cx: &mut Context) {
         match cx.editor.registers.write(reg, vec![s]) {
             Ok(_) => cx
                 .editor
-                .set_status(format!("Recorded to register [{}]", reg)),
+                .set_status(format!("{}{}]", crate::i18n::tr("Recorded to register ["), reg)),
             Err(err) => cx.editor.set_error(err.to_string()),
         }
     } else {
         let reg = cx.register.take().unwrap_or('@');
         cx.editor.macro_recording = Some((reg, Vec::new()));
         cx.editor
-            .set_status(format!("Recording to register [{}]", reg));
+            .set_status(format!("{}{}]", crate::i18n::tr("Recording to register ["), reg));
     }
 }
 
@@ -6773,8 +6798,10 @@ fn replay_macro(cx: &mut Context) {
 
     if cx.editor.macro_replaying.contains(&reg) {
         cx.editor.set_error(format!(
-            "Cannot replay from register [{}] because already replaying from same register",
-            reg
+            "{}{}{}",
+            crate::i18n::tr("Cannot replay from register ["),
+            reg,
+            crate::i18n::tr("] because already replaying from same register"),
         ));
         return;
     }
@@ -6789,12 +6816,12 @@ fn replay_macro(cx: &mut Context) {
         match helix_view::input::parse_macro(&keys) {
             Ok(keys) => keys,
             Err(err) => {
-                cx.editor.set_error(format!("Invalid macro: {}", err));
+                cx.editor.set_error(format!("{}: {}", crate::i18n::tr("Invalid macro"), err));
                 return;
             }
         }
     } else {
-        cx.editor.set_error(format!("Register [{}] empty", reg));
+        cx.editor.set_error(format!("{}{}{}", crate::i18n::tr("Register ["), reg, crate::i18n::tr("] empty")));
         return;
     };
 
@@ -7026,7 +7053,7 @@ fn lsp_or_syntax_symbol_picker(cx: &mut Context) {
         syntax_symbol_picker(cx);
     } else {
         cx.editor
-            .set_error("No language server supporting document symbols or syntax info available");
+            .set_error(crate::i18n::tr("No language server supporting document symbols or syntax info available"));
     }
 }
 

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -234,7 +234,7 @@ fn map_value(value: &Value, params: &[String]) -> Value {
 pub fn dap_launch(cx: &mut Context) {
     // TODO: Now that we support multiple Clients, we could run multiple debuggers at once but for now keep this as is
     if cx.editor.debug_adapters.get_active_client().is_some() {
-        cx.editor.set_error("Debugger is already running");
+        cx.editor.set_error(crate::i18n::tr("Debugger is already running"));
         return;
     }
 
@@ -247,7 +247,7 @@ pub fn dap_launch(cx: &mut Context) {
         Some(c) => c,
         None => {
             cx.editor
-                .set_error("No debug adapter available for language");
+                .set_error(crate::i18n::tr("No debug adapter available for language"));
             return;
         }
     };
@@ -290,7 +290,7 @@ pub fn dap_restart(cx: &mut Context) {
     let debugger = match cx.editor.debug_adapters.get_active_client() {
         Some(debugger) => debugger,
         None => {
-            cx.editor.set_error("Debugger is not running");
+            cx.editor.set_error(crate::i18n::tr("Debugger is not running"));
             return;
         }
     };
@@ -300,19 +300,19 @@ pub fn dap_restart(cx: &mut Context) {
         .unwrap_or(false)
     {
         cx.editor
-            .set_error("Debugger does not support session restarts");
+            .set_error(crate::i18n::tr("Debugger does not support session restarts"));
         return;
     }
     if debugger.starting_request_args().is_none() {
         cx.editor
-            .set_error("No arguments found with which to restart the sessions");
+            .set_error(crate::i18n::tr("No arguments found with which to restart the sessions"));
         return;
     }
 
     dap_callback(
         cx.jobs,
         debugger.restart(),
-        |editor, _compositor, _resp: ()| editor.set_status("Debugging session restarted"),
+        |editor, _compositor, _resp: ()| editor.set_status(crate::i18n::tr("Debugging session restarted")),
     );
 }
 
@@ -393,7 +393,7 @@ pub fn dap_toggle_breakpoint(cx: &mut Context) {
         Some(path) => path.clone(),
         None => {
             cx.editor
-                .set_error("Can't set breakpoint: document has no path");
+                .set_error(crate::i18n::tr("Can't set breakpoint: document has no path"));
             return;
         }
     };
@@ -424,7 +424,7 @@ pub fn dap_toggle_breakpoint_impl(cx: &mut Context, path: PathBuf, line: usize) 
 
     if let Err(e) = breakpoints_changed(debugger, path, breakpoints) {
         cx.editor
-            .set_error(format!("Failed to set breakpoints: {}", e));
+            .set_error(crate::i18n::tr("Failed to set breakpoints: {}").replace("{}", &e.to_string()));
     }
 }
 
@@ -443,7 +443,7 @@ pub fn dap_continue(cx: &mut Context) {
         );
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(crate::i18n::tr("Currently active thread is not stopped. Switch the thread."));
     }
 }
 
@@ -453,7 +453,7 @@ pub fn dap_pause(cx: &mut Context) {
         let request = debugger.pause(thread.id);
         // NOTE: we don't need to set active thread id here because DAP will emit a "stopped" event
         if let Err(e) = block_on(request) {
-            editor.set_error(format!("Failed to pause: {}", e));
+            editor.set_error(crate::i18n::tr("Failed to pause: {}").replace("{}", &e.to_string()));
         }
     })
 }
@@ -469,7 +469,7 @@ pub fn dap_step_in(cx: &mut Context) {
         });
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(crate::i18n::tr("Currently active thread is not stopped. Switch the thread."));
     }
 }
 
@@ -483,7 +483,7 @@ pub fn dap_step_out(cx: &mut Context) {
         });
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(crate::i18n::tr("Currently active thread is not stopped. Switch the thread."));
     }
 }
 
@@ -497,7 +497,7 @@ pub fn dap_next(cx: &mut Context) {
         });
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(crate::i18n::tr("Currently active thread is not stopped. Switch the thread."));
     }
 }
 
@@ -506,14 +506,14 @@ pub fn dap_variables(cx: &mut Context) {
 
     if debugger.thread_id.is_none() {
         cx.editor
-            .set_status("Cannot access variables while target is running.");
+            .set_status(crate::i18n::tr("Cannot access variables while target is running."));
         return;
     }
     let (frame, thread_id) = match (debugger.active_frame, debugger.thread_id) {
         (Some(frame), Some(thread_id)) => (frame, thread_id),
         _ => {
             cx.editor
-                .set_status("Cannot find current stack frame to access variables.");
+                .set_status(crate::i18n::tr("Cannot find current stack frame to access variables."));
             return;
         }
     };
@@ -522,16 +522,16 @@ pub fn dap_variables(cx: &mut Context) {
         Some(thread_frame) => thread_frame,
         None => {
             cx.editor
-                .set_error(format!("Failed to get stack frame for thread: {thread_id}"));
+                .set_error(crate::i18n::tr("Failed to get stack frame for thread: {thread_id}").replace("{thread_id}", &thread_id.to_string()));
             return;
         }
     };
     let stack_frame = match thread_frame.get(frame) {
         Some(stack_frame) => stack_frame,
         None => {
-            cx.editor.set_error(format!(
+            cx.editor.set_error(crate::i18n::tr(
                 "Failed to get stack frame for thread {thread_id} and frame {frame}."
-            ));
+            ).replace("{thread_id}", &thread_id.to_string()).replace("{frame}", &frame.to_string()));
             return;
         }
     };
@@ -540,7 +540,7 @@ pub fn dap_variables(cx: &mut Context) {
     let scopes = match block_on(debugger.scopes(frame_id)) {
         Ok(s) => s,
         Err(e) => {
-            cx.editor.set_error(format!("Failed to get scopes: {}", e));
+            cx.editor.set_error(crate::i18n::tr("Failed to get scopes: {}").replace("{}", &e.to_string()));
             return;
         }
     };
@@ -559,7 +559,7 @@ pub fn dap_variables(cx: &mut Context) {
         let response = block_on(debugger.variables(scope.variables_reference));
 
         variables.push(Spans::from(Span::styled(
-            format!("▸ {}", scope.name),
+            crate::i18n::tr("▸ {}").replace("{}", &scope.name),
             scope_style,
         )));
 
@@ -586,7 +586,7 @@ pub fn dap_variables(cx: &mut Context) {
 }
 
 pub fn dap_terminate(cx: &mut Context) {
-    cx.editor.set_status("Terminating debug session...");
+    cx.editor.set_status(crate::i18n::tr("Terminating debug session..."));
     let debugger = debugger!(cx.editor);
 
     if debugger
@@ -669,7 +669,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
 
                         if let Err(e) = breakpoints_changed(debugger, path.clone(), breakpoints) {
                             cx.editor
-                                .set_error(format!("Failed to set breakpoints: {}", e));
+                                .set_error(crate::i18n::tr("Failed to set breakpoints: {}").replace("{}", &e.to_string()));
                         }
                     },
                 );

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -46,10 +46,7 @@ macro_rules! language_server_with_feature {
         match language_server {
             Some(language_server) => language_server,
             None => {
-                $editor.set_error(format!(
-                    "No configured language server supports {}",
-                    $feature
-                ));
+                $editor.set_error(crate::i18n::tr("No configured language server supports {}").replace("{}", &$feature.to_string()));
                 return;
             }
         }
@@ -114,7 +111,7 @@ fn jump_to_location(editor: &mut Editor, location: &Location, action: Action) {
     push_jump(view, doc);
 
     let Some(path) = location.uri.as_path() else {
-        let err = format!("unable to convert URI to filepath: {:?}", location.uri);
+        let err = crate::i18n::tr("unable to convert URI to filepath: {:?}").replace("{:?}", &format!("{:?}", location.uri));
         editor.set_error(err);
         return;
     };
@@ -392,7 +389,7 @@ pub fn symbol_picker(cx: &mut Context) {
 
     if futures.is_empty() {
         cx.editor
-            .set_error("No configured language server supports document symbols");
+            .set_error(crate::i18n::tr("No configured language server supports document symbols"));
         return;
     }
 
@@ -453,7 +450,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
         == 0
     {
         cx.editor
-            .set_error("No configured language server supports workspace symbols");
+            .set_error(crate::i18n::tr("No configured language server supports workspace symbols"));
         return;
     }
 
@@ -504,7 +501,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
             .collect();
 
         if futures.is_empty() {
-            editor.set_error("No configured language server supports workspace symbols");
+            editor.set_error(crate::i18n::tr("No configured language server supports workspace symbols"));
         }
 
         let injector = injector.clone();
@@ -748,7 +745,7 @@ pub fn code_action(cx: &mut Context) {
 
     if futures.is_empty() {
         cx.editor
-            .set_error("No configured language server supports code actions");
+            .set_error(crate::i18n::tr("No configured language server supports code actions"));
         return;
     }
 
@@ -764,7 +761,7 @@ pub fn code_action(cx: &mut Context) {
 
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if actions.is_empty() {
-                editor.set_error("No code actions available");
+                editor.set_error(crate::i18n::tr("No code actions available"));
                 return;
             }
             let mut picker = ui::Menu::new(actions, (), move |editor, action, event| {
@@ -776,7 +773,7 @@ pub fn code_action(cx: &mut Context) {
                 let action = action.unwrap();
                 let Some(language_server) = editor.language_server_by_id(action.language_server_id)
                 else {
-                    editor.set_error("Language Server disappeared");
+                    editor.set_error(crate::i18n::tr("Language Server disappeared"));
                     return;
                 };
                 let offset_encoding = language_server.offset_encoding();
@@ -936,11 +933,11 @@ where
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if locations.is_empty() {
                 editor.set_error(match feature {
-                    LanguageServerFeature::GotoDeclaration => "No declaration found.",
-                    LanguageServerFeature::GotoDefinition => "No definition found.",
-                    LanguageServerFeature::GotoTypeDefinition => "No type definition found.",
-                    LanguageServerFeature::GotoImplementation => "No implementation found.",
-                    _ => "No location found.",
+                    LanguageServerFeature::GotoDeclaration => crate::i18n::tr("No declaration found."),
+                    LanguageServerFeature::GotoDefinition => crate::i18n::tr("No definition found."),
+                    LanguageServerFeature::GotoTypeDefinition => crate::i18n::tr("No type definition found."),
+                    LanguageServerFeature::GotoImplementation => crate::i18n::tr("No implementation found."),
+                    _ => crate::i18n::tr("No location found."),
                 });
             } else {
                 goto_impl(editor, compositor, locations);
@@ -1018,7 +1015,7 @@ pub fn goto_reference(cx: &mut Context) {
         }
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if locations.is_empty() {
-                editor.set_error("No references found.");
+                editor.set_error(crate::i18n::tr("No references found."));
             } else {
                 goto_impl(editor, compositor, locations);
             }
@@ -1043,7 +1040,7 @@ pub fn hover(cx: &mut Context) {
         == 0
     {
         cx.editor
-            .set_error("No configured language server supports hover");
+            .set_error(crate::i18n::tr("No configured language server supports hover"));
         return;
     }
 
@@ -1076,7 +1073,7 @@ pub fn hover(cx: &mut Context) {
 
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if hovers.is_empty() {
-                editor.set_status("No hover results available.");
+                editor.set_status(crate::i18n::tr("No hover results available."));
                 return;
             }
 
@@ -1149,7 +1146,7 @@ pub fn rename_symbol(cx: &mut Context) {
                     .find(|ls| language_server_id.is_none_or(|id| id == ls.id()))
                 else {
                     cx.editor
-                        .set_error("No configured language server supports symbol renaming");
+                        .set_error(crate::i18n::tr("No configured language server supports symbol renaming"));
                     return;
                 };
 
@@ -1183,7 +1180,7 @@ pub fn rename_symbol(cx: &mut Context) {
         .is_none()
     {
         cx.editor
-            .set_error("No configured language server supports symbol renaming");
+            .set_error(crate::i18n::tr("No configured language server supports symbol renaming"));
         return;
     }
 

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -157,7 +157,7 @@ pub fn syntax_symbol_picker(cx: &mut Context) {
     let doc = doc!(cx.editor);
     let Some(syntax) = doc.syntax() else {
         cx.editor
-            .set_error("Syntax tree is not available on this buffer");
+            .set_error(crate::i18n::tr("Syntax tree is not available on this buffer"));
         return;
     };
     let doc_id = doc.id();
@@ -407,7 +407,7 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
                     Ok(id) => id,
                     Err(e) => {
                         cx.editor
-                            .set_error(format!("Failed to open file '{uri:?}': {e}"));
+                            .set_error(crate::i18n::tr("Failed to open file '{uri:?}': {e}").replace("{uri:?}", &format!("{uri:?}")).replace("{e}", &e.to_string()));
                         return;
                     }
                 }
@@ -416,7 +416,7 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
             let view = view_mut!(cx.editor);
             let len_chars = doc.text().len_chars();
             if tag.start >= len_chars || tag.end > len_chars {
-                cx.editor.set_error("The location you jumped to does not exist anymore because the file has changed.");
+                cx.editor.set_error(crate::i18n::tr("The location you jumped to does not exist anymore because the file has changed."));
                 return;
             }
             doc.set_selection(view.id, Selection::single(tag.start, tag.end));

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -237,8 +237,9 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: Args) -> Vec<DocumentId> 
 
     if !nonexistent_buffers.is_empty() {
         editor.set_error(format!(
-            "cannot close non-existent buffers: {}",
-            nonexistent_buffers.join(", ")
+            "{}",
+            crate::i18n::tr("cannot close non-existent buffers: {}")
+                .replace("{}", &nonexistent_buffers.join(", "))
         ));
     }
 
@@ -601,9 +602,10 @@ fn set_indent_style(
     if args.is_empty() {
         let style = doc!(cx.editor).indent_style;
         cx.editor.set_status(match style {
-            Tabs => "tabs".to_owned(),
-            Spaces(1) => "1 space".to_owned(),
-            Spaces(n) => format!("{} spaces", n),
+            Tabs => crate::i18n::tr("tabs").into_owned(),
+            Spaces(1) => crate::i18n::tr("1 space").into_owned(),
+            Spaces(n) => crate::i18n::tr("{} spaces")
+                .replace("{}", &n.to_string()),
         });
         return Ok(());
     }
@@ -643,18 +645,18 @@ fn set_line_ending(
     if args.is_empty() {
         let line_ending = doc!(cx.editor).line_ending;
         cx.editor.set_status(match line_ending {
-            Crlf => "crlf",
-            LF => "line feed",
+            Crlf => crate::i18n::tr("crlf"),
+            LF => crate::i18n::tr("line feed"),
             #[cfg(feature = "unicode-lines")]
-            FF => "form feed",
+            FF => crate::i18n::tr("form feed"),
             #[cfg(feature = "unicode-lines")]
-            CR => "carriage return",
+            CR => crate::i18n::tr("carriage return"),
             #[cfg(feature = "unicode-lines")]
-            Nel => "next line",
+            Nel => crate::i18n::tr("next line"),
 
             // These should never be a document's default line ending.
             #[cfg(feature = "unicode-lines")]
-            VT | LS | PS => "error",
+            VT | LS | PS => crate::i18n::tr("error"),
         });
 
         return Ok(());
@@ -710,7 +712,7 @@ fn earlier(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyh
     let (view, doc) = current!(cx.editor);
     let success = doc.earlier(view, uk);
     if !success {
-        cx.editor.set_status("Already at oldest change");
+        cx.editor.set_status(crate::i18n::tr("Already at oldest change"));
     }
 
     Ok(())
@@ -725,7 +727,7 @@ fn later(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
     let (view, doc) = current!(cx.editor);
     let success = doc.later(view, uk);
     if !success {
-        cx.editor.set_status("Already at newest change");
+        cx.editor.set_status(crate::i18n::tr("Already at newest change"));
     }
 
     Ok(())
@@ -793,10 +795,11 @@ pub(super) fn buffers_remaining_impl(editor: &mut Editor) -> anyhow::Result<()> 
             .collect();
 
         bail!(
-            "{} unsaved buffer{} remaining: {:?}",
-            modified_names.len(),
-            if modified_names.len() == 1 { "" } else { "s" },
-            modified_names,
+            "{}",
+            crate::i18n::tr("{} unsaved buffer{} remaining: {:?}")
+                .replacen("{}", &modified_names.len().to_string(), 1)
+                .replacen("{}", &if modified_names.len() == 1 { "" } else { "s" }, 1)
+                .replacen("{}", &format!("{:?}", modified_names), 1)
         );
     }
     Ok(())
@@ -1034,7 +1037,7 @@ fn theme(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
             } else if let Some(theme_name) = args.first() {
                 if let Ok(theme) = cx.editor.theme_loader.load(theme_name) {
                     if !(true_color || theme.is_16_color()) {
-                        bail!("Unsupported theme: theme requires true color support");
+                    bail!("{}", crate::i18n::tr("Unsupported theme: theme requires true color support"));
                     }
                     cx.editor.set_theme_preview(theme)?;
                 };
@@ -1232,7 +1235,7 @@ fn show_clipboard_provider(
 #[inline]
 fn parse_first_arg_as_dir(args: &Args, last_cwd: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     match args.first().map(AsRef::as_ref) {
-        Some("-") => last_cwd.ok_or_else(|| anyhow!("No previous working directory")),
+        Some("-") => last_cwd.ok_or_else(|| anyhow!("{}", crate::i18n::tr("No previous working directory"))),
         Some(path) => Ok(helix_stdx::path::expand_tilde(Path::new(path)).into_owned()),
         None => Ok(home_dir()?),
     }
@@ -1243,14 +1246,17 @@ fn parse_first_arg_as_dir(args: &Args, last_cwd: Option<PathBuf>) -> anyhow::Res
 fn apply_directory_change(cx: &mut compositor::Context, dir: &Path) -> anyhow::Result<()> {
     cx.editor.set_cwd(dir).map_err(|err| {
         anyhow!(
-            "Could not change working directory to '{}': {err}",
-            dir.display()
+            "{}",
+            crate::i18n::tr("Could not change working directory to '{}': {err}")
+                .replace("{}", &dir.display().to_string())
+                .replace("{err}", &err.to_string())
         )
     })?;
 
     cx.editor.set_status(format!(
-        "Current working directory is now {}",
-        helix_stdx::env::current_working_dir().display()
+        "{}",
+        crate::i18n::tr("Current working directory is now {}")
+            .replace("{}", &helix_stdx::env::current_working_dir().display().to_string())
     ));
 
     Ok(())
@@ -1290,7 +1296,7 @@ fn show_directory_stack(
     if !serialized_stack.is_empty() {
         cx.editor.set_status(serialized_stack);
     } else {
-        cx.editor.set_error("Stack is empty");
+        cx.editor.set_error(crate::i18n::tr("Stack is empty"));
     }
 
     Ok(())
@@ -1329,7 +1335,7 @@ fn pop_directory(
     if let Some(dir) = cx.editor.dir_stack.pop_front() {
         apply_directory_change(cx, &dir)?;
     } else {
-        cx.editor.set_error("Stack is empty");
+        cx.editor.set_error(crate::i18n::tr("Stack is empty"));
     }
 
     Ok(())
@@ -1345,12 +1351,19 @@ fn show_current_directory(
     }
 
     let cwd = helix_stdx::env::current_working_dir();
-    let message = format!("Current working directory is {}", cwd.display());
+    let message = format!(
+        "{}",
+        crate::i18n::tr("Current working directory is {}")
+            .replace("{}", &cwd.display().to_string())
+    );
 
     if cwd.exists() {
         cx.editor.set_status(message);
     } else {
-        cx.editor.set_error(format!("{} (deleted)", message));
+        cx.editor.set_error(format!(
+            "{}",
+            crate::i18n::tr("{} (deleted)").replace("{}", &message)
+        ));
     }
     Ok(())
 }
@@ -1455,7 +1468,7 @@ fn get_character_info(
 
     // Give the decimal value for ascii characters
     let dec = if encoding.is_ascii_compatible() && grapheme.len() == 1 {
-        format!(" Dec {}", grapheme.as_bytes()[0])
+        format!(" {}", crate::i18n::tr("Dec {}").replace("{}", &grapheme.as_bytes()[0].to_string()))
     } else {
         String::new()
     };
@@ -1481,7 +1494,12 @@ fn get_character_info(
             );
 
             if let encoding::EncoderResult::Unmappable(char) = result {
-                bail!("{char:?} cannot be mapped to {}", encoding.name());
+                bail!(
+                    "{}",
+                    crate::i18n::tr("{:?} cannot be mapped to {}")
+                        .replace("{:?}", &format!("{char:?}"))
+                        .replace("{}", &encoding.name())
+                );
             }
 
             for byte in &bytes[current_byte..] {
@@ -1683,12 +1701,16 @@ fn lsp_workspace_command(
             }
             [] => {
                 cx.editor.set_status(format!(
-                    "`{command}` is not supported for any language server"
+                    "{}",
+                    crate::i18n::tr("`{command}` is not supported for any language server")
+                        .replace("{command}", &command)
                 ));
             }
             _ => {
                 cx.editor.set_status(format!(
-                    "`{command}` supported by multiple language servers"
+                    "{}",
+                    crate::i18n::tr("`{command}` supported by multiple language servers")
+                        .replace("{command}", &command)
                 ));
             }
         }
@@ -1721,7 +1743,12 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
             .partition(|name| language_servers.contains(name));
         if !invalid.is_empty() {
             let s = if invalid.len() == 1 { "" } else { "s" };
-            bail!("Unknown language server{s}: {}", invalid.join(", "));
+            bail!(
+                "{}",
+                crate::i18n::tr("Unknown language server{s}: {}")
+                    .replace("{s}", s)
+                    .replace("{}", &invalid.join(", "))
+            );
         }
         valid
     };
@@ -2028,7 +2055,7 @@ fn debug_eval(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
         let (frame, thread_id) = match (debugger.active_frame, debugger.thread_id) {
             (Some(frame), Some(thread_id)) => (frame, thread_id),
             _ => {
-                bail!("Cannot find current stack frame to access variables")
+                bail!("{}", crate::i18n::tr("Cannot find current stack frame to access variables"))
             }
         };
 
@@ -2161,7 +2188,7 @@ fn get_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
     }
 
     let key = &args[0].to_lowercase();
-    let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
+    let key_error = || anyhow::anyhow!("{}", crate::i18n::tr("Unknown key `{}`").replace("{}", key));
 
     let config = serde_json::json!(cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
@@ -2180,8 +2207,8 @@ fn set_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
 
     let (key, arg) = (&args[0].to_lowercase(), args[1].trim());
 
-    let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
-    let field_error = |_| anyhow::anyhow!("Could not parse field `{}`", arg);
+    let key_error = || anyhow::anyhow!("{}", crate::i18n::tr("Unknown key `{}`").replace("{}", key));
+    let field_error = |_| anyhow::anyhow!("{}", crate::i18n::tr("Could not parse field `{}`").replace("{}", arg));
 
     let mut config = serde_json::json!(&cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
@@ -2216,7 +2243,7 @@ fn toggle_option(
 
     let key = &args[0].to_lowercase();
 
-    let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
+    let key_error = || anyhow::anyhow!("{}", crate::i18n::tr("Unknown key `{}`").replace("{}", key));
 
     let mut config = serde_json::json!(&cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
@@ -2226,14 +2253,18 @@ fn toggle_option(
         Value::Bool(ref value) => {
             ensure!(
                 args.len() == 1,
-                "Bad arguments. For boolean configurations use: `:toggle {key}`"
+                "{}",
+                crate::i18n::tr("Bad arguments. For boolean configurations use: `:toggle {key}`")
+                    .replace("{key}", key)
             );
             Value::Bool(!value)
         }
         Value::String(ref value) => {
             ensure!(
                 args.len() == 2,
-                "Bad arguments. For string configurations use: `:toggle {key} val1 val2 ...`",
+                "{}",
+                crate::i18n::tr("Bad arguments. For string configurations use: `:toggle {key} val1 val2 ...`")
+                    .replace("{key}", key)
             );
             // For string values, parse the input according to normal command line rules.
             let values: Vec<_> = command_line::Tokenizer::new(&args[1], true)
@@ -2286,7 +2317,12 @@ fn toggle_option(
         }
     };
 
-    let status = format!("'{key}' is now set to {value}");
+    let status = format!(
+        "{}",
+        crate::i18n::tr("'{key}' is now set to {value}")
+            .replace("{key}", key)
+            .replace("{value}", &value.to_string())
+    );
     let config = serde_json::from_value(config)
         .map_err(|err| anyhow::anyhow!("Failed to parse config: {err}"))?;
 
@@ -2342,7 +2378,7 @@ fn sort(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     let selection = doc.selection(view.id);
 
     if selection.len() == 1 {
-        bail!("Sorting requires multiple selections. Hint: split selection first");
+        bail!("{}", crate::i18n::tr("Sorting requires multiple selections. Hint: split selection first"));
     }
 
     let mut fragments: Vec<_> = selection
@@ -2572,7 +2608,7 @@ fn run_shell_command(
                     ));
                     compositor.replace_or_push("shell", popup);
                 }
-                editor.set_status("Command run");
+                editor.set_status(crate::i18n::tr("Command run"));
             },
         ));
         Ok(call)
@@ -2596,7 +2632,7 @@ fn reset_diff_change(
 
     let (view, doc) = current!(editor);
     let Some(handle) = doc.diff_handle() else {
-        bail!("Diff is not available in the current buffer")
+        bail!("{}", crate::i18n::tr("Diff is not available in the current buffer"))
     };
 
     let diff = handle.load();
@@ -2620,7 +2656,7 @@ fn reset_diff_change(
             }),
     );
     if changes == 0 {
-        bail!("There are no changes under any selection");
+        bail!("{}", crate::i18n::tr("There are no changes under any selection"));
     }
 
     drop(diff); // make borrow check happy
@@ -2628,8 +2664,10 @@ fn reset_diff_change(
     doc.append_changes_to_history(view);
     view.ensure_cursor_in_view(doc, scrolloff);
     cx.editor.set_status(format!(
-        "Reset {changes} change{}",
-        if changes == 1 { "" } else { "s" }
+        "{}",
+        crate::i18n::tr("Reset {changes} change{}")
+            .replacen("{changes}", &changes.to_string(), 1)
+            .replace("{}", if changes == 1 { "" } else { "s" })
     ));
     Ok(())
 }
@@ -2645,21 +2683,28 @@ fn clear_register(
 
     if args.is_empty() {
         cx.editor.registers.clear();
-        cx.editor.set_status("All registers cleared");
+        cx.editor.set_status(crate::i18n::tr("All registers cleared"));
         return Ok(());
     }
 
     ensure!(
         args[0].chars().count() == 1,
-        format!("Invalid register {}", &args[0])
+        "{}",
+        crate::i18n::tr("Invalid register {}").replace("{}", &args[0])
     );
     let register = args[0].chars().next().unwrap_or_default();
     if cx.editor.registers.remove(register) {
         cx.editor
-            .set_status(format!("Register {} cleared", register));
+            .set_status(format!(
+                "{}",
+                crate::i18n::tr("Register {} cleared").replace("{}", &register.to_string())
+            ));
     } else {
         cx.editor
-            .set_error(format!("Register {} not found", register));
+            .set_error(format!(
+                "{}",
+                crate::i18n::tr("Register {} not found").replace("{}", &register.to_string())
+            ));
     }
     Ok(())
 }
@@ -2675,7 +2720,8 @@ fn set_register(
 
     ensure!(
         args[0].chars().count() == 1,
-        format!("Invalid register {}", &args[0])
+        "{}",
+        crate::i18n::tr("Invalid register {}").replace("{}", &args[0])
     );
 
     let register = args[0].chars().next().unwrap_or_default();
@@ -2754,7 +2800,8 @@ fn move_buffer_impl(
                     std::fs::DirBuilder::new().recursive(true).create(parent)?;
                 } else {
                     bail!(
-                        "can't move file, parent directory does not exist (use :mv! to create it)"
+                        "{}",
+                        crate::i18n::tr("can't move file, parent directory does not exist (use :mv! to create it)")
                     )
                 }
             }
@@ -2778,7 +2825,7 @@ fn yank_diagnostic(
 
     let reg = match args.first() {
         Some(s) => {
-            ensure!(s.chars().count() == 1, format!("Invalid register {s}"));
+            ensure!(s.chars().count() == 1, "{}", crate::i18n::tr("Invalid register {s}").replace("{s}", s));
             s.chars().next().unwrap()
         }
         None => '+',
@@ -2796,13 +2843,16 @@ fn yank_diagnostic(
         .collect();
     let n = diag.len();
     if n == 0 {
-        bail!("No diagnostics under primary selection");
+        bail!("{}", crate::i18n::tr("No diagnostics under primary selection"));
     }
 
     cx.editor.registers.write(reg, diag)?;
     cx.editor.set_status(format!(
-        "Yanked {n} diagnostic{} to register {reg}",
-        if n == 1 { "" } else { "s" }
+        "{}",
+        crate::i18n::tr("Yanked {n} diagnostic{} to register {reg}")
+            .replacen("{n}", &n.to_string(), 1)
+            .replace("{}", if n == 1 { "" } else { "s" })
+            .replace("{reg}", &reg.to_string())
     ));
     Ok(())
 }
@@ -2820,14 +2870,14 @@ fn read(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
 
     ensure!(
         path.exists() && path.is_file(),
-        "path is not a file: {:?}",
-        path
+        "{}",
+        crate::i18n::tr("path is not a file: {:?}").replace("{:?}", &format!("{path:?}"))
     );
 
-    let file = std::fs::File::open(path).map_err(|err| anyhow!("error opening file: {}", err))?;
+    let file = std::fs::File::open(path).map_err(|err| anyhow!("{}" , crate::i18n::tr("error opening file: {}").replace("{}", &err.to_string())))?;
     let mut reader = BufReader::new(file);
     let (contents, _, _) = read_to_string(&mut reader, Some(doc.encoding()))
-        .map_err(|err| anyhow!("error reading file: {}", err))?;
+        .map_err(|err| anyhow!("{}", crate::i18n::tr("error reading file: {}").replace("{}", &err.to_string())))?;
     let contents = Tendril::from(contents);
     let selection = doc.selection(view.id);
     let transaction = Transaction::insert(doc.text(), selection, contents);
@@ -4071,10 +4121,10 @@ fn command_line_doc(input: &str) -> Option<Cow<'_, str>> {
     let command = TYPABLE_COMMAND_MAP.get(command)?;
 
     if command.aliases.is_empty() && command.signature.flags.is_empty() {
-        return Some(Cow::Borrowed(command.doc));
+        return Some(crate::i18n::tr(command.doc));
     }
 
-    let mut doc = command.doc.to_string();
+    let mut doc = crate::i18n::tr(command.doc).into_owned();
 
     if !command.aliases.is_empty() {
         write!(doc, "\nAliases: {}", command.aliases.join(", ")).unwrap();

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -118,7 +118,7 @@ pub fn request_signature_help(
         // Do not show the message if signature help was invoked
         // automatically on backspace, trigger characters, etc.
         if invoked == SignatureHelpInvoked::Manual {
-            editor.set_error("No configured language server supports signature-help");
+            editor.set_error(crate::i18n::tr("No configured language server supports signature-help"));
         }
         return;
     };

--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -49,8 +49,10 @@ const TRUST_MESSAGE: &str = "Trust this workspace?
 Trusted workspaces may load local config files and auto-start language servers. Config and language servers can execute arbitrary code. Only trust workspaces which you know contain harmless config and code.";
 
 fn select() -> ui::Select<TrustUntrustStatus> {
+    use crate::i18n;
+    let message = i18n::tr(TRUST_MESSAGE);
     ui::Select::new(
-        TRUST_MESSAGE,
+        message,
         [
             TrustUntrustStatus::DenyOnce,
             TrustUntrustStatus::DenyAlways,
@@ -91,9 +93,9 @@ impl crate::ui::menu::Item for TrustUntrustStatus {
 
     fn format(&self, _data: &Self::Data) -> tui::widgets::Row<'_> {
         match self {
-            TrustUntrustStatus::DenyAlways => "Never",
-            TrustUntrustStatus::DenyOnce => "Not now",
-            TrustUntrustStatus::AllowAlways => "Always",
+            TrustUntrustStatus::DenyAlways => crate::i18n::tr("Never"),
+            TrustUntrustStatus::DenyOnce => crate::i18n::tr("Not now"),
+            TrustUntrustStatus::AllowAlways => crate::i18n::tr("Always"),
         }
         .into()
     }

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -94,17 +94,26 @@ pub fn general() -> std::io::Result<()> {
     for rt_dir in rt_dirs.iter() {
         if let Ok(path) = std::fs::read_link(rt_dir) {
             let msg = format!(
-                "Runtime directory {} is symlinked to: {}",
+                "{} {} {}",
+                crate::i18n::tr("Runtime directory"),
                 rt_dir.display(),
-                path.display()
+                crate::i18n::tr("is symlinked to: {}").replace("{}", &path.display().to_string())
             );
             writeln!(stdout, "{}", msg.yellow())?;
         }
         if !rt_dir.exists() {
-            let msg = format!("Runtime directory does not exist: {}", rt_dir.display());
+            let msg = format!(
+                "{}: {}",
+                crate::i18n::tr("Runtime directory does not exist"),
+                rt_dir.display()
+            );
             writeln!(stdout, "{}", msg.yellow())?;
         } else if rt_dir.read_dir().ok().map(|it| it.count()) == Some(0) {
-            let msg = format!("Runtime directory is empty: {}", rt_dir.display());
+            let msg = format!(
+                "{}: {}",
+                crate::i18n::tr("Runtime directory is empty"),
+                rt_dir.display()
+            );
             writeln!(stdout, "{}", msg.yellow())?;
         }
     }
@@ -122,7 +131,11 @@ pub fn clipboard() -> std::io::Result<()> {
             Config::default()
         }
         Err(err) => {
-            writeln!(stdout, "{}", "Configuration file malformed".red())?;
+            writeln!(
+                stdout,
+                "{}",
+                crate::i18n::tr("Configuration file malformed").red()
+            )?;
             writeln!(stdout, "{}", err)?;
             return Ok(());
         }
@@ -133,12 +146,12 @@ pub fn clipboard() -> std::io::Result<()> {
             writeln!(
                 stdout,
                 "{}",
-                "System clipboard provider: Not installed".red()
+                crate::i18n::tr("System clipboard provider: Not installed").red()
             )?;
             writeln!(
                 stdout,
                 "    {}",
-                "For troubleshooting system clipboard issues, refer".red()
+                crate::i18n::tr("For troubleshooting system clipboard issues, refer").red()
             )?;
             writeln!(stdout, "    {}",
                 "https://github.com/helix-editor/helix/wiki/Troubleshooting#copypaste-fromto-system-clipboard-not-working"
@@ -172,10 +185,14 @@ fn languages(selection: Option<HashSet<String>>) -> std::io::Result<()> {
             writeln!(
                 stderr,
                 "{}: {}",
-                "Error parsing user language config".red(),
+                crate::i18n::tr("Error parsing user language config").red(),
                 err
             )?;
-            writeln!(stderr, "{}", "Using default language config".yellow())?;
+            writeln!(
+                stderr,
+                "{}",
+                crate::i18n::tr("Using default language config").yellow()
+            )?;
             default_lang_config()
         }
     };
@@ -269,8 +286,9 @@ fn languages(selection: Option<HashSet<String>>) -> std::io::Result<()> {
     if selection.is_some() {
         writeln!(
             stdout,
-            "\nThis list is filtered according to the 'use-grammars' option in languages.toml file.\n\
-            To see the full list, use the '--health all' or '--health all-languages' option."
+            "\n{}\n{}",
+            crate::i18n::tr("This list is filtered according to the 'use-grammars' option in languages.toml file."),
+            crate::i18n::tr("To see the full list, use the '--health all' or '--health all-languages' option.")
         )?;
     }
 
@@ -307,7 +325,10 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
     {
         Some(l) => l,
         None => {
-            let msg = format!("Language '{}' not found", lang_str);
+            let msg = format!(
+                "{}",
+                crate::i18n::tr("Language '{}' not found").replace("{}", &lang_str)
+            );
             writeln!(stdout, "{}", msg.red())?;
             let suggestions: Vec<&str> = syn_loader_conf
                 .language
@@ -319,8 +340,14 @@ pub fn language(lang_str: String) -> std::io::Result<()> {
                 let suggestions = suggestions.join(", ");
                 writeln!(
                     stdout,
-                    "Did you mean one of these: {} ?",
-                    suggestions.yellow()
+                    "{}",
+                    format!(
+                        "{} {}",
+                        crate::i18n::tr("Did you mean one of these: {} ?")
+                            .replace("{}", &suggestions),
+                        ""
+                    )
+                    .yellow()
                 )?;
             }
             return Ok(());
@@ -389,7 +416,14 @@ fn probe_protocols<'a, I: Iterator<Item = (&'a str, &'a str)> + 'a>(
     for (name, cmd) in server_cmds {
         let (diag, icon) = match helix_stdx::env::which(cmd) {
             Ok(path) => (path.display().to_string().green(), "✓".green()),
-            Err(_) => (format!("'{}' not found in $PATH", cmd).red(), "✘".red()),
+            Err(_) => (
+                format!(
+                    "{}",
+                    crate::i18n::tr("'{}' not found in $PATH").replace("{}", cmd)
+                )
+                .red(),
+                "✘".red(),
+            ),
         };
         writeln!(stdout, "  {} {}: {}", icon, name, diag)?;
     }
@@ -411,7 +445,14 @@ fn probe_protocol(protocol_name: &str, server_cmd: Option<String>) -> std::io::R
 
     let (diag, icon) = match helix_stdx::env::which(&cmd) {
         Ok(path) => (path.display().to_string().green(), "✓".green()),
-        Err(_) => (format!("'{}' not found in $PATH", cmd).red(), "✘".red()),
+        Err(_) => (
+            format!(
+                "{}",
+                crate::i18n::tr("'{}' not found in $PATH").replace("{}", &cmd)
+            )
+            .red(),
+            "✘".red(),
+        ),
     };
     writeln!(stdout, "  {} {}", icon, diag)?;
 

--- a/helix-term/src/i18n.rs
+++ b/helix-term/src/i18n.rs
@@ -1,0 +1,42 @@
+use helix_view::editor::Config;
+use std::borrow::Cow;
+use std::ops::Deref;
+
+/// Initialize i18n with the configured UI language.
+/// Falls back to "en" if the configured language is not available.
+pub fn init(config: &Config) {
+    let locale = config.ui_language.as_deref().unwrap_or("en");
+
+    // Normalize locale: "zh_cn" -> "zh-CN", "zh-CN" -> "zh-CN", "en" -> "en"
+    let normalized = match locale {
+        "zh-CN" | "zh_cn" | "zh_CN" | "zh-cn" => "zh-CN",
+        "en" | "en-US" | "en_US" | "en-us" => "en",
+        other => other,
+    };
+
+    eprintln!("[i18n] setting locale to '{}'", normalized);
+    rust_i18n::set_locale(normalized);
+    eprintln!(
+        "[i18n] current locale is now: {:?}",
+        rust_i18n::locale().deref()
+    );
+}
+
+/// Translate a static string key to the current locale.
+/// The key must be a `'static` string (compile-time string literal).
+/// Returns the translated string if available, otherwise the original key.
+pub fn tr(key: &'static str) -> Cow<'static, str> {
+    crate::t!(key)
+}
+
+/// Translate a runtime string key to the current locale.
+/// Looks up the key in the translation table and returns the translated
+/// string if found, otherwise returns the original key as an owned string.
+pub fn tr_runtime(key: &str) -> Cow<'static, str> {
+    // Try to find a translation by checking if the key exists in the
+    // translation table. We do this by using the t! macro with a static
+    // lookup approach - but since we have a runtime key, we just return
+    // the original for now. In a full implementation, we'd have a runtime
+    // lookup table.
+    Cow::Owned(key.to_string())
+}

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -55,7 +55,7 @@ impl KeyTrieNode {
     }
 
     pub fn infobox(&self) -> Info {
-        let mut body: Vec<(BTreeSet<KeyEvent>, &str)> = Vec::with_capacity(self.len());
+        let mut body: Vec<(BTreeSet<KeyEvent>, Cow<'static, str>)> = Vec::with_capacity(self.len());
         for (&key, trie) in self.iter() {
             let desc = match trie {
                 KeyTrie::MappableCommand(cmd) => {
@@ -64,8 +64,8 @@ impl KeyTrieNode {
                     }
                     cmd.doc()
                 }
-                KeyTrie::Node(n) => &n.name,
-                KeyTrie::Sequence(_) => "[Multiple commands]",
+                KeyTrie::Node(n) => translate_keymap_label(&n.name),
+                KeyTrie::Sequence(_) => Cow::Borrowed("[Multiple commands]"),
             };
             match body.iter().position(|(_, d)| d == &desc) {
                 Some(pos) => {
@@ -83,6 +83,27 @@ impl KeyTrieNode {
             })
             .collect();
         Info::new(self.name.clone(), &body)
+    }
+}
+
+/// Translate a keymap label to the current locale.
+/// Falls back to the original label if no translation is found.
+fn translate_keymap_label(label: &str) -> Cow<'static, str> {
+    match label {
+        "Normal mode" => crate::i18n::tr("Normal mode"),
+        "Select mode" => crate::i18n::tr("Select mode"),
+        "Insert mode" => crate::i18n::tr("Insert mode"),
+        "Goto" => crate::i18n::tr("Goto"),
+        "Match" => crate::i18n::tr("Match"),
+        "Window" => crate::i18n::tr("Window"),
+        "View" => crate::i18n::tr("View"),
+        "Space" => crate::i18n::tr("Space"),
+        "Left bracket" => crate::i18n::tr("Left bracket"),
+        "Right bracket" => crate::i18n::tr("Right bracket"),
+        "Debug (experimental)" => crate::i18n::tr("Debug (experimental)"),
+        "Switch" => crate::i18n::tr("Switch"),
+        "New split scratch buffer" => crate::i18n::tr("New split scratch buffer"),
+        _ => Cow::Owned(label.to_string()),
     }
 }
 

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -1,6 +1,11 @@
 #[macro_use]
 extern crate helix_view;
 
+use rust_i18n::i18n;
+use rust_i18n::t;
+
+i18n!("i18n", fallback = "en");
+
 pub mod application;
 pub mod args;
 pub mod commands;
@@ -8,6 +13,7 @@ pub mod compositor;
 pub mod config;
 pub mod events;
 pub mod health;
+pub mod i18n;
 pub mod job;
 pub mod keymap;
 pub mod ui;
@@ -84,7 +90,7 @@ fn open_external_url_callback(
             }
         }
         Ok(job::Callback::Editor(Box::new(move |editor| {
-            editor.set_error("Opening URL in external program failed")
+            editor.set_error(crate::i18n::tr("Opening URL in external program failed"))
         })))
     }
 }

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -45,67 +45,149 @@ impl menu::Item for CompletionItem {
             CompletionItem::Other(core::CompletionItem { label, .. }) => label,
         };
 
+        let kind_text;
         let kind = match self {
             CompletionItem::Lsp(LspCompletionItem { item, .. }) => match item.kind {
-                Some(lsp::CompletionItemKind::TEXT) => "text".into(),
-                Some(lsp::CompletionItemKind::METHOD) => "method".into(),
-                Some(lsp::CompletionItemKind::FUNCTION) => "function".into(),
-                Some(lsp::CompletionItemKind::CONSTRUCTOR) => "constructor".into(),
-                Some(lsp::CompletionItemKind::FIELD) => "field".into(),
-                Some(lsp::CompletionItemKind::VARIABLE) => "variable".into(),
-                Some(lsp::CompletionItemKind::CLASS) => "class".into(),
-                Some(lsp::CompletionItemKind::INTERFACE) => "interface".into(),
-                Some(lsp::CompletionItemKind::MODULE) => "module".into(),
-                Some(lsp::CompletionItemKind::PROPERTY) => "property".into(),
-                Some(lsp::CompletionItemKind::UNIT) => "unit".into(),
-                Some(lsp::CompletionItemKind::VALUE) => "value".into(),
-                Some(lsp::CompletionItemKind::ENUM) => "enum".into(),
-                Some(lsp::CompletionItemKind::KEYWORD) => "keyword".into(),
-                Some(lsp::CompletionItemKind::SNIPPET) => "snippet".into(),
-                Some(lsp::CompletionItemKind::COLOR) => item
-                    .documentation
-                    .as_ref()
-                    .and_then(|docs| {
-                        let text = match docs {
-                            lsp::Documentation::String(text) => text,
-                            lsp::Documentation::MarkupContent(lsp::MarkupContent {
-                                value, ..
-                            }) => value,
-                        };
-                        // Language servers which send Color completion items tend to include a 6
-                        // digit hex code at the end for the color. The extra 1 digit is for the '#'
-                        text.get(text.len().checked_sub(7)?..)
-                    })
-                    .and_then(|c| Color::from_hex(c).ok())
-                    .map_or("color".into(), |color| {
-                        Spans::from(vec![
-                            Span::raw("color "),
-                            Span::styled("■", Style::default().fg(color)),
-                        ])
-                    }),
-                Some(lsp::CompletionItemKind::FILE) => "file".into(),
-                Some(lsp::CompletionItemKind::REFERENCE) => "reference".into(),
-                Some(lsp::CompletionItemKind::FOLDER) => "folder".into(),
-                Some(lsp::CompletionItemKind::ENUM_MEMBER) => "enum_member".into(),
-                Some(lsp::CompletionItemKind::CONSTANT) => "constant".into(),
-                Some(lsp::CompletionItemKind::STRUCT) => "struct".into(),
-                Some(lsp::CompletionItemKind::EVENT) => "event".into(),
-                Some(lsp::CompletionItemKind::OPERATOR) => "operator".into(),
-                Some(lsp::CompletionItemKind::TYPE_PARAMETER) => "type_param".into(),
+                Some(lsp::CompletionItemKind::TEXT) => {
+                    kind_text = "text";
+                    crate::i18n::tr("text").into()
+                }
+                Some(lsp::CompletionItemKind::METHOD) => {
+                    kind_text = "method";
+                    crate::i18n::tr("method").into()
+                }
+                Some(lsp::CompletionItemKind::FUNCTION) => {
+                    kind_text = "function";
+                    crate::i18n::tr("function").into()
+                }
+                Some(lsp::CompletionItemKind::CONSTRUCTOR) => {
+                    kind_text = "constructor";
+                    crate::i18n::tr("constructor").into()
+                }
+                Some(lsp::CompletionItemKind::FIELD) => {
+                    kind_text = "field";
+                    crate::i18n::tr("field").into()
+                }
+                Some(lsp::CompletionItemKind::VARIABLE) => {
+                    kind_text = "variable";
+                    crate::i18n::tr("variable").into()
+                }
+                Some(lsp::CompletionItemKind::CLASS) => {
+                    kind_text = "class";
+                    crate::i18n::tr("class").into()
+                }
+                Some(lsp::CompletionItemKind::INTERFACE) => {
+                    kind_text = "interface";
+                    crate::i18n::tr("interface").into()
+                }
+                Some(lsp::CompletionItemKind::MODULE) => {
+                    kind_text = "module";
+                    crate::i18n::tr("module").into()
+                }
+                Some(lsp::CompletionItemKind::PROPERTY) => {
+                    kind_text = "property";
+                    crate::i18n::tr("property").into()
+                }
+                Some(lsp::CompletionItemKind::UNIT) => {
+                    kind_text = "unit";
+                    crate::i18n::tr("unit").into()
+                }
+                Some(lsp::CompletionItemKind::VALUE) => {
+                    kind_text = "value";
+                    crate::i18n::tr("value").into()
+                }
+                Some(lsp::CompletionItemKind::ENUM) => {
+                    kind_text = "enum";
+                    crate::i18n::tr("enum").into()
+                }
+                Some(lsp::CompletionItemKind::KEYWORD) => {
+                    kind_text = "keyword";
+                    crate::i18n::tr("keyword").into()
+                }
+                Some(lsp::CompletionItemKind::SNIPPET) => {
+                    kind_text = "snippet";
+                    crate::i18n::tr("snippet").into()
+                }
+                Some(lsp::CompletionItemKind::COLOR) => {
+                    kind_text = "color";
+                    item.documentation
+                        .as_ref()
+                        .and_then(|docs| {
+                            let text = match docs {
+                                lsp::Documentation::String(text) => text,
+                                lsp::Documentation::MarkupContent(lsp::MarkupContent {
+                                    value,
+                                    ..
+                                }) => value,
+                            };
+                            text.get(text.len().checked_sub(7)?..)
+                        })
+                        .and_then(|c| Color::from_hex(c).ok())
+                        .map(|color| {
+                            Spans::from(vec![
+                                Span::raw(crate::i18n::tr("color ").into_owned()),
+                                Span::styled("■", Style::default().fg(color)),
+                            ])
+                        })
+                        .unwrap_or_else(|| Span::raw(crate::i18n::tr("color").into_owned()).into())
+                }
+                Some(lsp::CompletionItemKind::FILE) => {
+                    kind_text = "file";
+                    crate::i18n::tr("file").into()
+                }
+                Some(lsp::CompletionItemKind::REFERENCE) => {
+                    kind_text = "reference";
+                    crate::i18n::tr("reference").into()
+                }
+                Some(lsp::CompletionItemKind::FOLDER) => {
+                    kind_text = "folder";
+                    crate::i18n::tr("folder").into()
+                }
+                Some(lsp::CompletionItemKind::ENUM_MEMBER) => {
+                    kind_text = "enum_member";
+                    crate::i18n::tr("enum member").into()
+                }
+                Some(lsp::CompletionItemKind::CONSTANT) => {
+                    kind_text = "constant";
+                    crate::i18n::tr("constant").into()
+                }
+                Some(lsp::CompletionItemKind::STRUCT) => {
+                    kind_text = "struct";
+                    crate::i18n::tr("struct").into()
+                }
+                Some(lsp::CompletionItemKind::EVENT) => {
+                    kind_text = "event";
+                    crate::i18n::tr("event").into()
+                }
+                Some(lsp::CompletionItemKind::OPERATOR) => {
+                    kind_text = "operator";
+                    crate::i18n::tr("operator").into()
+                }
+                Some(lsp::CompletionItemKind::TYPE_PARAMETER) => {
+                    kind_text = "type parameter";
+                    crate::i18n::tr("type parameter").into()
+                }
                 Some(kind) => {
                     log::error!("Received unknown completion item kind: {:?}", kind);
-                    "".into()
+                    kind_text = "";
+                    Spans::default()
                 }
-                None => "".into(),
+                None => {
+                    kind_text = "";
+                    Spans::default()
+                }
             },
-            CompletionItem::Other(core::CompletionItem { kind, .. }) => kind.as_ref().into(),
+            CompletionItem::Other(core::CompletionItem { kind, .. }) => {
+                kind_text = kind.as_ref();
+                Spans::from(kind.clone().into_owned())
+            }
         };
 
         let label = Span::styled(
             label,
             if deprecated {
                 Style::default().add_modifier(Modifier::CROSSED_OUT)
-            } else if kind.0[0].content == "folder" {
+            } else if kind_text == "folder" {
                 *dir_style
             } else {
                 Style::default()

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -651,7 +651,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                             )
                             .or(Err(std::io::Error::new(
                                 std::io::ErrorKind::NotFound,
-                                "Cannot open document",
+                                crate::i18n::tr("Cannot open document"),
                             )))?;
                             let loader = editor.syn_loader.load();
                             if let Some(language_config) = doc.detect_language_config(&loader) {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -336,9 +336,15 @@ where
     write(
         context,
         if count == 1 {
-            " 1 sel ".into()
+            crate::i18n::tr(" 1 sel ").into_owned().into()
         } else {
-            format!(" {}/{count} sels ", selection.primary_index() + 1).into()
+            format!(
+                " {}/{}{}",
+                selection.primary_index() + 1,
+                count,
+                crate::i18n::tr(" sels ")
+            )
+            .into()
         },
     );
 }
@@ -350,7 +356,11 @@ where
     let tot_sel = context.doc.selection(context.view.id).primary().len();
     write(
         context,
-        format!(" {} char{} ", tot_sel, if tot_sel == 1 { "" } else { "s" }).into(),
+        if tot_sel == 1 {
+            format!(" {}{}", tot_sel, crate::i18n::tr(" char")).into()
+        } else {
+            format!(" {}{}", tot_sel, crate::i18n::tr(" chars")).into()
+        },
     );
 }
 
@@ -479,9 +489,9 @@ where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {
     let title = if context.doc.is_modified() {
-        "[+]"
+        crate::i18n::tr("[+]")
     } else {
-        "   "
+        "   ".into()
     };
 
     write(context, title.into());
@@ -492,9 +502,9 @@ where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {
     let title = if context.doc.readonly {
-        " [readonly] "
+        crate::i18n::tr(" [readonly] ")
     } else {
-        ""
+        "".into()
     };
     write(context, title.into());
 }
@@ -563,9 +573,13 @@ where
     write(
         context,
         match style {
-            IndentStyle::Tabs => " tabs ".into(),
+            IndentStyle::Tabs => crate::i18n::tr(" tabs ").into(),
             IndentStyle::Spaces(indent) => {
-                format!(" {} space{} ", indent, if indent == 1 { "" } else { "s" }).into()
+                if indent == 1 {
+                    format!(" {}{}", indent, crate::i18n::tr(" space")).into()
+                } else {
+                    format!(" {}{}", indent, crate::i18n::tr(" spaces")).into()
+                }
             }
         },
     );

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -434,6 +434,8 @@ pub struct Config {
     pub buffer_picker: BufferPickerConfig,
     /// Whether to implicitly trust every workspace or not
     pub insecure: bool,
+    /// UI language. Defaults to "en". Available: "en", "zh-CN".
+    pub ui_language: Option<String>,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -1157,6 +1159,7 @@ impl Default for Config {
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
             insecure: false,
+            ui_language: None,
         }
     }
 }


### PR DESCRIPTION
Add internationalization support using rust-i18n. Users can now switch the UI language via the editor.ui-language config option.

- Add rust-i18n dependency and i18n infrastructure
- Add ui-language config option to helix-view
- Translate ~920 strings including:
  - All static command documentation (~200 commands)
  - All typable command documentation (~100 commands)
  - Status and error messages across commands.rs, typed.rs, lsp.rs, dap.rs, syntax.rs, application.rs
  - Keymap mode labels and submenu names
  - Completion item kind labels
  - Statusline elements (selections, characters, readonly, indent)
  - Health check output
  - Workspace trust dialog
- Provide zh-CN (Simplified Chinese) and zh-TW (Traditional Chinese) translations