### PR TITLE
fix & refactor: workspace-trust

### DIFF
--- a/helix-loader/src/config.rs
+++ b/helix-loader/src/config.rs
@@ -14,7 +14,7 @@ pub fn user_lang_config(insecure: bool) -> Result<toml::Value, toml::de::Error> 
     let global_config = crate::lang_config_file();
     let workspace_config = crate::workspace_lang_config_file();
 
-    let files = if let TrustStatus::Trusted = quick_query_workspace(insecure) {
+    let files = if TrustStatus::Trusted == quick_query_workspace(insecure) {
         vec![global_config, workspace_config]
     } else {
         vec![global_config]

--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -1,3 +1,4 @@
+use helix_stdx::faccess::write_with_perms;
 use std::{
     collections::HashSet,
     fs,
@@ -72,7 +73,8 @@ impl WorkspaceTrust {
                 log::error!("Couldn't create helix's data directory: {:?}", e);
             };
         }
-        if let Err(e) = fs::write(workspace_trust_file(), trust_text) {
+        // TO-DO: apply mask for group and others, while setting owner
+        if let Err(e) = write_with_perms(workspace_trust_file(), trust_text, 0o0640) {
             log::error!("Error during write of workspace_trust file: {:?}", e);
         }
     }
@@ -92,7 +94,8 @@ impl WorkspaceTrust {
                     log::error!("Couldn't create helix's data directory: {:?}", e);
                 };
             }
-            if let Err(e) = fs::write(workspace_exclude_file(), trust_text) {
+            // TO-DO: apply mask for group and others, while setting owner
+            if let Err(e) = write_with_perms(workspace_exclude_file(), trust_text, 0o0640) {
                 log::error!("Error during write of workspace_trust file: {:?}", e);
             }
         } else {

--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -11,7 +11,7 @@ pub struct WorkspaceTrust {
     excluded: Option<HashSet<PathBuf>>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrustStatus {
     Untrusted,
     Trusted,
@@ -26,33 +26,29 @@ impl WorkspaceTrust {
     /// For querying trust status of a workspace use `quick_query_workspace()` or
     /// `quick_query_workspace_with_explicit_untrust()`
     pub fn load(with_exclusion: bool) -> Self {
-        let mut trusted = HashSet::new();
-
-        match fs::read_to_string(workspace_trust_file()) {
-            Ok(workspace_trust_file) => {
-                for line in workspace_trust_file.split('\n') {
-                    if !line.is_empty() {
-                        let path = PathBuf::from(line);
-                        trusted.insert(path);
-                    }
-                }
+        let trusted: HashSet<_> = match fs::read_to_string(workspace_trust_file()) {
+            Ok(workspace_trust_file) => workspace_trust_file
+                .split('\n')
+                .filter(|line| !line.is_empty())
+                .map(PathBuf::from)
+                .collect(),
+            Err(e) => {
+                log::error!("workspace file couldn't be read: {:?}", e);
+                HashSet::new()
             }
-            Err(e) => log::error!("workspace file couldn't be read: {:?}", e),
         };
 
         let excluded = if with_exclusion {
-            let mut untrusted = HashSet::new();
-
-            match fs::read_to_string(workspace_exclude_file()) {
-                Ok(workspace_untrust_file) => {
-                    for line in workspace_untrust_file.split('\n') {
-                        if !line.is_empty() {
-                            let path = PathBuf::from(line);
-                            untrusted.insert(path);
-                        }
-                    }
+            let untrusted: HashSet<_> = match fs::read_to_string(workspace_exclude_file()) {
+                Ok(workspace_untrust_file) => workspace_untrust_file
+                    .split('\n')
+                    .filter(|line| !line.is_empty())
+                    .map(PathBuf::from)
+                    .collect(),
+                Err(e) => {
+                    log::error!("workspace file couldn't be read: {:?}", e);
+                    HashSet::new()
                 }
-                Err(e) => log::error!("workspace file couldn't be read: {:?}", e),
             };
 
             Some(untrusted)
@@ -66,7 +62,8 @@ impl WorkspaceTrust {
         let mut trust_text = String::new();
         for workspace in self.trusted.iter() {
             if let Some(path_str) = workspace.to_str() {
-                trust_text += &format!("{path_str}\n");
+                trust_text += path_str;
+                trust_text += "\n";
             }
         }
         // let chains aren't supported in current MSRV
@@ -85,7 +82,8 @@ impl WorkspaceTrust {
             let mut trust_text = String::new();
             for workspace in untrusted.iter() {
                 if let Some(path_str) = workspace.to_str() {
-                    trust_text += &format!("{path_str}\n");
+                    trust_text += path_str;
+                    trust_text += "\n";
                 }
             }
             // let chains aren't supported in current MSRV

--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -63,6 +63,10 @@ impl WorkspaceTrust {
         let mut trust_text = String::new();
         for workspace in self.trusted.iter() {
             if let Some(path_str) = workspace.to_str() {
+                if path_str.contains('\n') {
+                    log::error!("Unsupported path (contains \\n): {:?}", path_str);
+                    continue;
+                }
                 trust_text += path_str;
                 trust_text += "\n";
             }
@@ -84,6 +88,10 @@ impl WorkspaceTrust {
             let mut trust_text = String::new();
             for workspace in untrusted.iter() {
                 if let Some(path_str) = workspace.to_str() {
+                    if path_str.contains('\n') {
+                        log::error!("Unsupported path (contains \\n): {:?}", path_str);
+                        continue;
+                    }
                     trust_text += path_str;
                     trust_text += "\n";
                 }

--- a/helix-stdx/src/faccess.rs
+++ b/helix-stdx/src/faccess.rs
@@ -1,4 +1,4 @@
-//! Functions for managine file metadata.
+//! Functions for managing file metadata.
 //! From <https://github.com/Freaky/faccess>
 
 use std::io;
@@ -93,6 +93,15 @@ mod imp {
         std::fs::set_permissions(to, perms)?;
 
         Ok(())
+    }
+
+    pub fn write_with_perms(path: &Path, contents: &[u8], perms: u32) -> io::Result<()> {
+        use std::io::Write;
+        let mut f = std::fs::File::create(path)?;
+        let mut p = f.metadata()?.permissions();
+        p.set_mode(perms);
+        std::fs::set_permissions(path, p)?;
+        f.write_all(contents)
     }
 
     pub fn hardlink_count(p: &Path) -> std::io::Result<u64> {
@@ -503,6 +512,18 @@ pub fn readonly(p: &Path) -> bool {
 
 pub fn copy_metadata(from: &Path, to: &Path) -> io::Result<()> {
     imp::copy_metadata(from, to)
+}
+
+/// Same [`fs::write`][std::fs::write], but sets mode bits on Unix targets
+pub fn write_with_perms<P: AsRef<Path>, C: AsRef<[u8]>>(
+    path: P,
+    contents: C,
+    perms: u32,
+) -> io::Result<()> {
+    #[cfg(unix)]
+    return imp::write_with_perms(path.as_ref(), contents.as_ref(), perms);
+    #[cfg(not(unix))]
+    return std::fs::write(path.as_ref(), contents.as_ref());
 }
 
 pub fn hardlink_count(p: &Path) -> io::Result<u64> {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -57,7 +57,7 @@ impl Display for ConfigLoadError {
 
 impl Config {
     pub fn load(
-        global: Result<&String, ConfigLoadError>,
+        global: Result<&str, ConfigLoadError>,
         local: Result<String, ConfigLoadError>,
     ) -> Result<Config, ConfigLoadError> {
         let global_config: Result<ConfigRaw, ConfigLoadError> =
@@ -125,8 +125,8 @@ impl Config {
 
         let phony_config = ConfigLoadError::Error(IOError::other("hacky placeholder"));
         let global_parsed = Config::load(Ok(&global_config), Err(phony_config))?;
-        if let helix_loader::workspace_trust::TrustStatus::Trusted =
-            helix_loader::workspace_trust::quick_query_workspace(global_parsed.editor.insecure)
+        if helix_loader::workspace_trust::TrustStatus::Trusted
+            == helix_loader::workspace_trust::quick_query_workspace(global_parsed.editor.insecure)
         {
             Config::load(Ok(&global_config), local_config)
         } else {
@@ -141,7 +141,7 @@ mod tests {
 
     impl Config {
         fn load_test(config: &str) -> Config {
-            Config::load(Ok(&config.to_owned()), Err(ConfigLoadError::default())).unwrap()
+            Config::load(Ok(config), Err(ConfigLoadError::default())).unwrap()
         }
     }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1742,8 +1742,8 @@ impl Editor {
         let config = doc.config.load();
         let root_dirs = &config.workspace_lsp_roots;
 
-        if let TrustStatus::Untrusted =
-            helix_loader::workspace_trust::quick_query_workspace(self.config.load().insecure)
+        if TrustStatus::Untrusted
+            == helix_loader::workspace_trust::quick_query_workspace(self.config.load().insecure)
         {
             self.set_status(
                 "Current workspace is not trusted. Run `:workspace-trust` to enable all features.",


### PR DESCRIPTION
- follow-up of #15177
- performance optimizations, mostly addressed by #15590
- bug-fix: don't append paths that contain `\n`. Those could be escaped, but it'd be overly complicated for such a [non-portable edge-case](https://dwheeler.com/essays/fixing-unix-linux-filenames.html), so just reject those paths as "invalid"
- stricter file permissions (similar to `gpg`)
- minor refactor