### PR TITLE
fix(lua): highlight table constructors in line with objects in other languages

### DIFF
--- a/runtime/queries/lua/highlights.scm
+++ b/runtime/queries/lua/highlights.scm
@@ -145,12 +145,6 @@
 
 (dot_index_expression field: (identifier) @variable.other.member)
 
-(table_constructor
-[
-  "{"
-  "}"
-] @constructor)
-
 ;; Functions
 
 (parameters (identifier) @variable.parameter)


### PR DESCRIPTION
In other languages (e.g. python, JS, etc.) object/table/dictionary constructors are highlighted with `@punctuation.bracket`. In Lua, however, the table brackets are highlighted as `@constructor`, which seems to be meant for constructor functions. This commit removes the explicit highlighting for table brackets, letting them fall back on the `@punctuation.bracket` highlight rule above. 