### PR TITLE
Workspace trust prompt improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,6 +1461,7 @@ dependencies = [
  "helix-stdx",
  "log",
  "once_cell",
+ "parking_lot",
  "serde",
  "tempfile",
  "threadpool",

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -68,6 +68,7 @@
 | `editor-config` | Whether to read settings from [EditorConfig](https://editorconfig.org) files | `true` |
 | `rainbow-brackets` | Whether to render rainbow colors for matching brackets. Requires tree-sitter `rainbows.scm` queries for the language. | `false` |
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
+| `workspace-trust-level` | `none` implies no trust, `lsp` allows starting language servers, `all` additionally allows loading local configuration files. | `"none"` |
 
 [^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
 

--- a/book/src/workspace-trust.md
+++ b/book/src/workspace-trust.md
@@ -15,9 +15,10 @@ Lists of trusted and excluded workspaces, delimited by newline characters, are s
 
 # Configuration
 
-You can return to the old behaviour of loading every local `.helix/config.toml` and `.helix/languages.toml` and starting LSP's without an explicit permission by setting following option:
+You can return to the old behaviour of starting language servers and optionally loading every local `.helix/config.toml` and `.helix/languages.toml` by setting the following option to one of these values:
 
 ```toml
 [editor]
-insecure = true
+workspace-trust-level = "lsp" # for starting language servers only
+workspace-trust-level = "all" # for all features
 ```

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -24,6 +24,8 @@ etcetera.workspace = true
 once_cell = "1.21"
 log = "0.4"
 
+parking_lot.workspace = true
+
 # TODO: these two should be on !wasm32 only
 
 # cloning/compiling tree-sitter grammars

--- a/helix-loader/src/config.rs
+++ b/helix-loader/src/config.rs
@@ -14,11 +14,14 @@ pub fn user_lang_config(insecure: bool) -> Result<toml::Value, toml::de::Error> 
     let global_config = crate::lang_config_file();
     let workspace_config = crate::workspace_lang_config_file();
 
-    let files = if quick_query_workspace(insecure) == TrustStatus::Trusted {
-        vec![global_config, workspace_config]
-    } else {
-        vec![global_config]
-    };
+    let workspace_config_exists = std::fs::exists(&workspace_config).unwrap_or(false);
+
+    let files =
+        if workspace_config_exists && quick_query_workspace(insecure) == TrustStatus::Trusted {
+            vec![global_config, workspace_config]
+        } else {
+            vec![global_config]
+        };
 
     let config = files
         .iter()

--- a/helix-loader/src/config.rs
+++ b/helix-loader/src/config.rs
@@ -14,7 +14,7 @@ pub fn user_lang_config(insecure: bool) -> Result<toml::Value, toml::de::Error> 
     let global_config = crate::lang_config_file();
     let workspace_config = crate::workspace_lang_config_file();
 
-    let files = if let TrustStatus::Trusted = quick_query_workspace(insecure) {
+    let files = if quick_query_workspace(insecure) == TrustStatus::Trusted {
         vec![global_config, workspace_config]
     } else {
         vec![global_config]

--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -7,7 +7,7 @@ pub struct WorkspaceTrust {
     excluded: Option<HashSet<PathBuf>>,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Eq, PartialEq)]
 pub enum TrustStatus {
     Untrusted,
     Trusted,
@@ -127,7 +127,7 @@ impl WorkspaceTrust {
     }
 }
 
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TrustUntrustStatus {
     DenyAlways,
     #[default]

--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -1,5 +1,8 @@
 use std::{collections::HashSet, fs, path::PathBuf};
 
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+
 use crate::{data_dir, workspace_exclude_file, workspace_trust_file};
 
 pub struct WorkspaceTrust {
@@ -135,6 +138,15 @@ pub enum TrustUntrustStatus {
     AllowAlways,
 }
 
+/// A set of canonicalized workspace paths for which trust has been queried
+static TRUST_QUERIED_WORKSPACES: Lazy<Mutex<HashSet<PathBuf>>> =
+    Lazy::new(|| Mutex::new(HashSet::new()));
+
+pub fn workspace_needs_trust() -> bool {
+    let workspace = crate::find_workspace().0;
+    TRUST_QUERIED_WORKSPACES.lock().contains(&workspace)
+}
+
 pub fn quick_query_workspace(insecure: bool) -> TrustStatus {
     if insecure {
         return TrustStatus::Trusted;
@@ -152,6 +164,7 @@ pub fn quick_query_workspace(insecure: bool) -> TrustStatus {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => (),
         Err(err) => log::error!("workspace file couldn't be read: {err:?}"),
     };
+    TRUST_QUERIED_WORKSPACES.lock().insert(workspace);
     TrustStatus::Untrusted
 }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -10,7 +10,7 @@ use helix_stdx::path::get_relative_path;
 use helix_view::{
     align_view,
     document::{DocumentOpenError, DocumentSavedEventResult},
-    editor::{ConfigEvent, EditorEvent},
+    editor::{ConfigEvent, EditorEvent, WorkspaceTrustLevelConfig},
     graphics::Rect,
     theme,
     tree::Layout,
@@ -421,7 +421,9 @@ impl Application {
             // Update the syntax language loader before setting the theme. Setting the theme will
             // call `Loader::set_scopes` which must be done before the documents are re-parsed for
             // the sake of locals highlighting.
-            let lang_loader = helix_core::config::user_lang_loader(default_config.editor.insecure)?;
+            let lang_loader = helix_core::config::user_lang_loader(
+                default_config.editor.workspace_trust_level == WorkspaceTrustLevelConfig::All,
+            )?;
             self.editor.syn_loader.store(Arc::new(lang_loader));
             Self::load_configured_theme(
                 &mut self.editor,

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,6 +1,9 @@
 use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
-use helix_loader::merge_toml_values;
+use helix_loader::{
+    merge_toml_values,
+    workspace_trust::{quick_query_workspace, TrustStatus},
+};
 use helix_view::{document::Mode, editor::WorkspaceTrustLevelConfig, theme};
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -125,9 +128,11 @@ impl Config {
 
         let phony_config = ConfigLoadError::Error(IOError::other("hacky placeholder"));
         let global_parsed = Config::load(Ok(&global_config), Err(phony_config))?;
-        if helix_loader::workspace_trust::quick_query_workspace(
-            global_parsed.editor.workspace_trust_level == WorkspaceTrustLevelConfig::All,
-        ) == helix_loader::workspace_trust::TrustStatus::Trusted
+
+        if local_config.is_ok()
+            && quick_query_workspace(
+                global_parsed.editor.workspace_trust_level == WorkspaceTrustLevelConfig::All,
+            ) == TrustStatus::Trusted
         {
             Config::load(Ok(&global_config), local_config)
         } else {

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,7 +1,7 @@
 use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
 use helix_loader::merge_toml_values;
-use helix_view::{document::Mode, theme};
+use helix_view::{document::Mode, editor::WorkspaceTrustLevelConfig, theme};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -125,8 +125,9 @@ impl Config {
 
         let phony_config = ConfigLoadError::Error(IOError::other("hacky placeholder"));
         let global_parsed = Config::load(Ok(&global_config), Err(phony_config))?;
-        if let helix_loader::workspace_trust::TrustStatus::Trusted =
-            helix_loader::workspace_trust::quick_query_workspace(global_parsed.editor.insecure)
+        if helix_loader::workspace_trust::quick_query_workspace(
+            global_parsed.editor.workspace_trust_level == WorkspaceTrustLevelConfig::All,
+        ) == helix_loader::workspace_trust::TrustStatus::Trusted
         {
             Config::load(Ok(&global_config), local_config)
         } else {

--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -2,7 +2,8 @@ use std::{collections::HashSet, path::PathBuf};
 
 use helix_event::register_hook;
 use helix_loader::workspace_trust::{
-    quick_query_workspace_with_explicit_untrust, TrustUntrustStatus, WorkspaceTrust,
+    quick_query_workspace_with_explicit_untrust, workspace_needs_trust, TrustUntrustStatus,
+    WorkspaceTrust,
 };
 use helix_view::{
     editor::WorkspaceTrustLevelConfig, events::DocumentDidOpen, handlers::Handlers, DocumentId,
@@ -20,17 +21,13 @@ static PROMPTED_WORKSPACES: Lazy<Mutex<HashSet<PathBuf>>> =
 
 pub(super) fn register_hooks(_handlers: &Handlers) {
     register_hook!(move |event: &mut DocumentDidOpen<'_>| {
-        let doc = doc!(event.editor, &event.doc);
-
-        // If there is no servers to be loaded, then the workspace might not be trusted yet
-        if doc.language_servers().next().is_none() {
-            if quick_query_workspace_with_explicit_untrust(
-                event.editor.config().workspace_trust_level == WorkspaceTrustLevelConfig::All,
+        if workspace_needs_trust()
+            && quick_query_workspace_with_explicit_untrust(
+                event.editor.config.load().workspace_trust_level == WorkspaceTrustLevelConfig::All,
             ) == TrustUntrustStatus::DenyOnce
-            {
-                let (workspace, _) = helix_loader::find_workspace();
-                job::dispatch_blocking(|_editor, compositor| prompt(workspace, compositor));
-            }
+        {
+            let (workspace, _) = helix_loader::find_workspace();
+            job::dispatch_blocking(|_editor, compositor| prompt(workspace, compositor));
         }
         Ok(())
     });

--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -4,7 +4,9 @@ use helix_event::register_hook;
 use helix_loader::workspace_trust::{
     quick_query_workspace_with_explicit_untrust, TrustUntrustStatus, WorkspaceTrust,
 };
-use helix_view::{events::DocumentDidOpen, handlers::Handlers, DocumentId};
+use helix_view::{
+    editor::WorkspaceTrustLevelConfig, events::DocumentDidOpen, handlers::Handlers, DocumentId,
+};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
@@ -22,8 +24,9 @@ pub(super) fn register_hooks(_handlers: &Handlers) {
 
         // If there is no servers to be loaded, then the workspace might not be trusted yet
         if doc.language_servers().next().is_none() {
-            if let TrustUntrustStatus::DenyOnce =
-                quick_query_workspace_with_explicit_untrust(event.editor.config().insecure)
+            if quick_query_workspace_with_explicit_untrust(
+                event.editor.config().workspace_trust_level == WorkspaceTrustLevelConfig::All,
+            ) == TrustUntrustStatus::DenyOnce
             {
                 let (workspace, _) = helix_loader::find_workspace();
                 job::dispatch_blocking(|_editor, compositor| prompt(workspace, compositor));
@@ -46,7 +49,9 @@ pub fn prompt(path: PathBuf, compositor: &mut Compositor) {
 
 const TRUST_MESSAGE: &str = "Trust this workspace?
 
-Trusted workspaces may load local config files and auto-start language servers. Config and language servers can execute arbitrary code. Only trust workspaces which you know contain harmless config and code.";
+Trusted workspaces may load local config files and auto-start language servers. Config and language servers can execute arbitrary code. Only trust workspaces which you know contain harmless config and code.
+
+This prompt can be disabled by setting `editor.workspace-trust-level` to \"lsp\" to always allow starting language servers, or \"all\" to always allow all insecure features.";
 
 fn select() -> ui::Select<TrustUntrustStatus> {
     ui::Select::new(

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -3,6 +3,7 @@ use helix_loader::VERSION_AND_GIT_HASH;
 use helix_term::application::Application;
 use helix_term::args::Args;
 use helix_term::config::{Config, ConfigLoadError};
+use helix_view::editor::WorkspaceTrustLevelConfig;
 
 fn setup_logging(verbosity: u64) -> Result<()> {
     let mut base_config = fern::Dispatch::new();
@@ -140,15 +141,17 @@ FLAGS:
         }
     };
 
-    let lang_loader =
-        helix_core::config::user_lang_loader(config.editor.insecure).unwrap_or_else(|err| {
-            eprintln!("{}", err);
-            eprintln!("Press <ENTER> to continue with default language config");
-            use std::io::Read;
-            // This waits for an enter press.
-            let _ = std::io::stdin().read(&mut []);
-            helix_core::config::default_lang_loader()
-        });
+    let lang_loader = helix_core::config::user_lang_loader(
+        config.editor.workspace_trust_level == WorkspaceTrustLevelConfig::All,
+    )
+    .unwrap_or_else(|err| {
+        eprintln!("{}", err);
+        eprintln!("Press <ENTER> to continue with default language config");
+        use std::io::Read;
+        // This waits for an enter press.
+        let _ = std::io::stdin().read(&mut []);
+        helix_core::config::default_lang_loader()
+    });
 
     // TODO: use the thread local executor to spawn the application task separately from the work pool
     let mut app = Application::new(args, config, lang_loader).context("unable to start Helix")?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -432,8 +432,7 @@ pub struct Config {
     /// Whether to enable Kitty Keyboard Protocol
     pub kitty_keyboard_protocol: KittyKeyboardProtocolConfig,
     pub buffer_picker: BufferPickerConfig,
-    /// Whether to implicitly trust every workspace or not
-    pub insecure: bool,
+    pub workspace_trust_level: WorkspaceTrustLevelConfig,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -469,6 +468,15 @@ pub enum KittyKeyboardProtocolConfig {
     Auto,
     Disabled,
     Enabled,
+}
+
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum WorkspaceTrustLevelConfig {
+    #[default]
+    None,
+    Lsp,
+    All,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Eq, PartialOrd, Ord)]
@@ -1156,7 +1164,7 @@ impl Default for Config {
             rainbow_brackets: false,
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
-            insecure: false,
+            workspace_trust_level: WorkspaceTrustLevelConfig::None,
         }
     }
 }
@@ -1652,8 +1660,9 @@ impl Editor {
         let config = doc.config.load();
         let root_dirs = &config.workspace_lsp_roots;
 
-        if let TrustStatus::Untrusted =
-            helix_loader::workspace_trust::quick_query_workspace(self.config.load().insecure)
+        if helix_loader::workspace_trust::quick_query_workspace(
+            config.workspace_trust_level >= WorkspaceTrustLevelConfig::Lsp,
+        ) != TrustStatus::Trusted
         {
             self.set_status(
                 "Current workspace is not trusted. Run `:workspace-trust` to enable all features.",


### PR DESCRIPTION
Introduces some improvements to how workspace trust prompt is handled:
* Added `editor.insecure-lsp` config option, which allows LSPs to start, without loading local configs
* Disabled showing the trust prompt for when there's nothing we need trust for. This means that if you have `editor.insecure-lsp` enabled, you will only ever see the prompt when there are local configs
* Documented `editor.insecure` and `editor.insecure-lsp` in config reference and the trust prompt

These changes are unrelated to https://github.com/helix-editor/helix/pull/15582