### PR TITLE
add lua doc comments to comment-tokens list

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1594,7 +1594,7 @@ scope = "source.lua"
 file-types = ["lua", "rockspec"]
 shebangs = ["lua", "luajit"]
 roots = [".luarc.json", ".luacheckrc", ".stylua.toml", "selene.toml", ".git"]
-comment-token = "--"
+comment-tokens = ["--", "---"]
 block-comment-tokens = { start = "--[[", end = "--]]" }
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "lua-language-server" ]


### PR DESCRIPTION
`---` is the conventional documentation comment prefix for lua, used by EmmyLua and lua-language-server.