### PR TITLE
nix: drop tree-sitter grammars from devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,11 @@
           platformRustFlagsEnv = lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-Wl,--no-rosegment";
         in
           pkgs.mkShell {
-            inputsFrom = [self.checks.${system}.helix];
+            inputsFrom = [
+              (self.checks.${system}.helix.override {
+                includeGrammarIf = _: false;
+              })
+            ];
             nativeBuildInputs = with pkgs;
               [
                 lld


### PR DESCRIPTION
Previously running `nix develop` (or any other way of entering the devshell) could take a long time due to downloading all of the tree-sitter grammars despite them not being used in the shell.

This drops the grammars from the devshell by overriding the grammar filter function to exclude all of them. This way other inputs are still automatically derived from the main helix packages, but grammars are excluded only when building for the devshell.
The main package and checks still builds with grammars included.

closes https://github.com/helix-editor/helix/issues/15600