### PR TITLE
ui::Menu: ignore unhandled events instead of consuming them

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -311,7 +311,7 @@ impl<T: Item + 'static> Component for Menu<T> {
             // if we run out of options the menu closes itself
             _ if self.auto_close => {
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Abort);
-                return EventResult::Consumed(close_fn);
+                return EventResult::Ignored(close_fn);
             }
             _ => (),
         }


### PR DESCRIPTION
This helps with unobtrusiveness of `Select` a lot. Right now, `Select` just "eats" unhandled keys, and with this it will pass event to whatever layer is underneath `Select`.