### PR TITLE
feat(languages): add Lateralus language support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1387,6 +1387,30 @@ name = "twig"
 source = { git = "https://github.com/gbprod/tree-sitter-twig", rev = "085648e01d1422163a1702a44e72303b4e2a0bd1" }
 
 [[language]]
+name = "lateralus"
+scope = "source.lateralus"
+injection-regex = "ltl|lateralus"
+file-types = ["ltl"]
+roots = ["lateralus.toml"]
+comment-tokens = ["//"]
+block-comment-tokens = { start = "/*", end = "*/" }
+language-servers = ["lateralus-ls"]
+indent = { tab-width = 4, unit = "    " }
+auto-format = true
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+'`' = '`'
+
+[[grammar]]
+name = "lateralus"
+source = { git = "https://github.com/bad-antics/tree-sitter-lateralus", rev = "main" }
+
+
+[[language]]
 name = "latex"
 scope = "source.tex"
 injection-regex = "tex"
@@ -5453,3 +5477,6 @@ comment-token = "//"
 [[grammar]]
 name = "tql"
 source = { git = "https://github.com/tenzir/tree-sitter-tql", rev = "d3b3b2699bc09fd0c63e2c13f15f6e474665c62e" }
+
+# Lateralus language
+lateralus-ls = { command = "lateralus-lsp" }

--- a/languages.toml
+++ b/languages.toml
@@ -1427,6 +1427,19 @@ name = "bibtex"
 source = { git = "https://github.com/latex-lsp/tree-sitter-bibtex", rev = "ccfd77db0ed799b6c22c214fe9d2937f47bc8b34" }
 
 [[language]]
+name = "lateralus"
+scope = "source.lateralus"
+injection-regex = "lateralus|ltl"
+file-types = ["ltl"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "lateralus"
+source = { git = "https://github.com/bad-antics/tree-sitter-lateralus", rev = "bcb8e71caf7723bf2b8b0501521f2c19404cbeb3" }
+
+[[language]]
 name = "lean"
 scope = "source.lean"
 injection-regex = "lean"

--- a/runtime/queries/lateralus/folds.scm
+++ b/runtime/queries/lateralus/folds.scm
@@ -1,0 +1,6 @@
+; Folding regions
+(function_decl body: (block) @fold)
+(struct_decl) @fold
+(enum_decl) @fold
+(impl_block) @fold
+(match_expression) @fold

--- a/runtime/queries/lateralus/highlights.scm
+++ b/runtime/queries/lateralus/highlights.scm
@@ -1,0 +1,101 @@
+; ---------------------------------------------------------------------------
+; tree-sitter-lateralus highlights query
+; Used by: nvim-treesitter, Helix, Zed, Neovim, …
+; ---------------------------------------------------------------------------
+
+; Comments
+(line_comment) @comment
+(block_comment) @comment
+
+; Imports
+"import" @keyword.import
+"use"    @keyword.import
+
+(import_decl (path (identifier) @namespace))
+
+; Keywords — control flow
+"if"     @keyword.conditional
+"else"   @keyword.conditional
+"match"  @keyword.conditional
+"while"  @keyword.repeat
+"for"    @keyword.repeat
+"in"     @keyword.repeat
+"return" @keyword.return
+
+; Keywords — declarations
+"fn"     @keyword.function
+"struct" @keyword.type
+"enum"   @keyword.type
+"impl"   @keyword.type
+"type"   @keyword.type
+"const"  @keyword
+"let"    @keyword
+"mut"    @keyword.modifier
+
+; Visibility
+(visibility) @keyword.modifier
+
+; Primitive types
+(primitive_type) @type.builtin
+
+; Type names (CamelCase identifiers in type position)
+(struct_decl name: (identifier) @type)
+(enum_decl   name: (identifier) @type)
+(type_alias  name: (identifier) @type)
+(impl_block  target: (identifier) @type)
+
+; Functions
+(function_decl name: (identifier) @function)
+(call_expression (identifier) @function.call)
+
+; Fields
+(field_decl name: (identifier) @property)
+(field_access (identifier) @property)
+
+; Parameters
+(parameter name: (identifier) @variable.parameter)
+
+; Variables
+(let_decl   name: (identifier) @variable)
+(const_decl name: (identifier) @constant)
+
+; Literals
+(string_literal)  @string
+(number_literal)  @number
+(boolean_literal) @boolean
+(null_literal)    @constant.builtin
+
+; Operators
+"|>" @operator
+"->" @operator
+"=>" @operator
+"::" @operator
+"+"  @operator
+"-"  @operator
+"*"  @operator
+"/"  @operator
+"%"  @operator
+"==" @operator
+"!=" @operator
+"<"  @operator
+">"  @operator
+"<=" @operator
+">=" @operator
+"&&" @operator
+"||" @operator
+"="  @operator
+
+; Punctuation
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket
+"<" @punctuation.bracket
+">" @punctuation.bracket
+"," @punctuation.delimiter
+";" @punctuation.delimiter
+":" @punctuation.delimiter
+"." @punctuation.delimiter
+
+; Identifiers — generic fallback
+(identifier) @variable


### PR DESCRIPTION
## Add Lateralus Language Support

This PR adds full language support for [Lateralus](https://lateralus.dev), a modern expressive programming language.

### Configuration Added

```toml
[[language]]
name = "lateralus"
scope = "source.lateralus"
file-types = ["ltl"]
roots = ["lateralus.toml"]
language-servers = ["lateralus-ls"]
auto-format = true
```

### Language Server

- **Name**: lateralus-lsp
- **Installation**: `curl -fsSL https://lateralus.dev/install.sh | sh` or `cargo install lateralus-lsp`
- **Protocol**: LSP 3.17
- **Features**: Completion, hover, go-to-definition, references, rename, formatting, inlay hints

### Tree-sitter Grammar

- **Repository**: https://github.com/bad-antics/tree-sitter-lateralus
- **Highlights**: Full syntax highlighting with semantic tokens
- **Queries**: highlights.scm, locals.scm, indents.scm, textobjects.scm

### About Lateralus

Lateralus is a compiled language featuring:
- Type inference with optional explicit types
- Pipeline operators (`|>`) for functional composition
- Pattern matching with exhaustiveness checking
- First-class concurrency (async/await, channels)
- LLVM-based native compilation

### Links

- 📦 [Repository](https://github.com/bad-antics/lateralus-lang)
- 📚 [Documentation](https://lateralus.dev)
- 🔧 [VS Code Extension](https://marketplace.visualstudio.com/items?itemName=bad-antics.lateralus)
