### PR TITLE
fix selecting characters with the crlf mode

### DIFF
--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -1169,6 +1169,68 @@ mod test {
             ))
         );
     }
+    
+    #[test]
+    fn test_select_on_matches_crlf() {
+        let r = Rope::from_str("This\r\nString\r\n\r\ncontains multiple\r\nlines");
+        let s = r.slice(..);
+
+        let start_of_line = rope::RegexBuilder::new()
+            .syntax(rope::Config::new().multi_line(true).crlf(true))
+            .build(r"^")
+            .unwrap();
+        let end_of_line = rope::RegexBuilder::new()
+            .syntax(rope::Config::new().multi_line(true).crlf(true))
+            .build(r"$")
+            .unwrap();
+
+        // line without ending
+        assert_eq!(
+            select_on_matches(s, &Selection::single(0, 4), &start_of_line),
+            Some(Selection::single(0, 0))
+        );
+        assert_eq!(
+            select_on_matches(s, &Selection::single(0, 4), &end_of_line),
+            None
+        );
+        // line with ending
+        assert_eq!(
+            select_on_matches(s, &Selection::single(0, 5), &start_of_line),
+            Some(Selection::single(0, 0))
+        );
+        assert_eq!(
+            select_on_matches(s, &Selection::single(0, 5), &end_of_line),
+            Some(Selection::single(4, 4))
+        );
+        // line with start of next line
+        assert_eq!(
+            select_on_matches(s, &Selection::single(0, 7), &start_of_line),
+            Some(Selection::new(
+                smallvec![Range::point(0), Range::point(6)],
+                0
+            ))
+        );
+        assert_eq!(
+            select_on_matches(s, &Selection::single(0, 6), &end_of_line),
+            Some(Selection::single(4, 4))
+        );
+
+        // multiple lines
+        assert_eq!(
+            select_on_matches(
+                s,
+                &Selection::single(0, s.len_chars()),
+                &rope::RegexBuilder::new()
+                    .syntax(rope::Config::new().multi_line(true).crlf(true))
+                    .build(r"^[a-z ]*$")
+                    .unwrap()
+            ),
+            Some(Selection::new(
+                smallvec![Range::point(14), Range::new(16, 33), Range::new(35, 40)],
+                0
+            ))
+        );
+    }
 
     #[test]
     fn test_line_range() {

--- a/helix-core/src/selection.rs
+++ b/helix-core/src/selection.rs
@@ -1169,7 +1169,7 @@ mod test {
             ))
         );
     }
-    
+
     #[test]
     fn test_select_on_matches_crlf() {
         let r = Rope::from_str("This\r\nString\r\n\r\ncontains multiple\r\nlines");

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -2409,11 +2409,13 @@ fn search_next_or_prev_impl(cx: &mut Context, movement: Movement, direction: Dir
             false
         };
         let wrap_around = search_config.wrap_around;
+        let is_crlf = doc!(cx.editor).line_ending == LineEnding::Crlf;
         if let Ok(regex) = rope::RegexBuilder::new()
             .syntax(
                 rope::Config::new()
                     .case_insensitive(case_insensitive)
-                    .multi_line(true),
+                    .multi_line(true)
+                    .crlf(is_crlf),
             )
             .build(&query)
         {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -126,11 +126,16 @@ pub fn raw_regex_prompt(
                         false
                     };
 
+                    let is_crlf = {
+                        let (_, doc) = current!(cx.editor);
+                        doc.line_ending == helix_core::LineEnding::Crlf
+                    };
                     match rope::RegexBuilder::new()
                         .syntax(
                             rope::Config::new()
                                 .case_insensitive(case_insensitive)
-                                .multi_line(true),
+                                .multi_line(true)
+                                .crlf(is_crlf),
                         )
                         .build(input)
                     {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -126,10 +126,7 @@ pub fn raw_regex_prompt(
                         false
                     };
 
-                    let is_crlf = {
-                        let (_, doc) = current!(cx.editor);
-                        doc.line_ending == helix_core::LineEnding::Crlf
-                    };
+                    let is_crlf = doc!(cx.editor).line_ending == helix_core::LineEnding::Crlf;
                     match rope::RegexBuilder::new()
                         .syntax(
                             rope::Config::new()


### PR DESCRIPTION
This fixes [#13680](https://github.com/helix-editor/helix/issues/13680).
It supports the review feedback from @the-mikedavis regarding conditional CRLF detection in [#13692](https://github.com/helix-editor/helix/pull/13692).
