### PR TITLE
Add `insert-pipe` and `append-pipe` commands.

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -601,7 +601,9 @@ impl MappableCommand {
         shell_pipe, "Pipe selections through shell command",
         shell_pipe_to, "Pipe selections into shell command ignoring output",
         shell_insert_output, "Insert shell command output before selections",
+        shell_insert_pipe, "Insert pipe command output before selections",
         shell_append_output, "Append shell command output after selections",
+        shell_append_pipe, "Append pipe command output after selections",
         shell_keep_pipe, "Filter selections with shell predicate",
         suspend, "Suspend and return to shell",
         rename_symbol, "Rename symbol",
@@ -6435,7 +6437,9 @@ enum ShellBehavior {
     Replace,
     Ignore,
     Insert,
+    InsertPipe,
     Append,
+    AppendPipe,
 }
 
 fn shell_pipe(cx: &mut Context) {
@@ -6450,8 +6454,16 @@ fn shell_insert_output(cx: &mut Context) {
     shell_prompt_for_behavior(cx, "insert-output:".into(), ShellBehavior::Insert);
 }
 
+fn shell_insert_pipe(cx: &mut Context) {
+    shell_prompt_for_behavior(cx, "insert-pipe:".into(), ShellBehavior::InsertPipe);
+}
+
 fn shell_append_output(cx: &mut Context) {
     shell_prompt_for_behavior(cx, "append-output:".into(), ShellBehavior::Append);
+}
+
+fn shell_append_pipe(cx: &mut Context) {
+    shell_prompt_for_behavior(cx, "append-pipe:".into(), ShellBehavior::AppendPipe);
 }
 
 fn shell_keep_pipe(cx: &mut Context) {
@@ -6560,7 +6572,10 @@ async fn shell_impl_async(
 
 fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     let pipe = match behavior {
-        ShellBehavior::Replace | ShellBehavior::Ignore => true,
+        ShellBehavior::Replace
+        | ShellBehavior::Ignore
+        | ShellBehavior::InsertPipe
+        | ShellBehavior::AppendPipe => true,
         ShellBehavior::Insert | ShellBehavior::Append => false,
     };
 
@@ -6605,8 +6620,8 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
 
         let (from, to, deleted_len) = match behavior {
             ShellBehavior::Replace => (range.from(), range.to(), range.len()),
-            ShellBehavior::Insert => (range.from(), range.from(), 0),
-            ShellBehavior::Append => (range.to(), range.to(), 0),
+            ShellBehavior::Insert | ShellBehavior::InsertPipe => (range.from(), range.from(), 0),
+            ShellBehavior::Append | ShellBehavior::AppendPipe => (range.to(), range.to(), 0),
             _ => (range.from(), range.from(), 0),
         };
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -601,7 +601,9 @@ impl MappableCommand {
         shell_pipe, "Pipe selections through shell command",
         shell_pipe_to, "Pipe selections into shell command ignoring output",
         shell_insert_output, "Insert shell command output before selections",
+        shell_insert_pipe, "Insert pipe command output before selections",
         shell_append_output, "Append shell command output after selections",
+        shell_append_pipe, "Append pipe command output after selections",
         shell_keep_pipe, "Filter selections with shell predicate",
         suspend, "Suspend and return to shell",
         rename_symbol, "Rename symbol",
@@ -6529,7 +6531,9 @@ enum ShellBehavior {
     Replace,
     Ignore,
     Insert,
+    InsertPipe,
     Append,
+    AppendPipe,
 }
 
 fn shell_pipe(cx: &mut Context) {
@@ -6544,8 +6548,16 @@ fn shell_insert_output(cx: &mut Context) {
     shell_prompt_for_behavior(cx, "insert-output:".into(), ShellBehavior::Insert);
 }
 
+fn shell_insert_pipe(cx: &mut Context) {
+    shell_prompt_for_behavior(cx, "insert-pipe:".into(), ShellBehavior::InsertPipe);
+}
+
 fn shell_append_output(cx: &mut Context) {
     shell_prompt_for_behavior(cx, "append-output:".into(), ShellBehavior::Append);
+}
+
+fn shell_append_pipe(cx: &mut Context) {
+    shell_prompt_for_behavior(cx, "append-pipe:".into(), ShellBehavior::AppendPipe);
 }
 
 fn shell_keep_pipe(cx: &mut Context) {
@@ -6654,7 +6666,10 @@ async fn shell_impl_async(
 
 fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
     let pipe = match behavior {
-        ShellBehavior::Replace | ShellBehavior::Ignore => true,
+        ShellBehavior::Replace
+        | ShellBehavior::Ignore
+        | ShellBehavior::InsertPipe
+        | ShellBehavior::AppendPipe => true,
         ShellBehavior::Insert | ShellBehavior::Append => false,
     };
 
@@ -6699,8 +6714,8 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
 
         let (from, to, deleted_len) = match behavior {
             ShellBehavior::Replace => (range.from(), range.to(), range.len()),
-            ShellBehavior::Insert => (range.from(), range.from(), 0),
-            ShellBehavior::Append => (range.to(), range.to(), 0),
+            ShellBehavior::Insert | ShellBehavior::InsertPipe => (range.from(), range.from(), 0),
+            ShellBehavior::Append | ShellBehavior::AppendPipe => (range.to(), range.to(), 0),
             _ => (range.from(), range.from(), 0),
         };
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2524,6 +2524,14 @@ fn insert_output(
     Ok(())
 }
 
+fn append_pipe(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::AppendPipe)
+}
+
+fn insert_pipe(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::InsertPipe)
+}
+
 fn pipe_to(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Ignore)
 }
@@ -3854,6 +3862,22 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Pipe each selection to the shell command, ignoring output.",
         fun: pipe_to,
+        completer: SHELL_COMPLETER,
+        signature: SHELL_SIGNATURE,
+    },
+    TypableCommand  {
+        name: "insert-pipe",
+        aliases: &[],
+        doc: "Pipe each selection to the shell command, insert output before selection.",
+        fun: insert_pipe,
+        completer: SHELL_COMPLETER,
+        signature: SHELL_SIGNATURE,
+    },
+    TypableCommand  {
+        name: "append-pipe",
+        aliases: &[],
+        doc: "Pipe each selection to the shell command, append output after selection.",
+        fun: append_pipe,
         completer: SHELL_COMPLETER,
         signature: SHELL_SIGNATURE,
     },

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2627,6 +2627,14 @@ fn insert_output(
     Ok(())
 }
 
+fn append_pipe(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::AppendPipe)
+}
+
+fn insert_pipe(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    pipe_impl(cx, args, event, &ShellBehavior::InsertPipe)
+}
+
 fn pipe_to(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     pipe_impl(cx, args, event, &ShellBehavior::Ignore)
 }
@@ -3963,6 +3971,22 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         aliases: &[],
         doc: "Pipe each selection to the shell command, ignoring output.",
         fun: pipe_to,
+        completer: SHELL_COMPLETER,
+        signature: SHELL_SIGNATURE,
+    },
+    TypableCommand  {
+        name: "insert-pipe",
+        aliases: &[],
+        doc: "Pipe each selection to the shell command, insert output before selection.",
+        fun: insert_pipe,
+        completer: SHELL_COMPLETER,
+        signature: SHELL_SIGNATURE,
+    },
+    TypableCommand  {
+        name: "append-pipe",
+        aliases: &[],
+        doc: "Pipe each selection to the shell command, append output after selection.",
+        fun: append_pipe,
         completer: SHELL_COMPLETER,
         signature: SHELL_SIGNATURE,
     },

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -271,6 +271,38 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
     ))
     .await?;
 
+    // insert-pipe
+    test((
+        indoc! {"\
+            #[|lorem]#
+            #(|ipsum)#
+            #(|dolor)#
+            "},
+        ":insert-pipe cat<ret>",
+        indoc! {"\
+            #[|lorem]#lorem
+            #(|ipsum)#ipsum
+            #(|dolor)#dolor
+            "},
+    ))
+    .await?;
+
+    // append-pipe
+    test((
+        indoc! {"\
+            #[|lorem]#
+            #(|ipsum)#
+            #(|dolor)#
+            "},
+        ":append-pipe cat<ret>",
+        indoc! {"\
+            lorem#[|lorem]#
+            ipsum#(|ipsum)#
+            dolor#(|dolor)#
+            "},
+    ))
+    .await?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Both commands behave similary to `insert-output` and `append-output` commands, except that they also pipe the selections into the command.

This PR is inspired by the now closed PR #12590.