### PR TITLE
enhnace: highlight interpolations normally

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -529,7 +529,13 @@ impl<'h, 'r, 't> SyntaxHighlighter<'h, 'r, 't> {
         };
 
         self.style = highlights.fold(base, |acc, highlight| {
-            acc.patch(self.theme.highlight(highlight))
+            // @embedded capture (string interpolation) resets syntax boundary
+            // so that the style from the parent (string) is not inherited
+            if self.theme.scope(highlight) == "embedded" {
+                Style::default()
+            } else {
+                acc.patch(self.theme.highlight(highlight))
+            }
         });
         self.update_pos();
     }

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -102,7 +102,13 @@ pub fn highlighted_code_block<'a>(
             .iter()
             .chain(overlay_highlight_stack.iter())
             .fold(text_style, |acc, highlight| {
-                acc.patch(theme.highlight(*highlight))
+                // @embedded capture (string interpolation) resets syntax boundary
+                // so that the style from the parent (string) is not inherited
+                if theme.scope(*highlight) == "embedded" {
+                    Style::default()
+                } else {
+                    acc.patch(theme.highlight(*highlight))
+                }
             });
 
         let mut slice = &text[start as usize..pos as usize];

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -388,6 +388,16 @@ fn build_theme_values(
         highlights.push(style);
     }
 
+    // the @embedded capture is reserved for correctly highlighting
+    // interpolated strings and must be present in the highlights
+    if !styles.contains_key("embedded") {
+        let name = "embedded".to_string();
+        let style = Style::default();
+        styles.insert(name.clone(), style);
+        scopes.push(name);
+        highlights.push(style);
+    };
+
     (styles, scopes, highlights, rainbow_length, warnings)
 }
 

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -6,7 +6,7 @@
 ["(" ")" "[" "]" "{" "}"] @punctuation.bracket
 (interpolation
   "{" @punctuation.special
-  "}" @punctuation.special)
+  "}" @punctuation.special) @embedded
 
 ; -------
 ; Operators


### PR DESCRIPTION
### Description

Interpolations on strings (in ruby, f-strings in python, template literals in javascript) get the highlight from the string scope for non-keywords. This makes it less easy to tell apart interpolations from the rest of the string.

This PR implements "normal" highlighting for interpolations, instead of inheriting the string scope. This is done in other editors like [VSCode](https://code.visualstudio.com/) or [marimo](https://marimo.io/).

### Implementation

The highlights `@embedded` capture resets the highlight styling, stopping inheritance from the parent. Piggybacking on highlights might feel a bit hacky, but I thought introducing a new set of queries (like the one for injections) was overkill.

I also added `@embedded` to the python highlights.scm queries, mirroring the queries in other languages.

* Before this PR:

Notice that `x`, which is not a keyword, got the highlights from the string scope (green), but other highlights like methods and numbers were already normally highlighted.

<img width="540" height="350" alt="image" src="https://github.com/user-attachments/assets/d951bb28-2d12-4e86-bedf-fbb398be7652" />

* After this PR:

<img width="565" height="353" alt="image" src="https://github.com/user-attachments/assets/e66c472a-064a-4601-80b8-d0739b6030d7" />
