### PR TITLE
Highlight string interpolations in onedark

### DIFF
--- a/runtime/themes/onedark.toml
+++ b/runtime/themes/onedark.toml
@@ -23,10 +23,12 @@
 "special" = { fg = "blue" }
 "string" = { fg = "green" }
 "type" = { fg = "yellow" }
-# "variable" = { fg = "blue" }
+"variable" = { fg = "white" }
 "variable.builtin" = { fg = "blue" }
 "variable.parameter" = { fg = "red" }
 "variable.other.member" = { fg = "red" }
+"punctuation" = { fg = "white" }
+"punctuation.special" = { fg = "purple" }
 
 "markup.heading" = { fg = "red" }
 "markup.raw.inline" = { fg = "green" }


### PR DESCRIPTION
This PR implements changes in onedark.toml so that string interpolations are properly highlighted, like in other themes.

* Before this PR: non-keyword text and punctuations inherited the string scope in green

<img width="540" height="350" alt="image" src="https://github.com/user-attachments/assets/d951bb28-2d12-4e86-bedf-fbb398be7652" />

* After this PR: interpolations can be easily tell apart from the rest of the string

<img width="549" height="403" alt="image" src="https://github.com/user-attachments/assets/c57f738b-c39d-4d8a-a6b4-01615e7c1368" />


