### PR TITLE
feat(stdx): add stable version of some std hints

### DIFF
--- a/helix-core/src/graphemes.rs
+++ b/helix-core/src/graphemes.rs
@@ -1,6 +1,7 @@
 //! Utility functions to traverse the unicode graphemes of a `Rope`'s text contents.
 //!
 //! Based on <https://github.com/cessen/led/blob/c4fa72405f510b7fd16052f90a598c429b3104a6/src/graphemes.rs>
+use helix_stdx::hint::likely;
 use ropey::{str_utils::byte_to_char_idx, RopeSlice};
 use unicode_segmentation::{GraphemeCursor, GraphemeIncomplete};
 use unicode_width::UnicodeWidthStr;
@@ -93,9 +94,10 @@ impl Display for Grapheme<'_> {
     }
 }
 
+#[inline]
 #[must_use]
 pub fn grapheme_width(g: &str) -> usize {
-    if g.as_bytes()[0] <= 127 {
+    if likely(g.as_bytes()[0] <= 127) {
         // Fast-path ascii.
         // Point 1: theoretically, ascii control characters should have zero
         // width, but in our case we actually want them to have width: if they

--- a/helix-lsp/src/jsonrpc.rs
+++ b/helix-lsp/src/jsonrpc.rs
@@ -7,6 +7,7 @@
 //   (For examples https://github.com/helix-editor/helix/issues/2786, https://github.com/helix-editor/helix/issues/15078)
 // * some variable names have been lengthened for readability
 
+use helix_stdx::hint::cold_path;
 use serde::de::{self, DeserializeOwned, Visitor};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -203,8 +204,13 @@ impl Params {
         D: DeserializeOwned,
     {
         let value: Value = self.into();
-        serde_json::from_value(value)
-            .map_err(|err| Error::invalid_params(format!("Invalid params: {}.", err)))
+        match serde_json::from_value(value) {
+            Ok(params) => Ok(params),
+            Err(err) => {
+                cold_path();
+                Err(Error::invalid_params(format!("Invalid params: {}.", err)))
+            }
+        }
     }
 
     pub fn is_none(&self) -> bool {

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -16,7 +16,7 @@ use futures_util::stream::select_all::SelectAll;
 use helix_core::syntax::config::{
     LanguageConfiguration, LanguageServerConfiguration, LanguageServerFeatures, RootMarkers,
 };
-use helix_stdx::path;
+use helix_stdx::{hint::cold_path, path};
 use slotmap::SlotMap;
 use tokio::sync::mpsc::UnboundedReceiver;
 
@@ -540,26 +540,31 @@ impl Notification {
         use lsp::notification::Notification as _;
 
         let notification = match method {
-            lsp::notification::Initialized::METHOD => Self::Initialized,
-            lsp::notification::Exit::METHOD => Self::Exit,
             lsp::notification::PublishDiagnostics::METHOD => {
                 let params: lsp::PublishDiagnosticsParams = params.parse()?;
                 Self::PublishDiagnostics(params)
+            }
+
+            lsp::notification::Progress::METHOD => {
+                let params: lsp::ProgressParams = params.parse()?;
+                Self::ProgressMessage(params)
             }
 
             lsp::notification::ShowMessage::METHOD => {
                 let params: lsp::ShowMessageParams = params.parse()?;
                 Self::ShowMessage(params)
             }
+
             lsp::notification::LogMessage::METHOD => {
                 let params: lsp::LogMessageParams = params.parse()?;
                 Self::LogMessage(params)
             }
-            lsp::notification::Progress::METHOD => {
-                let params: lsp::ProgressParams = params.parse()?;
-                Self::ProgressMessage(params)
-            }
+
+            lsp::notification::Initialized::METHOD => Self::Initialized,
+            lsp::notification::Exit::METHOD => Self::Exit,
+
             _ => {
+                cold_path();
                 return Err(Error::Unhandled);
             }
         };

--- a/helix-stdx/src/hint.rs
+++ b/helix-stdx/src/hint.rs
@@ -1,0 +1,22 @@
+#[cold]
+pub const fn cold_path() {}
+
+#[inline(always)]
+pub const fn likely(b: bool) -> bool {
+    if b {
+        true
+    } else {
+        cold_path();
+        false
+    }
+}
+
+#[inline(always)]
+pub const fn unlikely(b: bool) -> bool {
+    if b {
+        cold_path();
+        true
+    } else {
+        false
+    }
+}

--- a/helix-stdx/src/hint.rs
+++ b/helix-stdx/src/hint.rs
@@ -1,0 +1,33 @@
+/// Hints to the compiler that current code path is cold.
+#[cold]
+pub const fn cold_path() {}
+
+/// Hints to the compiler that branch condition is likely to be true.
+///
+/// Returns the value passed to it.
+///
+/// Any use other than with `if` statements will probably not have an effect.
+#[inline(always)]
+pub const fn likely(b: bool) -> bool {
+    if b {
+        true
+    } else {
+        cold_path();
+        false
+    }
+}
+
+/// Hints to the compiler that branch condition is likely to be false.
+///
+/// Returns the value passed to it.
+///
+/// Any use other than with `if` statements will probably not have an effect.
+#[inline(always)]
+pub const fn unlikely(b: bool) -> bool {
+    if b {
+        cold_path();
+        true
+    } else {
+        false
+    }
+}

--- a/helix-stdx/src/lib.rs
+++ b/helix-stdx/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod env;
 pub mod faccess;
+pub mod hint;
 pub mod path;
 pub mod range;
 pub mod rope;

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -6,6 +6,7 @@ use helix_core::str_utils::char_to_byte_idx;
 use helix_core::syntax::{self, HighlightEvent, Highlighter, OverlayHighlights};
 use helix_core::text_annotations::TextAnnotations;
 use helix_core::{visual_offset_from_block, Position, RopeSlice};
+use helix_stdx::hint::{cold_path, likely};
 use helix_stdx::rope::RopeSliceExt;
 use helix_view::editor::{WhitespaceConfig, WhitespaceRenderValue};
 use helix_view::graphics::Rect;
@@ -502,19 +503,23 @@ impl<'h, 'r, 't> SyntaxHighlighter<'h, 'r, 't> {
     }
 
     fn update_pos(&mut self) {
-        self.pos = self
-            .inner
-            .as_ref()
-            .and_then(|highlighter| {
+        self.pos = match self.inner.as_ref() {
+            Some(highlighter) => {
                 let next_byte_idx = highlighter.next_event_offset();
-                (next_byte_idx != u32::MAX).then(|| {
+                if likely(next_byte_idx != u32::MAX) {
                     // Move the byte index to the nearest character boundary (rounding up) and
                     // convert it to a character index.
                     self.text
                         .byte_to_char(self.text.ceil_char_boundary(next_byte_idx as usize))
-                })
-            })
-            .unwrap_or(usize::MAX);
+                } else {
+                    usize::MAX
+                }
+            }
+            None => {
+                cold_path();
+                usize::MAX
+            }
+        };
     }
 
     fn advance(&mut self) {

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -1,6 +1,7 @@
 use helix_core::indent::IndentStyle;
 use helix_core::{coords_at_pos, encoding, unicode::width::UnicodeWidthStr, Position};
 use helix_lsp::lsp::DiagnosticSeverity;
+use helix_stdx::hint::cold_path;
 use helix_view::document::DEFAULT_LANGUAGE_NAME;
 use helix_view::{
     document::{Mode, SCRATCH_BUFFER_NAME},
@@ -265,33 +266,37 @@ where
     F: Fn(&mut RenderContext<'a>, Span<'a>) + Copy,
 {
     use helix_core::diagnostic::Severity;
-    let (hints, info, warnings, errors) = context.editor.diagnostics.values().flatten().fold(
-        (0u32, 0u32, 0u32, 0u32),
-        |mut counts, (diag, _)| {
-            match diag.severity {
-                // PERF: For large workspace diagnostics, this loop can be very tight.
-                //
-                // Most often the diagnostics will be for warnings and errors.
-                // Errors should tend to be fixed fast, leaving warnings as the most common.
-                Some(DiagnosticSeverity::WARNING) => counts.2 += 1,
-                Some(DiagnosticSeverity::ERROR) => counts.3 += 1,
-                Some(DiagnosticSeverity::HINT) => counts.0 += 1,
-                Some(DiagnosticSeverity::INFORMATION) => counts.1 += 1,
-                // Fallback to `hint`.
-                _ => counts.0 += 1,
+    let mut hints = 0;
+    let mut info = 0;
+    let mut warnings = 0;
+    let mut errors = 0;
+
+    for (diagnostic, _) in context.editor.diagnostics.values().flatten() {
+        match diagnostic.severity {
+            // PERF: For large workspace diagnostics, this loop can be very tight.
+            //
+            // Most often the diagnostics will be for warnings and errors.
+            // Errors should tend to be fixed fast, leaving warnings as the most common.
+            Some(DiagnosticSeverity::WARNING) => warnings += 1,
+            Some(DiagnosticSeverity::ERROR) => errors += 1,
+            Some(DiagnosticSeverity::HINT) => hints += 1,
+            Some(DiagnosticSeverity::INFORMATION) => info += 1,
+            // Fallback to `hint`.
+            _ => {
+                cold_path();
+                hints += 1;
             }
-            counts
-        },
-    );
+        }
+    }
 
     let sevs_to_show = &context.editor.config().statusline.workspace_diagnostics;
 
     // Avoid showing the " W " if no diagnostic counts will be shown.
     if !sevs_to_show.iter().any(|sev| match sev {
-        Severity::Hint => hints != 0,
-        Severity::Info => info != 0,
         Severity::Warning => warnings != 0,
         Severity::Error => errors != 0,
+        Severity::Hint => hints != 0,
+        Severity::Info => info != 0,
     }) {
         return;
     }
@@ -300,14 +305,6 @@ where
 
     for sev in sevs_to_show {
         match sev {
-            Severity::Hint if hints > 0 => {
-                write(context, Span::styled("●", context.editor.theme.get("hint")));
-                write(context, format!(" {} ", hints).into());
-            }
-            Severity::Info if info > 0 => {
-                write(context, Span::styled("●", context.editor.theme.get("info")));
-                write(context, format!(" {} ", info).into());
-            }
             Severity::Warning if warnings > 0 => {
                 write(
                     context,
@@ -321,6 +318,14 @@ where
                     Span::styled("●", context.editor.theme.get("error")),
                 );
                 write(context, format!(" {} ", errors).into());
+            }
+            Severity::Hint if hints > 0 => {
+                write(context, Span::styled("●", context.editor.theme.get("hint")));
+                write(context, format!(" {} ", hints).into());
+            }
+            Severity::Info if info > 0 => {
+                write(context, Span::styled("●", context.editor.theme.get("info")));
+                write(context, format!(" {} ", info).into());
             }
             _ => {}
         }


### PR DESCRIPTION
Add some useful hints that are currently unstable in the std.

Code was gotten from: https://doc.rust-lang.org/src/core/intrinsics/mod.rs.html#418

These can be useful for performance work. 

Worth noting that `cold_path` will be stabilized for `1.95`. When the time comes, we can just use the stabilized version in `likeley` and `unlikely`.