### PR TITLE
fix(lsp): expert language server requires `--stdio` flag

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -47,7 +47,7 @@ elm-language-server = { command = "elm-language-server" }
 elp = { command = "elp", args = ["server"] }
 elvish = { command = "elvish", args = ["-lsp"] }
 erlang-ls = { command = "erlang_ls" }
-expert = { command = "expert" }
+expert = { command = "expert", args = ["--stdio"] }
 fennel-ls = { command = "fennel-ls" }
 fish-lsp = { command = "fish-lsp", args = ["start"] }
 forc = { command = "forc", args = ["lsp"] }


### PR DESCRIPTION
Without `--stdio` flag Expert fails with this error:

```
FATAL: A transport argument (--stdio|--port <port>) must be provided, expert won't initialize.
```