### PR TITLE
First pass at a very dumb two file diff viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,7 @@ dependencies = [
  "helix-stdx",
  "helix-tui",
  "helix-vcs",
+ "imara-diff 0.2.0",
  "kstring",
  "libc",
  "log",

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -12,6 +12,7 @@
   - [Syntax aware motions](./syntax-aware-motions.md)
   - [Pickers](./pickers.md)
   - [Jumplist](./jumplist.md)
+  - [Diff mode](./diff-mode.md)
   - [Keymap](./keymap.md)
   - [Command line](./command-line.md)
   - [Commands](./commands.md)

--- a/book/src/diff-mode.md
+++ b/book/src/diff-mode.md
@@ -1,0 +1,56 @@
+# Diff mode
+
+Diff mode opens two files side-by-side with hunks aligned. Added lines get a green tint, deleted lines red, and modified lines amber. Characters that changed within a line get their own highlight.
+
+## Opening a diff
+
+From the command line:
+
+```sh
+hx --diff file1 file2
+hx -d file1 file2
+```
+
+From inside the editor, with two file paths:
+
+```text
+:diff-open file1 file2
+```
+
+To diff two buffers you already have open, run `:diff-this` in each view in turn. Running it in the second view links both into a diff session.
+
+## Navigating
+
+Use `]g` and `[g` to jump between changed hunks, the same bindings that navigate VCS diff hunks.
+
+## Transferring changes
+
+| Command              | Aliases              | What it does                                                                                                      |
+| -------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `:diff-put`          | `:diffput`, `:diffp` | Push the hunk under the cursor to the partner buffer.                                                             |
+| `:reset-diff-change` | `:diffget`, `:diffg` | In a diff session: pull the hunk from the partner buffer. Outside a diff session: reset the hunk to the VCS base. |
+
+## Ending a diff session
+
+`:diff-off` closes the diff session for the current view. Both buffers stay open as independent documents.
+
+## Theme keys
+
+These scopes apply in diff mode:
+
+| Scope             | Purpose                       |
+| ----------------- | ----------------------------- |
+| `diff.delta`      | Modified line background      |
+| `diff.delta.text` | Intra-line changed characters |
+| `diff.minus`      | Deleted line background       |
+| `diff.plus`       | Added line background         |
+
+These scopes apply to the VCS diff gutter (the bar to the left of line numbers showing uncommitted changes), not diff mode:
+
+| Scope                 | Purpose                          |
+| --------------------- | -------------------------------- |
+| `diff.delta.conflict` | Merge conflict marker in pickers |
+| `diff.delta.gutter`   | `▍` bar for modified lines       |
+| `diff.delta.moved`    | Renamed or moved file in pickers |
+| `diff.minus.gutter`   | `▔` mark for deleted lines       |
+| `diff.plus.gutter`    | `▍` bar for added lines          |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -87,7 +87,11 @@
 | `:pipe`, `:\|` | Pipe each selection to the shell command. |
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh`, `:!` | Run a shell command |
-| `:reset-diff-change`, `:diffget`, `:diffg` | Reset the diff change at the cursor position. |
+| `:diff-open`, `:diffs` | Open two files side-by-side in diff mode with aligned hunks. |
+| `:reset-diff-change`, `:diffget`, `:diffg` | In a diff session: pull changes from the partner buffer. Outside a diff session: reset the diff change at the cursor position to the VCS base. |
+| `:diff-put`, `:diffput`, `:diffp` | In a diff session: push changes from the current buffer to the partner buffer at the cursor position. |
+| `:diff-off`, `:diffoff` | End the diff session for the current view. Both views continue as independent buffers. |
+| `:diff-this`, `:diffthis` | Mark the current view as a diff participant. Run in two views to create a diff session between them. |
 | `:clear-register` | Clear given register. If no argument is provided, clear all registers. |
 | `:set-register` | Set contents of the given register. |
 | `:redraw` | Clear and re-render the whole UI |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -87,7 +87,7 @@
 | `:pipe`, `:\|` | Pipe each selection to the shell command. |
 | `:pipe-to` | Pipe each selection to the shell command, ignoring output. |
 | `:run-shell-command`, `:sh`, `:!` | Run a shell command |
-| `:diff-open`, `:diffs` | Open two files side-by-side in diff mode with aligned hunks. |
+| `:diff-open`, `:diffs` | Open two files side-by-side in diff mode with aligned hunks. Each path accepts a file:line or file:line:col suffix. |
 | `:reset-diff-change`, `:diffget`, `:diffg` | In a diff session: pull changes from the partner buffer. Outside a diff session: reset the diff change at the cursor position to the VCS base. |
 | `:diff-put`, `:diffput`, `:diffp` | In a diff session: push changes from the current buffer to the partner buffer at the cursor position. |
 | `:diff-off`, `:diffoff` | End the diff session for the current view. Both views continue as independent buffers. |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -1,4 +1,4 @@
-## Themes
+# Themes
 
 To use a theme add `theme = "<name>"` to the top of your [`config.toml`](./configuration.md) file, or select it during runtime using `:theme <name>`.
 
@@ -48,11 +48,7 @@ Color values must be either a [CSS hex RGB string](https://developer.mozilla.org
 
 > 💡 Note that Helix doesn't support transparency (alpha channel).
 
-For inspiration, you can find the default `theme.toml`
-[here](https://github.com/helix-editor/helix/blob/master/theme.toml) and
-user-submitted themes
-[here](https://github.com/helix-editor/helix/blob/master/runtime/themes).
-
+For inspiration, you can browse the [default theme.toml](https://github.com/helix-editor/helix/blob/master/theme.toml) and the [user-submitted themes](https://github.com/helix-editor/helix/blob/master/runtime/themes).
 
 ## The details of theme creation
 
@@ -79,7 +75,7 @@ are listed below. The `[palette]` section in the config file takes precedence
 over it and is merged into the default palette.
 
 | Color Name      |
-| ---             |
+| --------------- |
 | `default`       |
 | `black`         |
 | `red`           |
@@ -103,17 +99,17 @@ over it and is merged into the default palette.
 The following values may be used as modifier, provided they are supported by
 your terminal emulator.
 
-| Modifier             |
-| ---                  |
-| `bold`               |
-| `dim`                |
-| `italic`             |
-| `underlined`         |
-| `slow_blink`         |
-| `rapid_blink`        |
-| `reversed`           |
-| `hidden`             |
-| `crossed_out`        |
+| Modifier      |
+| ------------- |
+| `bold`        |
+| `dim`         |
+| `italic`      |
+| `underlined`  |
+| `slow_blink`  |
+| `rapid_blink` |
+| `reversed`    |
+| `hidden`      |
+| `crossed_out` |
 
 > 💡 The `underlined` modifier is deprecated and only available for backwards compatibility.
 > Its behavior is equivalent to setting `underline.style="line"`.
@@ -123,14 +119,13 @@ your terminal emulator.
 One of the following values may be used as a value for `underline.style`, providing it is
 supported by your terminal emulator.
 
-| Modifier       |
-| ---            |
-| `line`         |
-| `curl`         |
-| `dashed`       |
-| `dotted`       |
-| `double_line`  |
-
+| Modifier      |
+| ------------- |
+| `line`        |
+| `curl`        |
+| `dashed`      |
+| `dotted`      |
+| `double_line` |
 
 ### Inheritance
 
@@ -252,7 +247,7 @@ We use a similar set of scopes as
 - `namespace` - Modules and namespaces (e.g. `std::collections`, package names)
 
 - `special` - `derive` in Rust, bolded query-match in pickers (includes file explorer), etc.
-See also [#2380]
+  See also [#2380]
 
 - `markup`
   - `heading`
@@ -281,9 +276,10 @@ See also [#2380]
   - `minus` - deletions
     - `gutter` - gutter indicator
   - `delta` - modifications
-    - `moved` - renamed or moved files/changes
     - `conflict` - merge conflicts
     - `gutter` - gutter indicator
+    - `moved` - renamed or moved files/changes
+    - `text` - intra-line changed characters in diff mode
 
 - `embedded` - Interpolated expressions embedded in a string template (`${…}`)
 
@@ -303,9 +299,8 @@ These scopes are used for theming the editor interface:
       - `completion` - for completion doc popup UI
       - `hover` - for hover popup UI
 
-
 | Key                               | Notes                                                                                          |
-| ---                               | ---                                                                                            |
+| --------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `ui.background`                   |                                                                                                |
 | `ui.background.separator`         | Picker separator below input line                                                              |
 | `ui.cursor`                       |                                                                                                |

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -147,7 +147,6 @@ impl Application {
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None);
         } else if args.diff {
-            // `hx --diff file1 file2`: open two files side-by-side in diff mode.
             // Filter out directory paths so `hx . --diff a b` works as expected.
             let files: Vec<_> = args
                 .files

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -148,7 +148,12 @@ impl Application {
             doc_mut!(editor).set_path(None);
         } else if args.diff {
             // `hx --diff file1 file2`: open two files side-by-side in diff mode.
-            let files: Vec<_> = args.files.into_iter().collect();
+            // Filter out directory paths so `hx . --diff a b` works as expected.
+            let files: Vec<_> = args
+                .files
+                .into_iter()
+                .filter(|(p, _)| !p.is_dir())
+                .collect();
             if files.len() != 2 {
                 anyhow::bail!("--diff requires exactly two file paths");
             }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -146,6 +146,33 @@ impl Application {
             editor.open(&path, Action::VerticalSplit)?;
             // Unset path to prevent accidentally saving to the original tutor file.
             doc_mut!(editor).set_path(None);
+        } else if args.diff {
+            // `hx --diff file1 file2`: open two files side-by-side in diff mode.
+            let files: Vec<_> = args.files.into_iter().collect();
+            if files.len() != 2 {
+                anyhow::bail!("--diff requires exactly two file paths");
+            }
+            let (path_a, _) = &files[0];
+            let (path_b, _) = &files[1];
+
+            let doc_a = editor.open(path_a, Action::VerticalSplit)?;
+            let view_a = editor.tree.focus;
+            let doc_b = editor.open(path_b, Action::VerticalSplit)?;
+            let view_b = editor.tree.focus;
+
+            let rope_a = editor.documents[&doc_a].text().clone();
+            let rope_b = editor.documents[&doc_b].text().clone();
+
+            let mut session =
+                helix_view::diff_session::DiffSession::new(view_a, view_b, doc_a, doc_b);
+            session.compute_hunks(&rope_a, &rope_b);
+            editor.diff_sessions.push(session);
+
+            editor.set_status(format!(
+                "Diff: {} vs {}",
+                path_a.display(),
+                path_b.display()
+            ));
         } else if !args.files.is_empty() {
             let mut files_it = args.files.into_iter().peekable();
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1,6 +1,6 @@
 use arc_swap::{access::Map, ArcSwap};
 use futures_util::Stream;
-use helix_core::{diagnostic::Severity, pos_at_coords, syntax, Range, Selection};
+use helix_core::{diagnostic::Severity, pos_at_coords, syntax, Position, Range, Selection};
 use helix_lsp::{
     lsp::{self, notification::Notification},
     util::lsp_range_to_range,
@@ -81,6 +81,27 @@ pub struct Application {
     theme_mode: Option<theme::Mode>,
 }
 
+fn apply_diff_positions(
+    editor: &mut Editor,
+    view_id: helix_view::ViewId,
+    doc_id: helix_view::DocumentId,
+    positions: &[Position],
+) {
+    if positions.is_empty() {
+        return;
+    }
+    let doc = doc_mut!(editor, &doc_id);
+    let selection = positions
+        .iter()
+        .map(|coords| Range::point(pos_at_coords(doc.text().slice(..), *coords, true)))
+        .collect();
+    doc.set_selection(view_id, selection);
+    if editor.tree.focus == view_id {
+        let (view, doc) = current!(editor);
+        align_view(doc, view, Align::Center);
+    }
+}
+
 #[cfg(feature = "integration")]
 fn setup_integration_logging() {
     let level = std::env::var("HELIX_LOG_LEVEL")
@@ -156,13 +177,16 @@ impl Application {
             if files.len() != 2 {
                 anyhow::bail!("--diff requires exactly two file paths");
             }
-            let (path_a, _) = &files[0];
-            let (path_b, _) = &files[1];
+            let (path_a, pos_a) = &files[0];
+            let (path_b, pos_b) = &files[1];
 
             let doc_a = editor.open(path_a, Action::VerticalSplit)?;
             let view_a = editor.tree.focus;
+            apply_diff_positions(&mut editor, view_a, doc_a, pos_a);
+
             let doc_b = editor.open(path_b, Action::VerticalSplit)?;
             let view_b = editor.tree.focus;
+            apply_diff_positions(&mut editor, view_b, doc_b, pos_b);
 
             let rope_a = editor.documents[&doc_a].text().clone();
             let rope_b = editor.documents[&doc_b].text().clone();

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 pub struct Args {
     pub display_help: bool,
     pub display_version: bool,
+    pub diff: bool,
     pub health: bool,
     pub health_arg: Option<String>,
     pub load_tutor: bool,
@@ -49,6 +50,7 @@ impl Args {
                 "--version" => args.display_version = true,
                 "--help" => args.display_help = true,
                 "--strict" => args.strict = true,
+                "--diff" | "-d" => args.diff = true,
                 "--tutor" => args.load_tutor = true,
                 "--vsplit" => match args.split {
                     Some(_) => anyhow::bail!("can only set a split once of a specific type"),

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1985,6 +1985,10 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
         });
         drop(annotations);
         doc.set_selection(view.id, selection);
+
+        // Sync scroll to partner view if in a diff session
+        let focus = cx.editor.tree.focus;
+        cx.editor.sync_diff_scroll(focus);
         return;
     }
 
@@ -2036,6 +2040,10 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
     sel = sel.replace(idx, prim_sel);
     drop(annotations);
     doc.set_selection(view.id, sel);
+
+    // Sync scroll to partner view if in a diff session
+    let focus = cx.editor.tree.focus;
+    cx.editor.sync_diff_scroll(focus);
 }
 
 fn page_up(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4217,8 +4217,38 @@ fn goto_last_change(cx: &mut Context) {
 }
 
 fn goto_first_change_impl(cx: &mut Context, reverse: bool) {
+    let view_id = cx.editor.tree.focus;
+
+    // Check for a diff session first; use session hunks if present.
+    let session_info = cx.editor
+        .diff_sessions
+        .iter()
+        .find(|s| s.contains_view(view_id))
+        .map(|s| (s.hunks().to_vec(), s.view_a() == view_id));
+
     let editor = &mut cx.editor;
     let (view, doc) = current!(editor);
+
+    if let Some((hunks, is_side_a)) = session_info {
+        if hunks.is_empty() {
+            return;
+        }
+        let idx = if reverse { hunks.len() - 1 } else { 0 };
+        let hunk = &hunks[idx];
+        let line_range = if is_side_a { &hunk.before } else { &hunk.after };
+        let doc_text = doc.text().slice(..);
+        let anchor = doc_text.line_to_char(line_range.start as usize);
+        let head = if line_range.is_empty() {
+            anchor + 1
+        } else {
+            doc_text.line_to_char(line_range.end as usize)
+        };
+        push_jump(view, doc);
+        doc.set_selection(view.id, Selection::single(anchor, head));
+        return;
+    }
+
+    // VCS-based navigation.
     if let Some(handle) = doc.diff_handle() {
         let hunk = {
             let diff = handle.load();
@@ -4248,8 +4278,71 @@ fn goto_prev_change(cx: &mut Context) {
 fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
     let count = cx.count() as u32 - 1;
     let motion = move |editor: &mut Editor| {
+        let view_id = editor.tree.focus;
+
+        // Check for a diff session first; clone the data to free the borrow.
+        let session_info = editor
+            .diff_sessions
+            .iter()
+            .find(|s| s.contains_view(view_id))
+            .map(|s| (s.hunks().to_vec(), s.view_a() == view_id));
+
         let (view, doc) = current!(editor);
         let doc_text = doc.text().slice(..);
+
+        if let Some((hunks, is_side_a)) = session_info {
+            let count = count as usize;
+            let selection = doc.selection(view.id).clone().transform(|range| {
+                let cursor_line = range.cursor_line(doc_text) as u32;
+                let hunk_idx = match direction {
+                    Direction::Forward => {
+                        let base = hunks.iter().position(|h| {
+                            let r = if is_side_a { &h.before } else { &h.after };
+                            if r.is_empty() {
+                                r.start >= cursor_line
+                            } else {
+                                r.end > cursor_line
+                            }
+                        });
+                        base.map(|idx| (idx + count).min(hunks.len().saturating_sub(1)))
+                    }
+                    Direction::Backward => {
+                        let base = hunks.iter().rposition(|h| {
+                            let r = if is_side_a { &h.before } else { &h.after };
+                            r.start < cursor_line
+                        });
+                        base.map(|idx| idx.saturating_sub(count))
+                    }
+                };
+                let Some(hunk_idx) = hunk_idx else {
+                    return range;
+                };
+                let hunk = &hunks[hunk_idx];
+                let line_range = if is_side_a { &hunk.before } else { &hunk.after };
+                let anchor = doc_text.line_to_char(line_range.start as usize);
+                let head = if line_range.is_empty() {
+                    anchor + 1
+                } else {
+                    doc_text.line_to_char(line_range.end as usize)
+                };
+                let new_range = Range::new(anchor, head);
+                if editor.mode == Mode::Select {
+                    let head = if new_range.head < range.anchor {
+                        new_range.anchor
+                    } else {
+                        new_range.head
+                    };
+                    Range::new(range.anchor, head)
+                } else {
+                    new_range.with_direction(direction)
+                }
+            });
+            push_jump(view, doc);
+            doc.set_selection(view.id, selection);
+            return;
+        }
+
+        // VCS-based navigation.
         let diff_handle = if let Some(diff_handle) = doc.diff_handle() {
             diff_handle
         } else {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4217,7 +4217,8 @@ fn goto_last_change(cx: &mut Context) {
 fn goto_first_change_impl(cx: &mut Context, reverse: bool) {
     let view_id = cx.editor.tree.focus;
 
-    let session_info = cx.editor
+    let session_info = cx
+        .editor
         .diff_sessions
         .iter()
         .find(|s| s.contains_view(view_id))

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1986,7 +1986,6 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
         drop(annotations);
         doc.set_selection(view.id, selection);
 
-        // Sync scroll to partner view if in a diff session
         let focus = cx.editor.tree.focus;
         cx.editor.sync_diff_scroll(focus);
         return;
@@ -2041,7 +2040,6 @@ pub fn scroll(cx: &mut Context, offset: usize, direction: Direction, sync_cursor
     drop(annotations);
     doc.set_selection(view.id, sel);
 
-    // Sync scroll to partner view if in a diff session
     let focus = cx.editor.tree.focus;
     cx.editor.sync_diff_scroll(focus);
 }
@@ -4219,12 +4217,11 @@ fn goto_last_change(cx: &mut Context) {
 fn goto_first_change_impl(cx: &mut Context, reverse: bool) {
     let view_id = cx.editor.tree.focus;
 
-    // Check for a diff session first; use session hunks if present.
     let session_info = cx.editor
         .diff_sessions
         .iter()
         .find(|s| s.contains_view(view_id))
-        .map(|s| (s.hunks().to_vec(), s.view_a() == view_id));
+        .map(|s| (s.hunks_arc(), s.view_a() == view_id));
 
     let editor = &mut cx.editor;
     let (view, doc) = current!(editor);
@@ -4280,12 +4277,12 @@ fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
     let motion = move |editor: &mut Editor| {
         let view_id = editor.tree.focus;
 
-        // Check for a diff session first; clone the data to free the borrow.
+        // Clone the Arc to release the borrow on diff_sessions before touching documents.
         let session_info = editor
             .diff_sessions
             .iter()
             .find(|s| s.contains_view(view_id))
-            .map(|s| (s.hunks().to_vec(), s.view_a() == view_id));
+            .map(|s| (s.hunks_arc(), s.view_a() == view_id));
 
         let (view, doc) = current!(editor);
         let doc_text = doc.text().slice(..);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4290,26 +4290,21 @@ fn goto_next_change_impl(cx: &mut Context, direction: Direction) {
 
         if let Some((hunks, is_side_a)) = session_info {
             let count = count as usize;
+            let side = if is_side_a {
+                helix_view::diff_session::DiffSide::A
+            } else {
+                helix_view::diff_session::DiffSide::B
+            };
             let selection = doc.selection(view.id).clone().transform(|range| {
                 let cursor_line = range.cursor_line(doc_text) as u32;
                 let hunk_idx = match direction {
                     Direction::Forward => {
-                        let base = hunks.iter().position(|h| {
-                            let r = if is_side_a { &h.before } else { &h.after };
-                            if r.is_empty() {
-                                r.start >= cursor_line
-                            } else {
-                                r.end > cursor_line
-                            }
-                        });
-                        base.map(|idx| (idx + count).min(hunks.len().saturating_sub(1)))
+                        helix_view::diff_session::find_next_hunk(&hunks, side, cursor_line)
+                            .map(|idx| (idx + count).min(hunks.len().saturating_sub(1)))
                     }
                     Direction::Backward => {
-                        let base = hunks.iter().rposition(|h| {
-                            let r = if is_side_a { &h.before } else { &h.after };
-                            r.start < cursor_line
-                        });
-                        base.map(|idx| idx.saturating_sub(count))
+                        helix_view::diff_session::find_prev_hunk(&hunks, side, cursor_line)
+                            .map(|idx| idx.saturating_sub(count))
                     }
                 };
                 let Some(hunk_idx) = hunk_idx else {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2685,6 +2685,46 @@ fn run_shell_command(
     Ok(())
 }
 
+fn diff_open(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let args: Vec<_> = args.into_iter().collect();
+    if args.len() != 2 {
+        bail!("Expected exactly 2 file paths: :diff-open file1 file2");
+    }
+
+    let (path_a, _) = crate::args::parse_file(&args[0]);
+    let (path_b, _) = crate::args::parse_file(&args[1]);
+    let path_a = helix_stdx::path::expand_tilde(path_a);
+    let path_b = helix_stdx::path::expand_tilde(path_b);
+
+    // Open first file in the current view
+    let doc_a = cx.editor.open(&path_a, Action::Replace)?;
+    let view_a = cx.editor.tree.focus;
+
+    // Open second file in a vertical split
+    let doc_b = cx.editor.open(&path_b, Action::VerticalSplit)?;
+    let view_b = cx.editor.tree.focus;
+
+    // Compute hunks between the two documents
+    let rope_a = cx.editor.documents[&doc_a].text().clone();
+    let rope_b = cx.editor.documents[&doc_b].text().clone();
+
+    let mut session = helix_view::diff_session::DiffSession::new(view_a, view_b, doc_a, doc_b);
+    session.compute_hunks(&rope_a, &rope_b);
+
+    cx.editor.diff_sessions.push(session);
+    cx.editor.set_status(format!(
+        "Diff: {} vs {}",
+        path_a.display(),
+        path_b.display()
+    ));
+
+    Ok(())
+}
+
 fn reset_diff_change(
     cx: &mut compositor::Context,
     _args: Args,
@@ -3973,6 +4013,17 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         fun: run_shell_command,
         completer: SHELL_COMPLETER,
         signature: SHELL_SIGNATURE,
+    },
+    TypableCommand {
+        name: "diff-open",
+        aliases: &["diffs"],
+        doc: "Open two files side-by-side in diff mode with aligned hunks.",
+        fun: diff_open,
+        completer: CommandCompleter::positional(&[completers::filename, completers::filename]),
+        signature: Signature {
+            positionals: (2, Some(2)),
+            ..Signature::DEFAULT
+        },
     },
     TypableCommand {
         name: "reset-diff-change",

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2695,16 +2695,28 @@ fn diff_open(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> an
         bail!("Expected exactly 2 file paths: :diff-open file1 file2");
     }
 
-    let (path_a, _) = crate::args::parse_file(&args[0]);
-    let (path_b, _) = crate::args::parse_file(&args[1]);
+    let (path_a, pos_a) = crate::args::parse_file(&args[0]);
+    let (path_b, pos_b) = crate::args::parse_file(&args[1]);
     let path_a = helix_stdx::path::expand_tilde(path_a);
     let path_b = helix_stdx::path::expand_tilde(path_b);
 
     let doc_a = cx.editor.open(&path_a, Action::Replace)?;
     let view_a = cx.editor.tree.focus;
+    {
+        let (view, doc) = current!(cx.editor);
+        let sel = Selection::point(pos_at_coords(doc.text().slice(..), pos_a, true));
+        doc.set_selection(view.id, sel);
+        align_view(doc, view, Align::Center);
+    }
 
     let doc_b = cx.editor.open(&path_b, Action::VerticalSplit)?;
     let view_b = cx.editor.tree.focus;
+    {
+        let (view, doc) = current!(cx.editor);
+        let sel = Selection::point(pos_at_coords(doc.text().slice(..), pos_b, true));
+        doc.set_selection(view.id, sel);
+        align_view(doc, view, Align::Center);
+    }
 
     let rope_a = cx.editor.documents[&doc_a].text().clone();
     let rope_b = cx.editor.documents[&doc_b].text().clone();
@@ -4197,7 +4209,7 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "diff-open",
         aliases: &["diffs"],
-        doc: "Open two files side-by-side in diff mode with aligned hunks.",
+        doc: "Open two files side-by-side in diff mode with aligned hunks. Each path accepts a file:line or file:line:col suffix.",
         fun: diff_open,
         completer: CommandCompleter::positional(&[completers::filename, completers::filename]),
         signature: Signature {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2700,15 +2700,12 @@ fn diff_open(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> an
     let path_a = helix_stdx::path::expand_tilde(path_a);
     let path_b = helix_stdx::path::expand_tilde(path_b);
 
-    // Open first file in the current view
     let doc_a = cx.editor.open(&path_a, Action::Replace)?;
     let view_a = cx.editor.tree.focus;
 
-    // Open second file in a vertical split
     let doc_b = cx.editor.open(&path_b, Action::VerticalSplit)?;
     let view_b = cx.editor.tree.focus;
 
-    // Compute hunks between the two documents
     let rope_a = cx.editor.documents[&doc_a].text().clone();
     let rope_b = cx.editor.documents[&doc_b].text().clone();
 
@@ -2737,22 +2734,17 @@ fn reset_diff_change(
     let scrolloff = cx.editor.config().scrolloff;
     let view_id = cx.editor.tree.focus;
 
-    // When in a diff session, pull content from the partner document.
     let session_info = cx.editor
         .diff_sessions
         .iter()
         .find(|s| s.contains_view(view_id))
-        .map(|s| {
-            let side = if s.view_a() == view_id {
-                helix_view::diff_session::DiffSide::A
-            } else {
-                helix_view::diff_session::DiffSide::B
-            };
+        .and_then(|s| {
+            let side = s.side_for_view(view_id)?;
             let (doc_curr_id, doc_partner_id) = match side {
                 helix_view::diff_session::DiffSide::A => (s.doc_a(), s.doc_b()),
                 helix_view::diff_session::DiffSide::B => (s.doc_b(), s.doc_a()),
             };
-            (s.hunks().to_vec(), side, doc_curr_id, doc_partner_id)
+            Some((s.hunks_arc(), side, doc_curr_id, doc_partner_id))
         });
 
     if let Some((hunks, side, doc_curr_id, doc_partner_id)) = session_info {
@@ -2765,15 +2757,13 @@ fn reset_diff_change(
                 .collect()
         };
 
-        let session_ref = helix_view::diff_session::DiffSession::new_with_hunks(
-            view_id,
-            view_id,
-            doc_curr_id,
-            doc_partner_id,
-            hunks,
+        let (transaction, changes) = helix_view::diff_session::build_get_transaction(
+            &hunks,
+            side,
+            &line_ranges,
+            &curr_text,
+            &partner_text,
         );
-        let (transaction, changes) =
-            session_ref.build_get_transaction(side, &line_ranges, &curr_text, &partner_text);
 
         if changes == 0 {
             bail!("No diff hunks under selection");
@@ -2792,8 +2782,6 @@ fn reset_diff_change(
         ));
         return Ok(());
     }
-
-    // VCS fallback: reset current selection to the diff base.
     let editor = &mut cx.editor;
     let (view, doc) = current!(editor);
     let Some(handle) = doc.diff_handle() else {
@@ -2850,21 +2838,14 @@ fn diff_put(
         .diff_sessions
         .iter()
         .find(|s| s.contains_view(view_id))
-        .map(|s| {
-            let side = if s.view_a() == view_id {
-                helix_view::diff_session::DiffSide::A
-            } else {
-                helix_view::diff_session::DiffSide::B
-            };
+        .and_then(|s| {
+            let side = s.side_for_view(view_id)?;
             let (doc_curr_id, doc_partner_id) = match side {
                 helix_view::diff_session::DiffSide::A => (s.doc_a(), s.doc_b()),
                 helix_view::diff_session::DiffSide::B => (s.doc_b(), s.doc_a()),
             };
-            let partner_view_id = match side {
-                helix_view::diff_session::DiffSide::A => s.view_b(),
-                helix_view::diff_session::DiffSide::B => s.view_a(),
-            };
-            (s.hunks().to_vec(), side, doc_curr_id, doc_partner_id, partner_view_id)
+            let partner_view_id = s.partner_view(view_id)?;
+            Some((s.hunks_arc(), side, doc_curr_id, doc_partner_id, partner_view_id))
         });
 
     let Some((hunks, side, doc_curr_id, doc_partner_id, partner_view_id)) = session_info else {
@@ -2880,15 +2861,13 @@ fn diff_put(
             .collect()
     };
 
-    let session_ref = helix_view::diff_session::DiffSession::new_with_hunks(
-        view_id,
-        partner_view_id,
-        doc_curr_id,
-        doc_partner_id,
-        hunks,
+    let (transaction, changes) = helix_view::diff_session::build_put_transaction(
+        &hunks,
+        side,
+        &line_ranges,
+        &curr_text,
+        &partner_text,
     );
-    let (transaction, changes) =
-        session_ref.build_put_transaction(side, &line_ranges, &curr_text, &partner_text);
 
     if changes == 0 {
         bail!("No diff hunks under selection");
@@ -2943,24 +2922,20 @@ fn diff_this(
 
     let view_id = cx.editor.tree.focus;
 
-    // If current view is already in a session, report it.
     if cx.editor.diff_session_for(view_id).is_some() {
         bail!("This view is already part of a diff session. Use :diff-off first.");
     }
 
     match cx.editor.pending_diff_this {
         None => {
-            // First call: mark this view as the first participant.
             cx.editor.pending_diff_this = Some(view_id);
             cx.editor.set_status("Diff: marked first view. Run :diffthis in the second view.");
         }
         Some(other_view_id) if other_view_id == view_id => {
-            // Called on the same view twice: cancel.
             cx.editor.pending_diff_this = None;
             cx.editor.set_status("Diff: cancelled (same view selected twice).");
         }
         Some(other_view_id) => {
-            // Second call on a different view: create the session.
             cx.editor.pending_diff_this = None;
 
             let other_doc_id = cx.editor.tree.get(other_view_id).doc;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2734,7 +2734,8 @@ fn reset_diff_change(
     let scrolloff = cx.editor.config().scrolloff;
     let view_id = cx.editor.tree.focus;
 
-    let session_info = cx.editor
+    let session_info = cx
+        .editor
         .diff_sessions
         .iter()
         .find(|s| s.contains_view(view_id))
@@ -2823,18 +2824,15 @@ fn reset_diff_change(
     Ok(())
 }
 
-fn diff_put(
-    cx: &mut compositor::Context,
-    _args: Args,
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn diff_put(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
 
     let view_id = cx.editor.tree.focus;
 
-    let session_info = cx.editor
+    let session_info = cx
+        .editor
         .diff_sessions
         .iter()
         .find(|s| s.contains_view(view_id))
@@ -2845,7 +2843,13 @@ fn diff_put(
                 helix_view::diff_session::DiffSide::B => (s.doc_b(), s.doc_a()),
             };
             let partner_view_id = s.partner_view(view_id)?;
-            Some((s.hunks_arc(), side, doc_curr_id, doc_partner_id, partner_view_id))
+            Some((
+                s.hunks_arc(),
+                side,
+                doc_curr_id,
+                doc_partner_id,
+                partner_view_id,
+            ))
         });
 
     let Some((hunks, side, doc_curr_id, doc_partner_id, partner_view_id)) = session_info else {
@@ -2886,11 +2890,7 @@ fn diff_put(
     Ok(())
 }
 
-fn diff_off(
-    cx: &mut compositor::Context,
-    _args: Args,
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn diff_off(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -2911,11 +2911,7 @@ fn diff_off(
     Ok(())
 }
 
-fn diff_this(
-    cx: &mut compositor::Context,
-    _args: Args,
-    event: PromptEvent,
-) -> anyhow::Result<()> {
+fn diff_this(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
@@ -2929,11 +2925,13 @@ fn diff_this(
     match cx.editor.pending_diff_this {
         None => {
             cx.editor.pending_diff_this = Some(view_id);
-            cx.editor.set_status("Diff: marked first view. Run :diffthis in the second view.");
+            cx.editor
+                .set_status("Diff: marked first view. Run :diffthis in the second view.");
         }
         Some(other_view_id) if other_view_id == view_id => {
             cx.editor.pending_diff_this = None;
-            cx.editor.set_status("Diff: cancelled (same view selected twice).");
+            cx.editor
+                .set_status("Diff: cancelled (same view selected twice).");
         }
         Some(other_view_id) => {
             cx.editor.pending_diff_this = None;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2734,9 +2734,67 @@ fn reset_diff_change(
         return Ok(());
     }
 
-    let editor = &mut cx.editor;
-    let scrolloff = editor.config().scrolloff;
+    let scrolloff = cx.editor.config().scrolloff;
+    let view_id = cx.editor.tree.focus;
 
+    // When in a diff session, pull content from the partner document.
+    let session_info = cx.editor
+        .diff_sessions
+        .iter()
+        .find(|s| s.contains_view(view_id))
+        .map(|s| {
+            let side = if s.view_a() == view_id {
+                helix_view::diff_session::DiffSide::A
+            } else {
+                helix_view::diff_session::DiffSide::B
+            };
+            let (doc_curr_id, doc_partner_id) = match side {
+                helix_view::diff_session::DiffSide::A => (s.doc_a(), s.doc_b()),
+                helix_view::diff_session::DiffSide::B => (s.doc_b(), s.doc_a()),
+            };
+            (s.hunks().to_vec(), side, doc_curr_id, doc_partner_id)
+        });
+
+    if let Some((hunks, side, doc_curr_id, doc_partner_id)) = session_info {
+        let curr_text = cx.editor.documents[&doc_curr_id].text().clone();
+        let partner_text = cx.editor.documents[&doc_partner_id].text().clone();
+        let line_ranges: Vec<(usize, usize)> = {
+            let doc = &cx.editor.documents[&doc_curr_id];
+            doc.selection(view_id)
+                .line_ranges(curr_text.slice(..))
+                .collect()
+        };
+
+        let session_ref = helix_view::diff_session::DiffSession::new_with_hunks(
+            view_id,
+            view_id,
+            doc_curr_id,
+            doc_partner_id,
+            hunks,
+        );
+        let (transaction, changes) =
+            session_ref.build_get_transaction(side, &line_ranges, &curr_text, &partner_text);
+
+        if changes == 0 {
+            bail!("No diff hunks under selection");
+        }
+
+        {
+            let view = cx.editor.tree.get_mut(view_id);
+            let doc = cx.editor.documents.get_mut(&doc_curr_id).unwrap();
+            doc.apply(&transaction, view_id);
+            doc.append_changes_to_history(view);
+            view.ensure_cursor_in_view(doc, scrolloff);
+        }
+        cx.editor.set_status(format!(
+            "Got {changes} change{}",
+            if changes == 1 { "" } else { "s" }
+        ));
+        return Ok(());
+    }
+
+    // VCS fallback: reset current selection to the diff base.
+    let editor = &mut cx.editor;
     let (view, doc) = current!(editor);
     let Some(handle) = doc.diff_handle() else {
         bail!("Diff is not available in the current buffer")
@@ -2774,6 +2832,155 @@ fn reset_diff_change(
         "Reset {changes} change{}",
         if changes == 1 { "" } else { "s" }
     ));
+    Ok(())
+}
+
+fn diff_put(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let view_id = cx.editor.tree.focus;
+
+    let session_info = cx.editor
+        .diff_sessions
+        .iter()
+        .find(|s| s.contains_view(view_id))
+        .map(|s| {
+            let side = if s.view_a() == view_id {
+                helix_view::diff_session::DiffSide::A
+            } else {
+                helix_view::diff_session::DiffSide::B
+            };
+            let (doc_curr_id, doc_partner_id) = match side {
+                helix_view::diff_session::DiffSide::A => (s.doc_a(), s.doc_b()),
+                helix_view::diff_session::DiffSide::B => (s.doc_b(), s.doc_a()),
+            };
+            let partner_view_id = match side {
+                helix_view::diff_session::DiffSide::A => s.view_b(),
+                helix_view::diff_session::DiffSide::B => s.view_a(),
+            };
+            (s.hunks().to_vec(), side, doc_curr_id, doc_partner_id, partner_view_id)
+        });
+
+    let Some((hunks, side, doc_curr_id, doc_partner_id, partner_view_id)) = session_info else {
+        bail!("Not in a diff session");
+    };
+
+    let curr_text = cx.editor.documents[&doc_curr_id].text().clone();
+    let partner_text = cx.editor.documents[&doc_partner_id].text().clone();
+    let line_ranges: Vec<(usize, usize)> = {
+        let doc = &cx.editor.documents[&doc_curr_id];
+        doc.selection(view_id)
+            .line_ranges(curr_text.slice(..))
+            .collect()
+    };
+
+    let session_ref = helix_view::diff_session::DiffSession::new_with_hunks(
+        view_id,
+        partner_view_id,
+        doc_curr_id,
+        doc_partner_id,
+        hunks,
+    );
+    let (transaction, changes) =
+        session_ref.build_put_transaction(side, &line_ranges, &curr_text, &partner_text);
+
+    if changes == 0 {
+        bail!("No diff hunks under selection");
+    }
+
+    {
+        let view = cx.editor.tree.get_mut(partner_view_id);
+        let doc = cx.editor.documents.get_mut(&doc_partner_id).unwrap();
+        doc.apply(&transaction, partner_view_id);
+        doc.append_changes_to_history(view);
+    }
+    cx.editor.set_status(format!(
+        "Put {changes} change{}",
+        if changes == 1 { "" } else { "s" }
+    ));
+    Ok(())
+}
+
+fn diff_off(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let view_id = cx.editor.tree.focus;
+    let idx = cx
+        .editor
+        .diff_sessions
+        .iter()
+        .position(|s| s.contains_view(view_id));
+
+    let Some(idx) = idx else {
+        bail!("Not in a diff session");
+    };
+
+    cx.editor.diff_sessions.remove(idx);
+    cx.editor.set_status("Diff session ended");
+    Ok(())
+}
+
+fn diff_this(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> anyhow::Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let view_id = cx.editor.tree.focus;
+
+    // If current view is already in a session, report it.
+    if cx.editor.diff_session_for(view_id).is_some() {
+        bail!("This view is already part of a diff session. Use :diff-off first.");
+    }
+
+    match cx.editor.pending_diff_this {
+        None => {
+            // First call: mark this view as the first participant.
+            cx.editor.pending_diff_this = Some(view_id);
+            cx.editor.set_status("Diff: marked first view. Run :diffthis in the second view.");
+        }
+        Some(other_view_id) if other_view_id == view_id => {
+            // Called on the same view twice: cancel.
+            cx.editor.pending_diff_this = None;
+            cx.editor.set_status("Diff: cancelled (same view selected twice).");
+        }
+        Some(other_view_id) => {
+            // Second call on a different view: create the session.
+            cx.editor.pending_diff_this = None;
+
+            let other_doc_id = cx.editor.tree.get(other_view_id).doc;
+            let this_doc_id = cx.editor.tree.get(view_id).doc;
+
+            let rope_a = cx.editor.documents[&other_doc_id].text().clone();
+            let rope_b = cx.editor.documents[&this_doc_id].text().clone();
+
+            let mut session = helix_view::diff_session::DiffSession::new(
+                other_view_id,
+                view_id,
+                other_doc_id,
+                this_doc_id,
+            );
+            session.compute_hunks(&rope_a, &rope_b);
+            cx.editor.diff_sessions.push(session);
+            cx.editor.set_status("Diff session started.");
+        }
+    }
+
     Ok(())
 }
 
@@ -4028,8 +4235,41 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
     TypableCommand {
         name: "reset-diff-change",
         aliases: &["diffget", "diffg"],
-        doc: "Reset the diff change at the cursor position.",
+        doc: "In a diff session: pull changes from the partner buffer. Outside a diff session: reset the diff change at the cursor position to the VCS base.",
         fun: reset_diff_change,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "diff-put",
+        aliases: &["diffput", "diffp"],
+        doc: "In a diff session: push changes from the current buffer to the partner buffer at the cursor position.",
+        fun: diff_put,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "diff-off",
+        aliases: &["diffoff"],
+        doc: "End the diff session for the current view. Both views continue as independent buffers.",
+        fun: diff_off,
+        completer: CommandCompleter::none(),
+        signature: Signature {
+            positionals: (0, Some(0)),
+            ..Signature::DEFAULT
+        },
+    },
+    TypableCommand {
+        name: "diff-this",
+        aliases: &["diffthis"],
+        doc: "Mark the current view as a diff participant. Run in two views to create a diff session between them.",
+        fun: diff_this,
         completer: CommandCompleter::none(),
         signature: Signature {
             positionals: (0, Some(0)),

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -58,7 +58,8 @@ FLAGS:
     --log <file>                   Specify a file to use for logging
                                    (default file: {})
     -V, --version                  Print version information
-    --diff, -d                     Open two files side-by-side in diff mode
+    --diff, -d                     Open two files side-by-side in diff mode.
+                                   Each path accepts a file:line or file:line:col suffix.
     --vsplit                       Split all given files vertically into different windows
     --hsplit                       Split all given files horizontally into different windows
     -w, --working-dir <path>       Specify an initial working directory

--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -58,6 +58,7 @@ FLAGS:
     --log <file>                   Specify a file to use for logging
                                    (default file: {})
     -V, --version                  Print version information
+    --diff, -d                     Open two files side-by-side in diff mode
     --vsplit                       Split all given files vertically into different windows
     --hsplit                       Split all given files horizontally into different windows
     -w, --working-dir <path>       Specify an initial working directory

--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -27,6 +27,30 @@ pub struct LinePos {
     pub visual_line: u16,
 }
 
+impl LinePos {
+    /// Returns the "no previous line yet" sentinel used by the render loop
+    /// before any grapheme has been emitted. `doc_line` uses `usize::MAX`
+    /// because no real document can reach that size (allocations are bounded
+    /// by `isize::MAX`); `visual_line` mirrors that with `u16::MAX` so any
+    /// addition into it is detectable as overflow rather than landing at a
+    /// plausible row.
+    pub const fn sentinel() -> Self {
+        Self {
+            first_visual_line: false,
+            doc_line: usize::MAX,
+            visual_line: u16::MAX,
+        }
+    }
+
+    /// True when `self` is still the [`LinePos::sentinel`] value, meaning
+    /// no real visual line has been processed yet. Decorations that read
+    /// `visual_line` (`draw_indent_guides`, `render_virtual_lines`) must
+    /// not run for a sentinel, since `u16::MAX + anything` overflows.
+    pub const fn is_sentinel(&self) -> bool {
+        self.doc_line == usize::MAX
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn render_document(
     surface: &mut Surface,
@@ -81,11 +105,7 @@ pub fn render_text(
         SyntaxHighlighter::new(syntax_highlighter, text, theme, renderer.text_style);
     let mut overlay_highlighter = OverlayHighlighter::new(overlay_highlights, theme);
 
-    let mut last_line_pos = LinePos {
-        first_visual_line: false,
-        doc_line: usize::MAX,
-        visual_line: u16::MAX,
-    };
+    let mut last_line_pos = LinePos::sentinel();
     let mut last_line_end = 0;
     let mut is_in_indent_area = true;
     let mut last_line_indent_level = 0;
@@ -113,11 +133,7 @@ pub fn render_text(
 
         // apply decorations before rendering a new line
         if grapheme.visual_pos.row as u16 != last_line_pos.visual_line {
-            // we initiate doc_line with usize::MAX because no file
-            // can reach that size (memory allocations are limited to isize::MAX)
-            // initially there is no "previous" line (so doc_line is set to usize::MAX)
-            // in that case we don't need to draw indent guides/virtual text
-            if last_line_pos.doc_line != usize::MAX {
+            if !last_line_pos.is_sentinel() {
                 // draw indent guides for the last line
                 renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
                 is_in_indent_area = true;
@@ -168,8 +184,10 @@ pub fn render_text(
         last_line_end = grapheme.visual_pos.col + grapheme_width;
     }
 
-    renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
-    decorations.render_virtual_lines(renderer, last_line_pos, last_line_end)
+    if !last_line_pos.is_sentinel() {
+        renderer.draw_indent_guides(last_line_indent_level, last_line_pos.visual_line);
+        decorations.render_virtual_lines(renderer, last_line_pos, last_line_end)
+    }
 }
 
 #[derive(Debug)]
@@ -578,5 +596,42 @@ impl<'t> OverlayHighlighter<'t> {
             acc.patch(self.theme.highlight(highlight))
         });
         self.update_pos();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_pos_sentinel_constructor_matches_is_sentinel() {
+        let pos = LinePos::sentinel();
+        assert!(pos.is_sentinel());
+        assert_eq!(pos.doc_line, usize::MAX);
+        assert_eq!(pos.visual_line, u16::MAX);
+    }
+
+    #[test]
+    fn line_pos_with_real_doc_line_is_not_sentinel() {
+        let pos = LinePos {
+            first_visual_line: true,
+            doc_line: 0,
+            visual_line: 0,
+        };
+        assert!(!pos.is_sentinel());
+    }
+
+    #[test]
+    fn line_pos_at_max_visual_line_with_real_doc_line_is_not_sentinel() {
+        // Only `doc_line` decides sentinel-ness. A real line that happens
+        // to land at `visual_line = u16::MAX` (the renderer's saturation
+        // ceiling) is still a real line: trailing decorations should run
+        // for it. The sentinel guard hinges on `doc_line` alone.
+        let pos = LinePos {
+            first_visual_line: false,
+            doc_line: 42,
+            visual_line: u16::MAX,
+        };
+        assert!(!pos.is_sentinel());
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -217,7 +217,12 @@ impl EditorView {
         // registers as a highlight). Applies that fg color to the changed char ranges,
         // making them visually distinct from the line-level bg.
         if let Some(session) = editor.diff_session_for(view.id) {
-            if let Some(highlight) = theme.find_highlight_exact("diff.delta") {
+            // Prefer diff.delta.text (explicit bg, makes whitespace changes visible) over
+            // diff.delta (line-level scope whose bg matches the line background).
+            let intra_highlight = theme
+                .find_highlight_exact("diff.delta.text")
+                .or_else(|| theme.find_highlight_exact("diff.delta"));
+            if let Some(highlight) = intra_highlight {
                 let side = if view.id == session.view_a() {
                     helix_view::diff_session::DiffSide::A
                 } else {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -96,14 +96,15 @@ impl EditorView {
         let diff_view_info = editor.diff_session_for(view.id).and_then(|session| {
             let side = session.side_for_view(view.id)?;
             let hunks = session.hunks_arc();
+            let intra_line_cache = session.intra_line_cache_arc();
             let doc_ids = session.doc_ids();
-            Some((side, hunks, doc_ids))
+            Some((side, hunks, intra_line_cache, doc_ids))
         });
 
         let mut text_annotations = view.text_annotations(doc, Some(theme));
 
         // Add DiffAlignment line annotation last so it can account for other virtual text.
-        if let Some((side, ref hunks, _)) = diff_view_info {
+        if let Some((side, ref hunks, _, _)) = diff_view_info {
             text_annotations.add_line_annotation(Box::new(
                 helix_view::diff_session::DiffAlignment::new(Arc::clone(hunks), side),
             ));
@@ -119,7 +120,7 @@ impl EditorView {
             Self::highlight_cursorcolumn(doc, view, surface, theme, inner, &text_annotations);
         }
 
-        if let Some((side, ref hunks, _)) = diff_view_info {
+        if let Some((side, ref hunks, _, _)) = diff_view_info {
             let hunks = Arc::clone(hunks);
 
             // Use diff theme fg as bg (most themes only set fg for diff.plus/delta/minus).
@@ -210,7 +211,7 @@ impl EditorView {
         // Intra-line diff highlighting via OverlayHighlights.
         // Prefer diff.delta.text (explicit bg, makes whitespace changes visible) over
         // diff.delta (line-level scope whose bg matches the line background).
-        if let Some((side, ref hunks, (doc_a_id, doc_b_id))) = diff_view_info {
+        if let Some((side, _, ref intra_line_cache, (doc_a_id, doc_b_id))) = diff_view_info {
             let intra_highlight = theme
                 .find_highlight_exact("diff.delta.text")
                 .or_else(|| theme.find_highlight_exact("diff.delta"));
@@ -223,15 +224,11 @@ impl EditorView {
                 };
 
                 let mut char_ranges = Vec::new();
-                for hunk in hunks.iter() {
-                    if hunk.before.is_empty() || hunk.after.is_empty() {
-                        continue;
-                    }
-                    let (changes_a, changes_b) =
-                        helix_view::diff_session::intra_line_changes(&rope_a, &rope_b, hunk);
+                // Use the pre-computed per-hunk cache instead of running Myers diff per frame.
+                for cached in intra_line_cache.iter() {
                     let my_changes = match side {
-                        helix_view::diff_session::DiffSide::A => changes_a,
-                        helix_view::diff_session::DiffSide::B => changes_b,
+                        helix_view::diff_session::DiffSide::A => &cached.0,
+                        helix_view::diff_session::DiffSide::B => &cached.1,
                     };
                     for change in my_changes {
                         char_ranges.push(change.to_char_range(my_rope));

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -123,7 +123,9 @@ impl EditorView {
         if let Some((side, ref hunks, _, _)) = diff_view_info {
             let hunks = Arc::clone(hunks);
 
-            // Use diff theme fg as bg (most themes only set fg for diff.plus/delta/minus).
+            // Use diff theme bg as line background; fall back to fg if no bg is set
+            // (many themes only define fg on diff scopes). If neither is set,
+            // Style::default() is returned, which is a no-op on cell backgrounds.
             let fg_to_bg = |style: Style| -> Style {
                 if let Some(bg) = style.bg {
                     Style::default().bg(bg)
@@ -133,9 +135,23 @@ impl EditorView {
                     style
                 }
             };
-            let style_deleted = fg_to_bg(theme.get("diff.minus"));
-            let style_added = fg_to_bg(theme.get("diff.plus"));
-            let style_modified = fg_to_bg(theme.get("diff.delta"));
+            // Fall back to the default theme's diff colors when the active theme
+            // does not define these scopes at all.
+            let style_deleted = fg_to_bg(
+                theme
+                    .try_get("diff.minus")
+                    .unwrap_or_else(|| Style::default().fg(Color::Rgb(242, 44, 134))),
+            );
+            let style_added = fg_to_bg(
+                theme
+                    .try_get("diff.plus")
+                    .unwrap_or_else(|| Style::default().fg(Color::Rgb(53, 191, 134))),
+            );
+            let style_modified = fg_to_bg(
+                theme
+                    .try_get("diff.delta")
+                    .unwrap_or_else(|| Style::default().fg(Color::Rgb(111, 68, 240))),
+            );
 
             let mut cursor: usize = 0;
             let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -136,9 +136,25 @@ impl EditorView {
             let style_added = fg_to_bg(theme.get("diff.plus"));
             let style_modified = fg_to_bg(theme.get("diff.delta"));
 
+            let mut cursor: usize = 0;
             let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
                 let doc_line = pos.doc_line as u32;
-                for hunk in hunks.iter() {
+                // Advance past hunks that ended before this line.
+                // Relies on decorate_line being called in ascending doc_line order
+                // within a single render pass. The closure is rebuilt each render_view
+                // call so cursor resets to 0 implicitly every frame.
+                while cursor < hunks.len() {
+                    let my_range = match side {
+                        helix_view::diff_session::DiffSide::A => hunks[cursor].before.clone(),
+                        helix_view::diff_session::DiffSide::B => hunks[cursor].after.clone(),
+                    };
+                    if my_range.end <= doc_line {
+                        cursor += 1;
+                    } else {
+                        break;
+                    }
+                }
+                if let Some(hunk) = hunks.get(cursor) {
                     let (my_range, other_range) = match side {
                         helix_view::diff_session::DiffSide::A => {
                             (hunk.before.clone(), hunk.after.clone())
@@ -155,10 +171,6 @@ impl EditorView {
                         };
                         renderer
                             .set_style(Rect::new(inner.x, pos.visual_line, inner.width, 1), style);
-                        return;
-                    }
-                    if my_range.start > doc_line {
-                        break;
                     }
                 }
             };

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -91,7 +91,22 @@ impl EditorView {
 
         let view_offset = doc.view_offset(view.id);
 
-        let text_annotations = view.text_annotations(doc, Some(theme));
+        let mut text_annotations = view.text_annotations(doc, Some(theme));
+
+        // Add DiffAlignment line annotation if this view is part of a diff session.
+        // This must be added last so it can account for other virtual text when aligning.
+        if let Some(session) = editor.diff_session_for(view.id) {
+            let side = if view.id == session.view_a() {
+                helix_view::diff_session::DiffSide::A
+            } else {
+                helix_view::diff_session::DiffSide::B
+            };
+            let hunks = std::sync::Arc::new(session.hunks().to_vec());
+            text_annotations.add_line_annotation(Box::new(
+                helix_view::diff_session::DiffAlignment::new(hunks, side),
+            ));
+        }
+
         let mut decorations = DecorationManager::default();
 
         if is_focused && config.cursorline {
@@ -100,6 +115,58 @@ impl EditorView {
 
         if is_focused && config.cursorcolumn {
             Self::highlight_cursorcolumn(doc, view, surface, theme, inner, &text_annotations);
+        }
+
+        // Set diff line background highlighting if this view is part of a diff session.
+        // Intra-line char-level highlighting is added later via OverlayHighlights.
+        if let Some(session) = editor.diff_session_for(view.id) {
+            let side = if view.id == session.view_a() {
+                helix_view::diff_session::DiffSide::A
+            } else {
+                helix_view::diff_session::DiffSide::B
+            };
+            let hunks: Vec<_> = session.hunks().to_vec();
+
+            // Use diff theme fg as bg (most themes only set fg for diff.plus/delta/minus).
+            let fg_to_bg = |style: Style| -> Style {
+                if let Some(bg) = style.bg {
+                    Style::default().bg(bg)
+                } else if let Some(fg) = style.fg {
+                    Style::default().bg(fg)
+                } else {
+                    style
+                }
+            };
+            let style_added = fg_to_bg(theme.get("diff.plus"));
+            let style_modified = fg_to_bg(theme.get("diff.delta"));
+
+            let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
+                let doc_line = pos.doc_line as u32;
+                for hunk in &hunks {
+                    let (my_range, other_range) = match side {
+                        helix_view::diff_session::DiffSide::A => {
+                            (hunk.before.clone(), hunk.after.clone())
+                        }
+                        helix_view::diff_session::DiffSide::B => {
+                            (hunk.after.clone(), hunk.before.clone())
+                        }
+                    };
+                    if my_range.contains(&doc_line) {
+                        let style = if other_range.is_empty() {
+                            style_added
+                        } else {
+                            style_modified
+                        };
+                        renderer
+                            .set_style(Rect::new(inner.x, pos.visual_line, inner.width, 1), style);
+                        return;
+                    }
+                    if my_range.start > doc_line {
+                        break;
+                    }
+                }
+            };
+            decorations.add_decoration(line_decoration);
         }
 
         // Set DAP highlights, if needed.
@@ -144,6 +211,49 @@ impl EditorView {
         }
 
         Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
+
+        // Intra-line diff highlighting via OverlayHighlights.
+        // Uses the "diff.delta" theme scope (which every theme with diff.delta defined
+        // registers as a highlight). Applies that fg color to the changed char ranges,
+        // making them visually distinct from the line-level bg.
+        if let Some(session) = editor.diff_session_for(view.id) {
+            if let Some(highlight) = theme.find_highlight_exact("diff.delta") {
+                let side = if view.id == session.view_a() {
+                    helix_view::diff_session::DiffSide::A
+                } else {
+                    helix_view::diff_session::DiffSide::B
+                };
+                let (doc_a_id, doc_b_id) = session.doc_ids();
+                let rope_a = editor.documents[&doc_a_id].text().clone();
+                let rope_b = editor.documents[&doc_b_id].text().clone();
+                let my_rope = match side {
+                    helix_view::diff_session::DiffSide::A => &rope_a,
+                    helix_view::diff_session::DiffSide::B => &rope_b,
+                };
+
+                let mut char_ranges = Vec::new();
+                for hunk in session.hunks() {
+                    if hunk.before.is_empty() || hunk.after.is_empty() {
+                        continue;
+                    }
+                    let (changes_a, changes_b) =
+                        helix_view::diff_session::intra_line_changes(&rope_a, &rope_b, hunk);
+                    let my_changes = match side {
+                        helix_view::diff_session::DiffSide::A => changes_a,
+                        helix_view::diff_session::DiffSide::B => changes_b,
+                    };
+                    for change in my_changes {
+                        char_ranges.push(change.to_char_range(my_rope));
+                    }
+                }
+                if !char_ranges.is_empty() {
+                    overlays.push(OverlayHighlights::Homogeneous {
+                        highlight,
+                        ranges: char_ranges,
+                    });
+                }
+            }
+        }
 
         if is_focused {
             if config.lsp.auto_document_highlight {
@@ -1640,6 +1750,19 @@ impl Component for EditorView {
         if use_bufferline {
             Self::render_bufferline(cx.editor, area.with_height(1), surface);
         }
+
+        // Recompute diff session hunks if either document changed
+        for session in &mut cx.editor.diff_sessions {
+            let version_a = cx.editor.documents[&session.doc_a()].version();
+            let version_b = cx.editor.documents[&session.doc_b()].version();
+            let rope_a = cx.editor.documents[&session.doc_a()].text().clone();
+            let rope_b = cx.editor.documents[&session.doc_b()].text().clone();
+            session.update_if_changed(version_a, version_b, &rope_a, &rope_b);
+        }
+
+        // Sync scroll position from the focused view to its diff partner
+        let focus = cx.editor.tree.focus;
+        cx.editor.sync_diff_scroll(focus);
 
         for (view, is_focused) in cx.editor.tree.views() {
             let doc = cx.editor.document(view.doc).unwrap();

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -133,6 +133,7 @@ impl EditorView {
                     style
                 }
             };
+            let style_deleted = fg_to_bg(theme.get("diff.minus"));
             let style_added = fg_to_bg(theme.get("diff.plus"));
             let style_modified = fg_to_bg(theme.get("diff.delta"));
 
@@ -164,11 +165,13 @@ impl EditorView {
                         }
                     };
                     if my_range.contains(&doc_line) {
-                        let style = if other_range.is_empty() {
-                            style_added
-                        } else {
-                            style_modified
-                        };
+                        let style = diff_line_style(
+                            side,
+                            other_range.is_empty(),
+                            style_deleted,
+                            style_added,
+                            style_modified,
+                        );
                         renderer
                             .set_style(Rect::new(inner.x, pos.visual_line, inner.width, 1), style);
                     }
@@ -1881,5 +1884,65 @@ fn canonicalize_key(key: &mut KeyEvent) {
     } = key
     {
         key.modifiers.remove(KeyModifiers::SHIFT)
+    }
+}
+
+/// Selects the diff line background style based on which side is being rendered
+/// and whether the opposite side has any content for this hunk.
+fn diff_line_style(
+    side: helix_view::diff_session::DiffSide,
+    other_range_empty: bool,
+    style_deleted: Style,
+    style_added: Style,
+    style_modified: Style,
+) -> Style {
+    if other_range_empty {
+        match side {
+            helix_view::diff_session::DiffSide::A => style_deleted,
+            helix_view::diff_session::DiffSide::B => style_added,
+        }
+    } else {
+        style_modified
+    }
+}
+
+#[cfg(test)]
+mod diff_coloring_tests {
+    use helix_view::{
+        diff_session::DiffSide,
+        graphics::{Color, Style},
+    };
+
+    use super::diff_line_style;
+
+    fn mk(r: u8, g: u8, b: u8) -> Style {
+        Style::default().bg(Color::Rgb(r, g, b))
+    }
+
+    #[test]
+    fn deletion_lines_use_minus_style() {
+        let deleted = mk(255, 0, 0); // red
+        let added = mk(0, 255, 0); // green
+        let modified = mk(255, 165, 0); // orange
+
+        // pure deletion on A side = red
+        assert_eq!(
+            diff_line_style(DiffSide::A, true, deleted, added, modified),
+            deleted
+        );
+        // pure addition on B side = green
+        assert_eq!(
+            diff_line_style(DiffSide::B, true, deleted, added, modified),
+            added
+        );
+        // modifications = orange regardless of side
+        assert_eq!(
+            diff_line_style(DiffSide::A, false, deleted, added, modified),
+            modified
+        );
+        assert_eq!(
+            diff_line_style(DiffSide::B, false, deleted, added, modified),
+            modified
+        );
     }
 }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1967,18 +1967,18 @@ fn diff_view_highlight(
         .or_else(|| theme.find_highlight_exact(base))
 }
 
-/// Compute the row-decoration Style for a diff line from a theme `diff.*` scope.
+/// Row-decoration Style for a diff line from a theme `diff.*` scope.
 ///
-/// - Both fg and bg set: preserves both so vimdiff-style "white on red" scopes
-///   override syntax fg on the diff line.
-/// - Only bg set: bg-only Style (preserves syntax fg underneath).
-/// - Only fg set: fg is used as bg. This is the fallback for themes that
-///   define diff scopes as gutter-only accents without an explicit bg.
-/// - Neither set: returns the input Style unchanged (no-op on cell bgs).
+/// - bg set (with or without fg): pass the style through unchanged so any
+///   modifiers (italic, bold, underline) the theme attached to the scope are
+///   honored on the diff line.
+/// - Only fg set: legacy fallback for themes that define diff scopes as
+///   gutter-only accents without an explicit bg. The fg is promoted to bg
+///   and modifiers are dropped, since they were attached to a fg we discard.
+/// - Neither set: passthrough.
 fn diff_bg_style(style: Style) -> Style {
     match (style.bg, style.fg) {
-        (Some(bg), Some(fg)) => Style::default().bg(bg).fg(fg),
-        (Some(bg), None) => Style::default().bg(bg),
+        (Some(_), _) => style,
         (None, Some(fg)) => Style::default().bg(fg),
         (None, None) => style,
     }
@@ -2100,6 +2100,22 @@ mod diff_coloring_tests {
         // Empty style returns unchanged (no-op on cell bgs).
         let input = Style::default();
         assert_eq!(diff_bg_style(input), Style::default());
+    }
+
+    #[test]
+    fn diff_bg_style_preserves_modifiers_when_bg_is_set() {
+        // m4rch3n1ng's bonus point: a theme attaching italic / bold to a
+        // diff scope should see those modifiers on the diff line as long as
+        // the theme also set a bg.
+        use helix_view::graphics::Modifier;
+        let input = Style::default()
+            .bg(Color::Rgb(31, 111, 78))
+            .add_modifier(Modifier::ITALIC)
+            .add_modifier(Modifier::BOLD);
+        let result = diff_bg_style(input);
+        assert!(result.add_modifier.contains(Modifier::ITALIC));
+        assert!(result.add_modifier.contains(Modifier::BOLD));
+        assert_eq!(result.bg, Some(Color::Rgb(31, 111, 78)));
     }
 
     use super::{diff_view_highlight, diff_view_line_style};

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -31,7 +31,7 @@ use helix_view::{
     keyboard::{KeyCode, KeyModifiers},
     Document, Editor, Theme, View,
 };
-use std::{mem::take, num::NonZeroUsize, ops, path::PathBuf, rc::Rc};
+use std::{mem::take, num::NonZeroUsize, ops, path::PathBuf, rc::Rc, sync::Arc};
 
 use tui::{buffer::Buffer as Surface, text::Span};
 
@@ -91,19 +91,21 @@ impl EditorView {
 
         let view_offset = doc.view_offset(view.id);
 
+        // Compute diff session info once: avoids three separate linear scans of diff_sessions
+        // and releases the borrow on editor.diff_sessions before touching editor.documents.
+        let diff_view_info = editor.diff_session_for(view.id).and_then(|session| {
+            let side = session.side_for_view(view.id)?;
+            let hunks = session.hunks_arc();
+            let doc_ids = session.doc_ids();
+            Some((side, hunks, doc_ids))
+        });
+
         let mut text_annotations = view.text_annotations(doc, Some(theme));
 
-        // Add DiffAlignment line annotation if this view is part of a diff session.
-        // This must be added last so it can account for other virtual text when aligning.
-        if let Some(session) = editor.diff_session_for(view.id) {
-            let side = if view.id == session.view_a() {
-                helix_view::diff_session::DiffSide::A
-            } else {
-                helix_view::diff_session::DiffSide::B
-            };
-            let hunks = std::sync::Arc::new(session.hunks().to_vec());
+        // Add DiffAlignment line annotation last so it can account for other virtual text.
+        if let Some((side, ref hunks, _)) = diff_view_info {
             text_annotations.add_line_annotation(Box::new(
-                helix_view::diff_session::DiffAlignment::new(hunks, side),
+                helix_view::diff_session::DiffAlignment::new(Arc::clone(hunks), side),
             ));
         }
 
@@ -117,15 +119,8 @@ impl EditorView {
             Self::highlight_cursorcolumn(doc, view, surface, theme, inner, &text_annotations);
         }
 
-        // Set diff line background highlighting if this view is part of a diff session.
-        // Intra-line char-level highlighting is added later via OverlayHighlights.
-        if let Some(session) = editor.diff_session_for(view.id) {
-            let side = if view.id == session.view_a() {
-                helix_view::diff_session::DiffSide::A
-            } else {
-                helix_view::diff_session::DiffSide::B
-            };
-            let hunks: Vec<_> = session.hunks().to_vec();
+        if let Some((side, ref hunks, _)) = diff_view_info {
+            let hunks = Arc::clone(hunks);
 
             // Use diff theme fg as bg (most themes only set fg for diff.plus/delta/minus).
             let fg_to_bg = |style: Style| -> Style {
@@ -142,7 +137,7 @@ impl EditorView {
 
             let line_decoration = move |renderer: &mut TextRenderer, pos: LinePos| {
                 let doc_line = pos.doc_line as u32;
-                for hunk in &hunks {
+                for hunk in hunks.iter() {
                     let (my_range, other_range) = match side {
                         helix_view::diff_session::DiffSide::A => {
                             (hunk.before.clone(), hunk.after.clone())
@@ -213,22 +208,13 @@ impl EditorView {
         Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
 
         // Intra-line diff highlighting via OverlayHighlights.
-        // Uses the "diff.delta" theme scope (which every theme with diff.delta defined
-        // registers as a highlight). Applies that fg color to the changed char ranges,
-        // making them visually distinct from the line-level bg.
-        if let Some(session) = editor.diff_session_for(view.id) {
-            // Prefer diff.delta.text (explicit bg, makes whitespace changes visible) over
-            // diff.delta (line-level scope whose bg matches the line background).
+        // Prefer diff.delta.text (explicit bg, makes whitespace changes visible) over
+        // diff.delta (line-level scope whose bg matches the line background).
+        if let Some((side, ref hunks, (doc_a_id, doc_b_id))) = diff_view_info {
             let intra_highlight = theme
                 .find_highlight_exact("diff.delta.text")
                 .or_else(|| theme.find_highlight_exact("diff.delta"));
             if let Some(highlight) = intra_highlight {
-                let side = if view.id == session.view_a() {
-                    helix_view::diff_session::DiffSide::A
-                } else {
-                    helix_view::diff_session::DiffSide::B
-                };
-                let (doc_a_id, doc_b_id) = session.doc_ids();
                 let rope_a = editor.documents[&doc_a_id].text().clone();
                 let rope_b = editor.documents[&doc_b_id].text().clone();
                 let my_rope = match side {
@@ -237,7 +223,7 @@ impl EditorView {
                 };
 
                 let mut char_ranges = Vec::new();
-                for hunk in session.hunks() {
+                for hunk in hunks.iter() {
                     if hunk.before.is_empty() || hunk.after.is_empty() {
                         continue;
                     }
@@ -1756,13 +1742,14 @@ impl Component for EditorView {
             Self::render_bufferline(cx.editor, area.with_height(1), surface);
         }
 
-        // Recompute diff session hunks if either document changed
         for session in &mut cx.editor.diff_sessions {
             let version_a = cx.editor.documents[&session.doc_a()].version();
             let version_b = cx.editor.documents[&session.doc_b()].version();
-            let rope_a = cx.editor.documents[&session.doc_a()].text().clone();
-            let rope_b = cx.editor.documents[&session.doc_b()].text().clone();
-            session.update_if_changed(version_a, version_b, &rope_a, &rope_b);
+            if session.needs_update(version_a, version_b) {
+                let rope_a = cx.editor.documents[&session.doc_a()].text().clone();
+                let rope_b = cx.editor.documents[&session.doc_b()].text().clone();
+                session.update_if_changed(version_a, version_b, &rope_a, &rope_b);
+            }
         }
 
         // Sync scroll position from the focused view to its diff partner

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -123,31 +123,19 @@ impl EditorView {
         if let Some((side, ref hunks, _, _)) = diff_view_info {
             let hunks = Arc::clone(hunks);
 
-            // Use diff theme bg as line background; fall back to fg if no bg is set
-            // (many themes only define fg on diff scopes). If neither is set,
-            // Style::default() is returned, which is a no-op on cell backgrounds.
-            let fg_to_bg = |style: Style| -> Style {
-                if let Some(bg) = style.bg {
-                    Style::default().bg(bg)
-                } else if let Some(fg) = style.fg {
-                    Style::default().bg(fg)
-                } else {
-                    style
-                }
-            };
             // Fall back to the default theme's diff colors when the active theme
             // does not define these scopes at all.
-            let style_deleted = fg_to_bg(
+            let style_deleted = diff_bg_style(
                 theme
                     .try_get("diff.minus")
                     .unwrap_or_else(|| Style::default().fg(Color::Rgb(242, 44, 134))),
             );
-            let style_added = fg_to_bg(
+            let style_added = diff_bg_style(
                 theme
                     .try_get("diff.plus")
                     .unwrap_or_else(|| Style::default().fg(Color::Rgb(53, 191, 134))),
             );
-            let style_modified = fg_to_bg(
+            let style_modified = diff_bg_style(
                 theme
                     .try_get("diff.delta")
                     .unwrap_or_else(|| Style::default().fg(Color::Rgb(111, 68, 240))),
@@ -238,6 +226,49 @@ impl EditorView {
         }
 
         Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
+
+        // Full-line diff overlays. Pushed BEFORE the intra-line overlay below
+        // so intra-line (diff.delta.text) wins on changed-token cells via
+        // overlay ordering. Line decoration already sets the full-width bg;
+        // these overlays add fg (and an identical bg patch) to character
+        // cells so theme fg overrides syntax — classic vim "whole line in
+        // one color" behavior when the theme sets both fg+bg on diff scopes.
+        if let Some((side, ref hunks, _, (doc_a_id, doc_b_id))) = diff_view_info {
+            let rope_a = editor.documents[&doc_a_id].text().clone();
+            let rope_b = editor.documents[&doc_b_id].text().clone();
+            let my_rope = match side {
+                helix_view::diff_session::DiffSide::A => &rope_a,
+                helix_view::diff_session::DiffSide::B => &rope_b,
+            };
+
+            let (minus_ranges, plus_ranges, delta_ranges) =
+                diff_line_char_ranges(hunks, my_rope, side);
+
+            // Only push the full-line overlay when the theme explicitly sets
+            // BOTH fg and bg on the scope. That pair signals "the theme wants
+            // to override syntax fg on diff lines" (vimdiff-style). Themes
+            // that set only fg (upstream nord et al.) rely on the fg-as-bg
+            // fallback in decoration and would break if we forced their fg
+            // over syntax. Themes that set only bg want syntax preserved too.
+            let push_if_overriding =
+                |overlays: &mut Vec<OverlayHighlights>,
+                 scope: &str,
+                 ranges: Vec<std::ops::Range<usize>>| {
+                    if ranges.is_empty() {
+                        return;
+                    }
+                    let style = theme.try_get(scope).unwrap_or_default();
+                    if style.fg.is_none() || style.bg.is_none() {
+                        return;
+                    }
+                    if let Some(highlight) = theme.find_highlight_exact(scope) {
+                        overlays.push(OverlayHighlights::Homogeneous { highlight, ranges });
+                    }
+                };
+            push_if_overriding(&mut overlays, "diff.minus", minus_ranges);
+            push_if_overriding(&mut overlays, "diff.plus", plus_ranges);
+            push_if_overriding(&mut overlays, "diff.delta", delta_ranges);
+        }
 
         // Intra-line diff highlighting via OverlayHighlights.
         // Prefer diff.delta.text (explicit bg, makes whitespace changes visible) over
@@ -1903,6 +1934,72 @@ fn canonicalize_key(key: &mut KeyEvent) {
     }
 }
 
+/// Compute the row-decoration Style for a diff line from a theme `diff.*` scope.
+///
+/// - Both fg and bg set: preserves both so vimdiff-style "white on red" scopes
+///   override syntax fg on the diff line.
+/// - Only bg set: bg-only Style (preserves syntax fg underneath).
+/// - Only fg set: fg is used as bg. This is the fallback for themes that
+///   define diff scopes as gutter-only accents without an explicit bg.
+/// - Neither set: returns the input Style unchanged (no-op on cell bgs).
+fn diff_bg_style(style: Style) -> Style {
+    match (style.bg, style.fg) {
+        (Some(bg), Some(fg)) => Style::default().bg(bg).fg(fg),
+        (Some(bg), None) => Style::default().bg(bg),
+        (None, Some(fg)) => Style::default().bg(fg),
+        (None, None) => style,
+    }
+}
+
+/// Compute char ranges for each diff line category (minus/plus/delta) on the
+/// given side. Used to push full-line overlay highlights so diff scope fgs
+/// override syntax on diff lines — the decoration path can't do that because
+/// syntax rendering runs after line decoration and clobbers cell fg.
+///
+/// Returns `(minus_ranges, plus_ranges, delta_ranges)` as char offsets into
+/// `rope`.
+/// - `minus`: hunks on side A with an empty side B (pure deletion).
+/// - `plus`: hunks on side B with an empty side A (pure addition).
+/// - `delta`: hunks where both sides have lines (modified pair).
+type CharRangeVec = Vec<std::ops::Range<usize>>;
+
+fn diff_line_char_ranges(
+    hunks: &[helix_vcs::Hunk],
+    rope: &helix_core::Rope,
+    side: helix_view::diff_session::DiffSide,
+) -> (CharRangeVec, CharRangeVec, CharRangeVec) {
+    use helix_view::diff_session::DiffSide;
+    let mut minus = Vec::new();
+    let mut plus = Vec::new();
+    let mut delta = Vec::new();
+
+    for hunk in hunks {
+        let (my_range, other_range) = match side {
+            DiffSide::A => (hunk.before.clone(), hunk.after.clone()),
+            DiffSide::B => (hunk.after.clone(), hunk.before.clone()),
+        };
+
+        if my_range.is_empty() {
+            continue;
+        }
+
+        let start = rope.line_to_char(my_range.start as usize);
+        let end = rope.line_to_char(my_range.end as usize);
+        let line_range = start..end;
+
+        if other_range.is_empty() {
+            match side {
+                DiffSide::A => minus.push(line_range),
+                DiffSide::B => plus.push(line_range),
+            }
+        } else {
+            delta.push(line_range);
+        }
+    }
+
+    (minus, plus, delta)
+}
+
 /// Selects the diff line background style based on which side is being rendered
 /// and whether the opposite side has any content for this hunk.
 fn diff_line_style(
@@ -1929,10 +2026,156 @@ mod diff_coloring_tests {
         graphics::{Color, Style},
     };
 
-    use super::diff_line_style;
+    use super::{diff_bg_style, diff_line_style};
 
     fn mk(r: u8, g: u8, b: u8) -> Style {
         Style::default().bg(Color::Rgb(r, g, b))
+    }
+
+    #[test]
+    fn diff_bg_style_preserves_fg_when_both_set() {
+        // vimdiff-style scope: theme sets both fg and bg (e.g., "white on red")
+        // so the fg overrides syntax on the diff line.
+        let input = Style::default()
+            .bg(Color::Rgb(191, 97, 106))
+            .fg(Color::Rgb(236, 239, 244));
+        let expected = Style::default()
+            .bg(Color::Rgb(191, 97, 106))
+            .fg(Color::Rgb(236, 239, 244));
+        assert_eq!(diff_bg_style(input), expected);
+    }
+
+    #[test]
+    fn diff_bg_style_bg_only_when_only_bg_set() {
+        // Subtle diff scope: only bg set, syntax fg remains visible underneath.
+        let input = Style::default().bg(Color::Rgb(120, 80, 88));
+        let expected = Style::default().bg(Color::Rgb(120, 80, 88));
+        assert_eq!(diff_bg_style(input), expected);
+    }
+
+    #[test]
+    fn diff_bg_style_uses_fg_as_bg_when_only_fg_set() {
+        // Legacy / gutter-only theme: scope defines fg but no bg, so fg is
+        // promoted to bg for the line decoration.
+        let input = Style::default().fg(Color::Rgb(191, 97, 106));
+        let expected = Style::default().bg(Color::Rgb(191, 97, 106));
+        assert_eq!(diff_bg_style(input), expected);
+    }
+
+    #[test]
+    fn diff_bg_style_passthrough_when_nothing_set() {
+        // Empty style returns unchanged (no-op on cell bgs).
+        let input = Style::default();
+        assert_eq!(diff_bg_style(input), Style::default());
+    }
+
+    use super::diff_line_char_ranges;
+    use helix_core::Rope;
+    use helix_vcs::Hunk;
+
+    #[test]
+    fn diff_line_char_ranges_pure_deletion_on_side_a() {
+        // 3-line rope; hunk deletes lines 0..2 from A (B side empty).
+        let rope = Rope::from("aaa\nbbb\nccc\n");
+        let hunk = Hunk {
+            before: 0..2,
+            after: 0..0,
+        };
+        let (minus, plus, delta) = diff_line_char_ranges(&[hunk], &rope, DiffSide::A);
+        assert_eq!(minus, vec![0..8]); // "aaa\nbbb\n" = 8 chars
+        assert!(plus.is_empty());
+        assert!(delta.is_empty());
+    }
+
+    #[test]
+    fn diff_line_char_ranges_pure_addition_on_side_b() {
+        // Hunk adds lines 1..3 on B (A side empty).
+        let rope = Rope::from("aaa\nbbb\nccc\n");
+        let hunk = Hunk {
+            before: 0..0,
+            after: 1..3,
+        };
+        let (minus, plus, delta) = diff_line_char_ranges(&[hunk], &rope, DiffSide::B);
+        assert!(minus.is_empty());
+        assert_eq!(plus, vec![4..12]); // "bbb\nccc\n" starts at char 4, length 8
+        assert!(delta.is_empty());
+    }
+
+    #[test]
+    fn diff_line_char_ranges_modified_pair_on_side_a() {
+        // Both sides have line 1; it's a paired modification.
+        let rope = Rope::from("aaa\nbbb\nccc\n");
+        let hunk = Hunk {
+            before: 1..2,
+            after: 1..2,
+        };
+        let (minus, plus, delta) = diff_line_char_ranges(&[hunk], &rope, DiffSide::A);
+        assert!(minus.is_empty());
+        assert!(plus.is_empty());
+        assert_eq!(delta, vec![4..8]); // "bbb\n"
+    }
+
+    #[test]
+    fn diff_line_char_ranges_modified_pair_on_side_b() {
+        // Same hunk viewed from side B: still a modified pair.
+        let rope = Rope::from("aaa\nBBB\nccc\n");
+        let hunk = Hunk {
+            before: 1..2,
+            after: 1..2,
+        };
+        let (minus, plus, delta) = diff_line_char_ranges(&[hunk], &rope, DiffSide::B);
+        assert!(minus.is_empty());
+        assert!(plus.is_empty());
+        assert_eq!(delta, vec![4..8]);
+    }
+
+    #[test]
+    fn diff_line_char_ranges_skips_empty_side_hunks() {
+        // An addition hunk viewed from side A: my_range (before) is empty,
+        // so the hunk contributes nothing to A-side overlays.
+        let rope = Rope::from("aaa\nbbb\n");
+        let hunk = Hunk {
+            before: 0..0,
+            after: 1..2,
+        };
+        let (minus, plus, delta) = diff_line_char_ranges(&[hunk], &rope, DiffSide::A);
+        assert!(minus.is_empty());
+        assert!(plus.is_empty());
+        assert!(delta.is_empty());
+    }
+
+    #[test]
+    fn diff_line_char_ranges_empty_hunks_list() {
+        let rope = Rope::from("aaa\n");
+        let (minus, plus, delta) = diff_line_char_ranges(&[], &rope, DiffSide::A);
+        assert!(minus.is_empty());
+        assert!(plus.is_empty());
+        assert!(delta.is_empty());
+    }
+
+    #[test]
+    fn diff_line_char_ranges_mixed_hunks_buckets_correctly() {
+        // Three hunks on side A: a pure deletion, a modified pair, and an
+        // addition (which contributes nothing since my_range is empty on A).
+        let rope = Rope::from("aaa\nbbb\nccc\nddd\neee\n");
+        let hunks = [
+            Hunk {
+                before: 0..1,
+                after: 0..0,
+            }, // pure deletion
+            Hunk {
+                before: 2..3,
+                after: 1..2,
+            }, // modified pair
+            Hunk {
+                before: 4..4,
+                after: 3..4,
+            }, // addition, empty A range
+        ];
+        let (minus, plus, delta) = diff_line_char_ranges(&hunks, &rope, DiffSide::A);
+        assert_eq!(minus, vec![0..4]); // "aaa\n"
+        assert!(plus.is_empty());
+        assert_eq!(delta, vec![8..12]); // "ccc\n" starts at char 8
     }
 
     #[test]

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -123,21 +123,19 @@ impl EditorView {
         if let Some((side, ref hunks, _, _)) = diff_view_info {
             let hunks = Arc::clone(hunks);
 
-            // Fall back to the default theme's diff colors when the active theme
-            // does not define these scopes at all.
+            // Look up `<base>.view` first, falling back to bare `<base>` for
+            // themes that only define the legacy scope. Falls through to a
+            // hardcoded color when neither key is set.
             let style_deleted = diff_bg_style(
-                theme
-                    .try_get("diff.minus")
+                diff_view_line_style(theme, "diff.minus")
                     .unwrap_or_else(|| Style::default().fg(Color::Rgb(242, 44, 134))),
             );
             let style_added = diff_bg_style(
-                theme
-                    .try_get("diff.plus")
+                diff_view_line_style(theme, "diff.plus")
                     .unwrap_or_else(|| Style::default().fg(Color::Rgb(53, 191, 134))),
             );
             let style_modified = diff_bg_style(
-                theme
-                    .try_get("diff.delta")
+                diff_view_line_style(theme, "diff.delta")
                     .unwrap_or_else(|| Style::default().fg(Color::Rgb(111, 68, 240))),
             );
 
@@ -257,11 +255,14 @@ impl EditorView {
                     if ranges.is_empty() {
                         return;
                     }
-                    let style = theme.try_get(scope).unwrap_or_default();
+                    let style = match diff_view_line_style(theme, scope) {
+                        Some(s) => s,
+                        None => return,
+                    };
                     if style.fg.is_none() || style.bg.is_none() {
                         return;
                     }
-                    if let Some(highlight) = theme.find_highlight_exact(scope) {
+                    if let Some(highlight) = diff_view_highlight(theme, scope) {
                         overlays.push(OverlayHighlights::Homogeneous { highlight, ranges });
                     }
                 };
@@ -271,11 +272,17 @@ impl EditorView {
         }
 
         // Intra-line diff highlighting via OverlayHighlights.
-        // Prefer diff.delta.text (explicit bg, makes whitespace changes visible) over
-        // diff.delta (line-level scope whose bg matches the line background).
+        // Prefer the most-specific scope, falling back through the namespace chain:
+        // `diff.delta.view.text` (intra-line override in the diff viewer)
+        //   -> `diff.delta.view` (line-level override in the diff viewer)
+        //   -> `diff.delta` (legacy / shared).
+        // The hop into the `.view` namespace keeps the diff viewer's styling distinct
+        // from the bare `diff.delta` scope, which is shared with the diff language
+        // grammar and the VCS gutter.
         if let Some((side, _, ref intra_line_cache, (doc_a_id, doc_b_id))) = diff_view_info {
             let intra_highlight = theme
-                .find_highlight_exact("diff.delta.text")
+                .find_highlight_exact("diff.delta.view.text")
+                .or_else(|| theme.find_highlight_exact("diff.delta.view"))
                 .or_else(|| theme.find_highlight_exact("diff.delta"));
             if let Some(highlight) = intra_highlight {
                 let rope_a = editor.documents[&doc_a_id].text().clone();
@@ -1934,6 +1941,32 @@ fn canonicalize_key(key: &mut KeyEvent) {
     }
 }
 
+/// Look up the diff viewer's line-bg style for a base scope.
+///
+/// Tries `<base>.view` first (the diff viewer's own namespace, e.g.
+/// `diff.plus.view`), and falls back to the bare `<base>` so themes that only
+/// define the bare scope still color diff lines.
+///
+/// Uses `try_get_exact` (no rsplit cascade) on both lookups to keep the
+/// fallback bounded: it must not leak further to bare `diff`, which the `diff`
+/// language grammar and the VCS gutter already use for unrelated meanings.
+fn diff_view_line_style(theme: &helix_view::Theme, base: &str) -> Option<Style> {
+    theme
+        .try_get_exact(&format!("{base}.view"))
+        .or_else(|| theme.try_get_exact(base))
+}
+
+/// Look up an `OverlayHighlights` highlight for the diff viewer with the same
+/// bounded `<base>.view` -> `<base>` fallback as [`diff_view_line_style`].
+fn diff_view_highlight(
+    theme: &helix_view::Theme,
+    base: &str,
+) -> Option<helix_core::syntax::Highlight> {
+    theme
+        .find_highlight_exact(&format!("{base}.view"))
+        .or_else(|| theme.find_highlight_exact(base))
+}
+
 /// Compute the row-decoration Style for a diff line from a theme `diff.*` scope.
 ///
 /// - Both fg and bg set: preserves both so vimdiff-style "white on red" scopes
@@ -2067,6 +2100,89 @@ mod diff_coloring_tests {
         // Empty style returns unchanged (no-op on cell bgs).
         let input = Style::default();
         assert_eq!(diff_bg_style(input), Style::default());
+    }
+
+    use super::{diff_view_highlight, diff_view_line_style};
+    use helix_view::Theme;
+
+    fn theme_from_toml(toml_str: &str) -> Theme {
+        let value: toml::Value = toml::from_str(toml_str).expect("valid theme toml");
+        Theme::from(value)
+    }
+
+    #[test]
+    fn diff_view_line_style_prefers_view_namespace() {
+        // Theme defines BOTH `.view` and bare; the `.view` entry must win.
+        let theme = theme_from_toml(
+            r##"
+"diff.plus" = { bg = "#000000" }
+"diff.plus.view" = { bg = "#112233" }
+            "##,
+        );
+        let style = diff_view_line_style(&theme, "diff.plus").expect("should resolve");
+        assert_eq!(style.bg, Some(Color::Rgb(0x11, 0x22, 0x33)));
+    }
+
+    #[test]
+    fn diff_view_line_style_falls_back_to_bare_scope() {
+        // Theme only defines bare `diff.plus`; the helper must return it as a soft fallback.
+        let theme = theme_from_toml(r##""diff.plus" = { bg = "#445566" }"##);
+        let style = diff_view_line_style(&theme, "diff.plus").expect("should fall back");
+        assert_eq!(style.bg, Some(Color::Rgb(0x44, 0x55, 0x66)));
+    }
+
+    #[test]
+    fn diff_view_line_style_returns_none_when_neither_is_defined() {
+        // Theme defines unrelated keys only; both lookups miss.
+        let theme = theme_from_toml(r##""ui.text" = { fg = "#ffffff" }"##);
+        assert!(diff_view_line_style(&theme, "diff.plus").is_none());
+    }
+
+    #[test]
+    fn diff_view_line_style_does_not_leak_to_bare_diff() {
+        // Bare `diff` is reserved for the language grammar / VCS gutter. The
+        // bounded fallback must NOT promote a bare `diff` style up to the line bg.
+        let theme = theme_from_toml(r##"diff = { fg = "#abcdef" }"##);
+        assert!(diff_view_line_style(&theme, "diff.plus").is_none());
+    }
+
+    #[test]
+    fn diff_view_line_style_handles_minus_and_delta_too() {
+        // Helper must work for every diff scope the renderer cares about.
+        let theme = theme_from_toml(
+            r##"
+"diff.minus.view" = { bg = "#101010" }
+"diff.delta.view" = { bg = "#202020" }
+            "##,
+        );
+        assert_eq!(
+            diff_view_line_style(&theme, "diff.minus").unwrap().bg,
+            Some(Color::Rgb(0x10, 0x10, 0x10))
+        );
+        assert_eq!(
+            diff_view_line_style(&theme, "diff.delta").unwrap().bg,
+            Some(Color::Rgb(0x20, 0x20, 0x20))
+        );
+    }
+
+    #[test]
+    fn diff_view_highlight_prefers_view_then_bare_then_none() {
+        // `.view` set: helper resolves to it.
+        let theme_view = theme_from_toml(
+            r##"
+"diff.delta" = { bg = "#000000" }
+"diff.delta.view" = { bg = "#abcdef" }
+            "##,
+        );
+        assert!(diff_view_highlight(&theme_view, "diff.delta").is_some());
+
+        // only bare set: helper still resolves (soft fallback).
+        let theme_bare = theme_from_toml(r##""diff.delta" = { bg = "#abcdef" }"##);
+        assert!(diff_view_highlight(&theme_bare, "diff.delta").is_some());
+
+        // neither set: helper returns None (no leakage to plain `diff`).
+        let theme_none = theme_from_toml(r##"diff = { fg = "#abcdef" }"##);
+        assert!(diff_view_highlight(&theme_none, "diff.delta").is_none());
     }
 
     use super::diff_line_char_ranges;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -95,18 +95,60 @@ impl EditorView {
         // and releases the borrow on editor.diff_sessions before touching editor.documents.
         let diff_view_info = editor.diff_session_for(view.id).and_then(|session| {
             let side = session.side_for_view(view.id)?;
+            let partner_view_id = session.partner_view(view.id)?;
             let hunks = session.hunks_arc();
             let intra_line_cache = session.intra_line_cache_arc();
             let doc_ids = session.doc_ids();
-            Some((side, hunks, intra_line_cache, doc_ids))
+            Some((side, partner_view_id, hunks, intra_line_cache, doc_ids))
         });
 
         let mut text_annotations = view.text_annotations(doc, Some(theme));
 
         // Add DiffAlignment line annotation last so it can account for other virtual text.
-        if let Some((side, ref hunks, _, _)) = diff_view_info {
+        if let Some((side, partner_view_id, ref hunks, _, (doc_a_id, doc_b_id))) = diff_view_info {
+            // Compute filler counts in visual rows so soft-wrapped hunks stay
+            // aligned. Falls back to doc-line subtraction if the partner view
+            // can't be resolved (closed mid-render, etc.).
+            let fillers = (|| -> Option<Vec<u32>> {
+                let partner_view = editor.tree.try_get(partner_view_id)?;
+                let partner_doc_id = if side == helix_view::diff_session::DiffSide::A {
+                    doc_b_id
+                } else {
+                    doc_a_id
+                };
+                let partner_doc = editor.documents.get(&partner_doc_id)?;
+                let my_text_fmt = doc.text_format(view.inner_area(doc).width, Some(theme));
+                let partner_text_fmt = partner_doc
+                    .text_format(partner_view.inner_area(partner_doc).width, Some(theme));
+                Some(helix_view::diff_session::compute_visual_fillers(
+                    hunks,
+                    side,
+                    doc.text(),
+                    partner_doc.text(),
+                    &my_text_fmt,
+                    &partner_text_fmt,
+                ))
+            })()
+            .unwrap_or_else(|| {
+                // Doc-line fallback: matches the previous behavior.
+                hunks
+                    .iter()
+                    .map(|h| {
+                        let (my_range, other_range) = match side {
+                            helix_view::diff_session::DiffSide::A => (&h.before, &h.after),
+                            helix_view::diff_session::DiffSide::B => (&h.after, &h.before),
+                        };
+                        (other_range.end - other_range.start)
+                            .saturating_sub(my_range.end - my_range.start)
+                    })
+                    .collect()
+            });
             text_annotations.add_line_annotation(Box::new(
-                helix_view::diff_session::DiffAlignment::new(Arc::clone(hunks), side),
+                helix_view::diff_session::DiffAlignment::new(
+                    Arc::clone(hunks),
+                    side,
+                    Arc::new(fillers),
+                ),
             ));
         }
 
@@ -120,7 +162,7 @@ impl EditorView {
             Self::highlight_cursorcolumn(doc, view, surface, theme, inner, &text_annotations);
         }
 
-        if let Some((side, ref hunks, _, _)) = diff_view_info {
+        if let Some((side, _, ref hunks, _, _)) = diff_view_info {
             let hunks = Arc::clone(hunks);
 
             // Look up `<base>.view` first, falling back to bare `<base>` for
@@ -231,7 +273,7 @@ impl EditorView {
         // these overlays add fg (and an identical bg patch) to character
         // cells so theme fg overrides syntax — classic vim "whole line in
         // one color" behavior when the theme sets both fg+bg on diff scopes.
-        if let Some((side, ref hunks, _, (doc_a_id, doc_b_id))) = diff_view_info {
+        if let Some((side, _, ref hunks, _, (doc_a_id, doc_b_id))) = diff_view_info {
             let rope_a = editor.documents[&doc_a_id].text().clone();
             let rope_b = editor.documents[&doc_b_id].text().clone();
             let my_rope = match side {
@@ -279,7 +321,7 @@ impl EditorView {
         // The hop into the `.view` namespace keeps the diff viewer's styling distinct
         // from the bare `diff.delta` scope, which is shared with the diff language
         // grammar and the VCS gutter.
-        if let Some((side, _, ref intra_line_cache, (doc_a_id, doc_b_id))) = diff_view_info {
+        if let Some((side, _, _, ref intra_line_cache, (doc_a_id, doc_b_id))) = diff_view_info {
             let intra_highlight = theme
                 .find_highlight_exact("diff.delta.view.text")
                 .or_else(|| theme.find_highlight_exact("diff.delta.view"))

--- a/helix-term/tests/integration.rs
+++ b/helix-term/tests/integration.rs
@@ -18,6 +18,8 @@ mod test {
     mod auto_pairs;
     mod command_line;
     mod commands;
+    mod diff_mode;
+    mod languages;
     mod movement;
     mod splits;
 }

--- a/helix-term/tests/test/diff_mode.rs
+++ b/helix-term/tests/test/diff_mode.rs
@@ -3,6 +3,195 @@ use super::*;
 use helix_stdx::path;
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_diff_open_applies_line_numbers_to_both_sides() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("a1\na2\na3\na4\na5\na6\n")?;
+    let file2 = helpers::temp_file_with_contents("b1\nb2\nb3\nb4\nb5\nb6\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {}:3 {}:5<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                    helpers::assert_status_not_error(&app.editor);
+
+                    let norm1 = path::normalize(file1.path());
+                    let norm2 = path::normalize(file2.path());
+
+                    let cursor_line = |target: &std::path::Path| -> usize {
+                        for (view, _focused) in app.editor.tree.views() {
+                            let doc = &app.editor.documents[&view.doc];
+                            if doc.path() == Some(&path::normalize(target)) {
+                                let head = doc.selection(view.id).primary().head;
+                                return doc.text().char_to_line(head);
+                            }
+                        }
+                        panic!("no view for {}", target.display());
+                    };
+
+                    assert_eq!(
+                        2,
+                        cursor_line(&norm1),
+                        "file1 cursor should be on line 3 (0-indexed 2)"
+                    );
+                    assert_eq!(
+                        4,
+                        cursor_line(&norm2),
+                        "file2 cursor should be on line 5 (0-indexed 4)"
+                    );
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_open_applies_line_number_on_only_one_side() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("a1\na2\na3\na4\na5\na6\n")?;
+    let file2 = helpers::temp_file_with_contents("b1\nb2\nb3\nb4\nb5\nb6\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {}:3 {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                    helpers::assert_status_not_error(&app.editor);
+
+                    let norm1 = path::normalize(file1.path());
+                    let norm2 = path::normalize(file2.path());
+
+                    let cursor_line = |target: &std::path::Path| -> usize {
+                        for (view, _focused) in app.editor.tree.views() {
+                            let doc = &app.editor.documents[&view.doc];
+                            if doc.path() == Some(&path::normalize(target)) {
+                                let head = doc.selection(view.id).primary().head;
+                                return doc.text().char_to_line(head);
+                            }
+                        }
+                        panic!("no view for {}", target.display());
+                    };
+
+                    assert_eq!(
+                        2,
+                        cursor_line(&norm1),
+                        "file1 with :3 suffix should be on line 3"
+                    );
+                    assert_eq!(
+                        0,
+                        cursor_line(&norm2),
+                        "file2 without suffix should stay at line 1"
+                    );
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_cli_flag_applies_line_numbers_to_both_sides() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("a1\na2\na3\na4\na5\na6\n")?;
+    let file2 = helpers::temp_file_with_contents("b1\nb2\nb3\nb4\nb5\nb6\n")?;
+
+    let app = helpers::AppBuilder::new()
+        .with_diff()
+        .with_file(file1.path(), Some(helix_core::Position::new(2, 0)))
+        .with_file(file2.path(), Some(helix_core::Position::new(4, 0)))
+        .build()?;
+
+    let norm1 = path::normalize(file1.path());
+    let norm2 = path::normalize(file2.path());
+
+    let cursor_line = |target: &std::path::Path| -> usize {
+        for (view, _focused) in app.editor.tree.views() {
+            let doc = &app.editor.documents[&view.doc];
+            if doc.path() == Some(&path::normalize(target)) {
+                let head = doc.selection(view.id).primary().head;
+                return doc.text().char_to_line(head);
+            }
+        }
+        panic!("no view for {}", target.display());
+    };
+
+    assert_eq!(
+        1,
+        app.editor.diff_sessions.len(),
+        "--diff should create one diff session"
+    );
+    assert_eq!(
+        2,
+        cursor_line(&norm1),
+        "file1 cursor should be on line 3 (0-indexed 2)"
+    );
+    assert_eq!(
+        4,
+        cursor_line(&norm2),
+        "file2 cursor should be on line 5 (0-indexed 4)"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_open_without_line_numbers_stays_at_start() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("a1\na2\na3\n")?;
+    let file2 = helpers::temp_file_with_contents("b1\nb2\nb3\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {} {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    helpers::assert_status_not_error(&app.editor);
+
+                    for (view, _focused) in app.editor.tree.views() {
+                        let doc = &app.editor.documents[&view.doc];
+                        if doc.path().is_none() {
+                            continue;
+                        }
+                        let head = doc.selection(view.id).primary().head;
+                        assert_eq!(
+                            0,
+                            doc.text().char_to_line(head),
+                            "unqualified :diff-open must leave both cursors at line 1 (0-indexed 0)"
+                        );
+                    }
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_diff_open_creates_session() -> anyhow::Result<()> {
     let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
     let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;

--- a/helix-term/tests/test/diff_mode.rs
+++ b/helix-term/tests/test/diff_mode.rs
@@ -77,6 +77,164 @@ async fn test_diff_this_pairs_views() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_closing_view_prunes_diff_session() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {} {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                }),
+            ),
+            // Close the focused view (:q); the diff session must be pruned.
+            (
+                Some(":q!<ret>"),
+                Some(&|app| {
+                    assert!(
+                        app.editor.diff_sessions.is_empty(),
+                        "diff session must be removed when a participant view is closed"
+                    );
+                    helpers::assert_status_not_error(&app.editor);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_closing_unrelated_view_preserves_diff_session() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+    let file3 = helpers::temp_file_with_contents("unrelated\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                // Open a diff session, then open a third unrelated split.
+                Some(&format!(
+                    ":diff-open {} {}<ret>:sp<ret>:o {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy(),
+                    file3.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                    assert_eq!(3, app.editor.tree.views().count());
+                }),
+            ),
+            // Close the unrelated view; session must survive.
+            (
+                Some(":q!<ret>"),
+                Some(&|app| {
+                    assert_eq!(
+                        1,
+                        app.editor.diff_sessions.len(),
+                        "diff session must survive closing an unrelated view"
+                    );
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_closing_diff_this_pending_view_clears_pending() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new()
+        .with_file(file1.path(), None)
+        .build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                // Open a split, mark it via :diff-this, creating pending_diff_this.
+                Some(&format!(
+                    ":sp<ret>:o {}<ret>:diff-this<ret>",
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert!(app.editor.pending_diff_this.is_some());
+                }),
+            ),
+            // Close the marked view; pending_diff_this must be cleared.
+            (
+                Some(":q!<ret>"),
+                Some(&|app| {
+                    assert!(
+                        app.editor.pending_diff_this.is_none(),
+                        "pending_diff_this must be cleared when the marked view is closed"
+                    );
+                    helpers::assert_status_not_error(&app.editor);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_closing_document_prunes_diff_session() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {} {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                }),
+            ),
+            // Close the buffer (not just the view) via :bc!
+            (
+                Some(":bc!<ret>"),
+                Some(&|app| {
+                    assert!(
+                        app.editor.diff_sessions.is_empty(),
+                        "diff session must be removed when a participant document is closed"
+                    );
+                    helpers::assert_status_not_error(&app.editor);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_diff_off_removes_session() -> anyhow::Result<()> {
     let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
     let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;

--- a/helix-term/tests/test/diff_mode.rs
+++ b/helix-term/tests/test/diff_mode.rs
@@ -1,0 +1,182 @@
+use super::*;
+
+use helix_stdx::path;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_open_creates_session() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {} {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                    assert_eq!(2, app.editor.tree.views().count());
+                    helpers::assert_status_not_error(&app.editor);
+
+                    let norm1 = path::normalize(file1.path());
+                    let norm2 = path::normalize(file2.path());
+                    assert!(app.editor.documents().any(|d| d.path() == Some(&norm1)));
+                    assert!(app.editor.documents().any(|d| d.path() == Some(&norm2)));
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_this_pairs_views() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new()
+        .with_file(file1.path(), None)
+        .build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                // Open file2 in a split, then mark it as the first diff view.
+                Some(&format!(
+                    ":sp<ret>:o {}<ret>:diff-this<ret>",
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert!(app.editor.pending_diff_this.is_some());
+                    assert_eq!(0, app.editor.diff_sessions.len());
+                    helpers::assert_status_not_error(&app.editor);
+                }),
+            ),
+            (
+                // Switch to the other view and pair it.
+                Some("<C-w>w:diff-this<ret>"),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                    assert!(app.editor.pending_diff_this.is_none());
+                    helpers::assert_status_not_error(&app.editor);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diff_off_removes_session() -> anyhow::Result<()> {
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {} {}<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    assert_eq!(1, app.editor.diff_sessions.len());
+                    assert_eq!(2, app.editor.tree.views().count());
+                }),
+            ),
+            (
+                Some(":diff-off<ret>"),
+                Some(&|app| {
+                    assert!(app.editor.diff_sessions.is_empty());
+                    // Both views remain open after the session ends.
+                    assert_eq!(2, app.editor.tree.views().count());
+                    helpers::assert_status_not_error(&app.editor);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diffget_pulls_hunk_from_partner() -> anyhow::Result<()> {
+    // left: "two", right: "TWO". After diffget from view A, left becomes "TWO".
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                // After diff-open, focus is on view B (right/file2).
+                // <C-w>w switches to view A (left/file1). j moves to the changed line.
+                Some(&format!(
+                    ":diff-open {} {}<ret><C-w>wj:diffget<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    helpers::assert_status_not_error(&app.editor);
+                    assert_eq!(1, app.editor.diff_sessions.len());
+
+                    let doc_a_id = app.editor.diff_sessions[0].doc_a();
+                    let doc_text = app.editor.documents[&doc_a_id].text().to_string();
+                    assert_eq!("one\nTWO\nthree\n", doc_text);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_diffput_pushes_hunk_to_partner() -> anyhow::Result<()> {
+    // left: "two", right: "TWO". After diffput from view A, right becomes "two".
+    let file1 = helpers::temp_file_with_contents("one\ntwo\nthree\n")?;
+    let file2 = helpers::temp_file_with_contents("one\nTWO\nthree\n")?;
+
+    let mut app = helpers::AppBuilder::new().build()?;
+
+    test_key_sequences(
+        &mut app,
+        vec![
+            (
+                Some(&format!(
+                    ":diff-open {} {}<ret><C-w>wj:diffput<ret>",
+                    file1.path().to_string_lossy(),
+                    file2.path().to_string_lossy()
+                )),
+                Some(&|app| {
+                    helpers::assert_status_not_error(&app.editor);
+                    assert_eq!(1, app.editor.diff_sessions.len());
+
+                    let doc_b_id = app.editor.diff_sessions[0].doc_b();
+                    let doc_text = app.editor.documents[&doc_b_id].text().to_string();
+                    assert_eq!("one\ntwo\nthree\n", doc_text);
+                }),
+            ),
+            (Some(":qa!<ret>"), None),
+        ],
+        true,
+    )
+    .await
+}

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -384,6 +384,13 @@ impl AppBuilder {
         self
     }
 
+    // Remove this attribute once `with_diff` is used outside the diff tests:
+    #[allow(dead_code)]
+    pub fn with_diff(mut self) -> Self {
+        self.args.diff = true;
+        self
+    }
+
     // Remove this attribute once `with_config` is used in a test:
     #[allow(dead_code)]
     pub fn with_config(mut self, mut config: Config) -> Self {

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -43,13 +43,27 @@ once_cell = "1.21"
 
 arc-swap.workspace = true
 
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
+tokio = { version = "1", features = [
+  "rt",
+  "rt-multi-thread",
+  "io-util",
+  "io-std",
+  "time",
+  "process",
+  "macros",
+  "fs",
+  "parking_lot",
+] }
 tokio-stream = "0.1"
-futures-util = { version = "0.3", features = ["std", "async-await"], default-features = false }
+futures-util = { version = "0.3", features = [
+  "std",
+  "async-await",
+], default-features = false }
 
 slotmap.workspace = true
 
 chardetng = "1.0"
+imara-diff = "0.2.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -164,9 +164,10 @@ mod external {
                 Self::XSel
             } else if binary_exists("win32yank.exe") {
                 Self::Win32Yank
-            } else if cfg!(feature = "term") {
-                Self::Termcode
             } else {
+                #[cfg(feature = "term")]
+                return Self::Termcode;
+                #[cfg(not(feature = "term"))]
                 Self::None
             }
         }

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use helix_core::text_annotations::LineAnnotation;
-use helix_core::{Position, Rope, RopeSlice};
+use helix_core::{Position, Rope, RopeSlice, Tendril, Transaction};
 use helix_vcs::Hunk;
 use imara_diff::{Algorithm, Diff, InternedInput};
 
@@ -46,6 +46,26 @@ impl DiffSession {
             doc_a,
             doc_b,
             hunks: Vec::new(),
+            version_a: -1,
+            version_b: -1,
+        }
+    }
+
+    /// Creates a session with pre-computed hunks. Useful for calling transaction helpers
+    /// when the hunk data has already been cloned out of the live session.
+    pub fn new_with_hunks(
+        view_a: ViewId,
+        view_b: ViewId,
+        doc_a: DocumentId,
+        doc_b: DocumentId,
+        hunks: Vec<Hunk>,
+    ) -> Self {
+        Self {
+            view_a,
+            view_b,
+            doc_a,
+            doc_b,
+            hunks,
             version_a: -1,
             version_b: -1,
         }
@@ -124,6 +144,115 @@ impl DiffSession {
         } else {
             None
         }
+    }
+
+    /// Returns which side of the diff session the given view is on.
+    pub fn side_for_view(&self, view_id: ViewId) -> Option<DiffSide> {
+        if view_id == self.view_a {
+            Some(DiffSide::A)
+        } else if view_id == self.view_b {
+            Some(DiffSide::B)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the partner document ID for the given document.
+    pub fn partner_doc(&self, doc_id: DocumentId) -> Option<DocumentId> {
+        if doc_id == self.doc_a {
+            Some(self.doc_b)
+        } else if doc_id == self.doc_b {
+            Some(self.doc_a)
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over hunks whose range on `side` intersects any of the given line
+    /// ranges. Line ranges are (start_line, end_line) pairs (inclusive, 0-indexed).
+    ///
+    /// For empty ranges (pure deletions on this side), a hunk matches if its start position
+    /// is at or before the end of the selection range, mirroring VCS `hunks_intersecting_line_ranges`.
+    fn hunks_intersecting<'a>(
+        &'a self,
+        line_ranges: &'a [(usize, usize)],
+        side: DiffSide,
+    ) -> impl Iterator<Item = &'a Hunk> {
+        self.hunks.iter().filter(move |h| {
+            let curr_range = match side {
+                DiffSide::A => &h.before,
+                DiffSide::B => &h.after,
+            };
+            line_ranges.iter().any(|(start, end)| {
+                if curr_range.is_empty() {
+                    // Deletion on this side: the insertion point must be at or before selection end.
+                    curr_range.start as usize <= *end
+                } else {
+                    // Standard half-open range overlap.
+                    curr_range.start as usize <= *end && curr_range.end as usize > *start
+                }
+            })
+        })
+    }
+
+    /// Build a transaction on `curr_text` that replaces content at hunks under `line_ranges`
+    /// with content from `partner_text`. This is the `:diffget` operation: pull from partner.
+    /// Returns `(transaction, number_of_changes)`.
+    pub fn build_get_transaction(
+        &self,
+        side: DiffSide,
+        line_ranges: &[(usize, usize)],
+        curr_text: &Rope,
+        partner_text: &Rope,
+    ) -> (Transaction, usize) {
+        let mut changes = 0usize;
+        let transaction = Transaction::change(
+            curr_text,
+            self.hunks_intersecting(line_ranges, side).map(|h| {
+                let (curr_range, partner_range) = match side {
+                    DiffSide::A => (&h.before, &h.after),
+                    DiffSide::B => (&h.after, &h.before),
+                };
+                changes += 1;
+                let curr_start = curr_text.line_to_char(curr_range.start as usize);
+                let curr_end = curr_text.line_to_char(curr_range.end as usize);
+                let p_start = partner_text.line_to_char(partner_range.start as usize);
+                let p_end = partner_text.line_to_char(partner_range.end as usize);
+                let text: Tendril = partner_text.slice(p_start..p_end).chunks().collect();
+                (curr_start, curr_end, (!text.is_empty()).then_some(text))
+            }),
+        );
+        (transaction, changes)
+    }
+
+    /// Build a transaction on `partner_text` that replaces content at hunks under `line_ranges`
+    /// with content from `curr_text`. This is the `:diffput` operation: push to partner.
+    /// Returns `(transaction, number_of_changes)`.
+    pub fn build_put_transaction(
+        &self,
+        side: DiffSide,
+        line_ranges: &[(usize, usize)],
+        curr_text: &Rope,
+        partner_text: &Rope,
+    ) -> (Transaction, usize) {
+        let mut changes = 0usize;
+        let transaction = Transaction::change(
+            partner_text,
+            self.hunks_intersecting(line_ranges, side).map(|h| {
+                let (curr_range, partner_range) = match side {
+                    DiffSide::A => (&h.before, &h.after),
+                    DiffSide::B => (&h.after, &h.before),
+                };
+                changes += 1;
+                let p_start = partner_text.line_to_char(partner_range.start as usize);
+                let p_end = partner_text.line_to_char(partner_range.end as usize);
+                let c_start = curr_text.line_to_char(curr_range.start as usize);
+                let c_end = curr_text.line_to_char(curr_range.end as usize);
+                let text: Tendril = curr_text.slice(c_start..c_end).chunks().collect();
+                (p_start, p_end, (!text.is_empty()).then_some(text))
+            }),
+        );
+        (transaction, changes)
     }
 }
 
@@ -602,5 +731,79 @@ mod tests {
             assert_eq!(align_a.filler_lines_at(line), 0);
             assert_eq!(align_b.filler_lines_at(line), 0);
         }
+    }
+
+    // --- build_get_transaction / build_put_transaction tests ---
+
+    fn apply_tx(rope: &Rope, tx: Transaction) -> Rope {
+        let mut result = rope.clone();
+        tx.apply(&mut result);
+        result
+    }
+
+    #[test]
+    fn diffget_replaces_hunk_with_partner_content() {
+        let mut session = make_session();
+        let rope_a = Rope::from("line1\nold_content\nline3\n");
+        let rope_b = Rope::from("line1\nnew_content\nline3\n");
+        session.compute_hunks(&rope_a, &rope_b);
+
+        // Cursor on line 1 (old_content line) in doc_a
+        let line_ranges = vec![(1usize, 1usize)];
+        let (tx, changes) =
+            session.build_get_transaction(DiffSide::A, &line_ranges, &rope_a, &rope_b);
+
+        assert_eq!(changes, 1);
+        assert_eq!(apply_tx(&rope_a, tx), rope_b);
+    }
+
+    #[test]
+    fn diffput_replaces_partner_hunk_with_current_content() {
+        let mut session = make_session();
+        let rope_a = Rope::from("line1\nold_content\nline3\n");
+        let rope_b = Rope::from("line1\nnew_content\nline3\n");
+        session.compute_hunks(&rope_a, &rope_b);
+
+        // Cursor on line 1 (old_content line) in doc_a: push doc_a's content to doc_b
+        let line_ranges = vec![(1usize, 1usize)];
+        let (tx, changes) =
+            session.build_put_transaction(DiffSide::A, &line_ranges, &rope_a, &rope_b);
+
+        assert_eq!(changes, 1);
+        assert_eq!(apply_tx(&rope_b, tx), rope_a);
+    }
+
+    #[test]
+    fn diffget_no_change_when_no_intersecting_hunks() {
+        let mut session = make_session();
+        let rope_a = Rope::from("aaa\nbbb\nccc\nddd\n");
+        let rope_b = Rope::from("aaa\nBBB\nccc\nDDD\n");
+        session.compute_hunks(&rope_a, &rope_b);
+
+        // Cursor on line 2 (ccc) which is unchanged
+        let line_ranges = vec![(2usize, 2usize)];
+        let (_, changes) =
+            session.build_get_transaction(DiffSide::A, &line_ranges, &rope_a, &rope_b);
+
+        assert_eq!(changes, 0);
+    }
+
+    #[test]
+    fn diffget_handles_pure_deletion_from_side_b() {
+        // doc_a has line2 that doc_b is missing; hunk: before=1..2, after=1..1 (empty in B)
+        let mut session = make_session();
+        let rope_a = Rope::from("line1\nline2\nline3\n");
+        let rope_b = Rope::from("line1\nline3\n");
+        session.compute_hunks(&rope_a, &rope_b);
+
+        // On side B, the deletion hunk has after.start=1 (between line1 and line3).
+        // Cursor on line 1 (line3) in doc_b: after.start=1 <= end_line=1, so it matches.
+        let line_ranges = vec![(1usize, 1usize)];
+        let (tx, changes) =
+            session.build_get_transaction(DiffSide::B, &line_ranges, &rope_b, &rope_a);
+
+        assert_eq!(changes, 1);
+        // After diffget on side B: doc_b gains line2 back from doc_a.
+        assert_eq!(apply_tx(&rope_b, tx), rope_a);
     }
 }

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -52,6 +52,11 @@ pub struct DiffSession {
     /// Shared hunk list. Stored as Arc so callers can take a cheap reference-counted
     /// snapshot for closures and annotations without cloning the full Vec each frame.
     hunks: Arc<Vec<Hunk>>,
+    /// Character-level diff results cached per hunk, parallel to `hunks`.
+    /// Stored as Arc so render closures can take a cheap snapshot without cloning.
+    /// Populated in `compute_hunks` and replaced on each recomputation.
+    /// Pure insertions/deletions store empty vecs (no character diff needed).
+    intra_line_cache: Arc<Vec<(Vec<InlineChange>, Vec<InlineChange>)>>,
     version_a: Option<i32>,
     version_b: Option<i32>,
 }
@@ -64,6 +69,7 @@ impl DiffSession {
             doc_a,
             doc_b,
             hunks: Arc::new(Vec::new()),
+            intra_line_cache: Arc::new(Vec::new()),
             version_a: None,
             version_b: None,
         }
@@ -121,6 +127,13 @@ impl DiffSession {
         Arc::clone(&self.hunks)
     }
 
+    /// Returns a cheap reference-counted snapshot of the intra-line cache.
+    /// Render closures should use this to capture the cache without cloning it,
+    /// mirroring the `hunks_arc` pattern.
+    pub fn intra_line_cache_arc(&self) -> Arc<Vec<(Vec<InlineChange>, Vec<InlineChange>)>> {
+        Arc::clone(&self.intra_line_cache)
+    }
+
     /// Returns true if the given view is part of this diff session.
     pub fn contains_view(&self, view_id: ViewId) -> bool {
         self.view_a == view_id || self.view_b == view_id
@@ -133,6 +146,7 @@ impl DiffSession {
 
     /// Computes line-level hunks between two Ropes using the Histogram diff algorithm.
     /// `rope_a` corresponds to the left/before side, `rope_b` to the right/after side.
+    /// Also rebuilds the intra-line character diff cache, indexed parallel to `hunks`.
     pub fn compute_hunks(&mut self, rope_a: &Rope, rope_b: &Rope) {
         let input = InternedInput::new(RopeLines(rope_a.slice(..)), RopeLines(rope_b.slice(..)));
         let mut diff = Diff::compute(Algorithm::Histogram, &input);
@@ -144,6 +158,30 @@ impl DiffSession {
             }),
         );
         self.hunks = Arc::new(diff.hunks().collect());
+        // Rebuild cache parallel to hunks. Pure insertions/deletions get empty entries
+        // (nothing to diff at the character level when one side is empty).
+        self.intra_line_cache = Arc::new(
+            self.hunks
+                .iter()
+                .map(|hunk| {
+                    if hunk.before.is_empty() || hunk.after.is_empty() {
+                        (Vec::new(), Vec::new())
+                    } else {
+                        intra_line_changes(rope_a, rope_b, hunk)
+                    }
+                })
+                .collect(),
+        );
+    }
+
+    /// Returns the cached intra-line character diff for the hunk at `index`,
+    /// or `None` if the index is out of range.
+    /// The tuple is `(changes_a, changes_b)` as produced by `intra_line_changes`.
+    pub fn intra_line_changes_for(
+        &self,
+        index: usize,
+    ) -> Option<&(Vec<InlineChange>, Vec<InlineChange>)> {
+        self.intra_line_cache.get(index)
     }
 
     /// Returns the documents in this session.
@@ -271,7 +309,7 @@ pub fn build_put_transaction(
 }
 
 /// A per-line column range that should be highlighted for intra-line changes.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct InlineChange {
     pub doc_line: usize,
     pub col_start: usize,
@@ -841,5 +879,73 @@ mod tests {
         let session = DiffSession::new(view_a, view_b, doc_a, doc_b);
 
         assert!(!session.contains_doc(unrelated));
+    }
+
+    #[test]
+    fn intra_line_cache_is_populated_after_compute_hunks() {
+        let (view_a, view_b) = make_view_ids();
+        let mut session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        let rope_a = Rope::from("line1\nold\nline3\n");
+        let rope_b = Rope::from("line1\nnew\nline3\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        // One modified hunk; cache entry must be present.
+        assert_eq!(session.hunks().len(), 1);
+        assert!(session.intra_line_changes_for(0).is_some());
+    }
+
+    #[test]
+    fn intra_line_cache_matches_free_function() {
+        let (view_a, view_b) = make_view_ids();
+        let mut session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        let rope_a = Rope::from("line1\nold\nline3\n");
+        let rope_b = Rope::from("line1\nnew\nline3\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        let hunk = &session.hunks()[0];
+        let expected = intra_line_changes(&rope_a, &rope_b, hunk);
+        let cached = session.intra_line_changes_for(0).unwrap();
+
+        assert_eq!(cached.0, expected.0);
+        assert_eq!(cached.1, expected.1);
+    }
+
+    #[test]
+    fn intra_line_cache_is_empty_for_pure_addition() {
+        let (view_a, view_b) = make_view_ids();
+        let mut session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        let rope_a = Rope::from("line1\nline3\n");
+        let rope_b = Rope::from("line1\nnew\nline3\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        // Pure insertion: before is empty, no character diff to compute.
+        assert_eq!(session.hunks().len(), 1);
+        let cached = session.intra_line_changes_for(0).unwrap();
+        assert!(cached.0.is_empty());
+        assert!(cached.1.is_empty());
+    }
+
+    #[test]
+    fn intra_line_cache_refreshes_on_update_if_changed() {
+        let (view_a, view_b) = make_view_ids();
+        let mut session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        let rope_a = Rope::from("line1\nold\nline3\n");
+        let rope_b_v1 = Rope::from("line1\nnew\nline3\n");
+        let rope_b_v2 = Rope::from("line1\ncompletely different\nline3\n");
+
+        session.compute_hunks(&rope_a, &rope_b_v1);
+        let cached_v1 = session.intra_line_changes_for(0).unwrap().clone();
+
+        // Simulate a document edit: version changes, triggering recomputation.
+        session.update_if_changed(1, 1, &rope_a, &rope_b_v2);
+        let cached_v2 = session.intra_line_changes_for(0).unwrap();
+
+        assert_ne!(
+            cached_v1.1, cached_v2.1,
+            "cache must reflect updated content"
+        );
     }
 }

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -23,21 +23,85 @@ impl<'a> imara_diff::TokenSource for RopeLines<'a> {
     }
 }
 
-/// A `TokenSource` that yields individual chars, giving char-level token indices
-/// in imara-diff hunks. Used by `intra_line_changes` for per-character diff.
-struct CharSlice<'a>(&'a [char]);
+/// Iterator that yields word-level tokens from a string slice.
+/// Alphanumeric + underscore runs are emitted as a single token; all other chars
+/// (whitespace, punctuation, newlines) are emitted individually. This gives
+/// coarser intra-line diffs than char-level: only whole words are marked as changed.
+struct WordTokenIter<'a> {
+    text: &'a str,
+    byte_pos: usize,
+}
 
-impl<'a> TokenSource for CharSlice<'a> {
-    type Token = char;
-    type Tokenizer = std::iter::Copied<std::slice::Iter<'a, char>>;
+impl<'a> Iterator for WordTokenIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.byte_pos >= self.text.len() {
+            return None;
+        }
+        let rest = &self.text[self.byte_pos..];
+        let first = rest.chars().next()?;
+        let end_byte = if first.is_alphanumeric() || first == '_' {
+            rest.char_indices()
+                .take_while(|(_, c)| c.is_alphanumeric() || *c == '_')
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(first.len_utf8())
+        } else {
+            first.len_utf8()
+        };
+        let token = &rest[..end_byte];
+        self.byte_pos += end_byte;
+        Some(token)
+    }
+}
+
+/// A `TokenSource` that yields word-level tokens from a `&str`.
+/// Used by `intra_line_changes` so the Myers diff operates on whole words
+/// rather than individual characters.
+struct WordSlice<'a>(&'a str);
+
+impl<'a> TokenSource for WordSlice<'a> {
+    type Token = &'a str;
+    type Tokenizer = WordTokenIter<'a>;
 
     fn tokenize(&self) -> Self::Tokenizer {
-        self.0.iter().copied()
+        WordTokenIter {
+            text: self.0,
+            byte_pos: 0,
+        }
     }
 
     fn estimate_tokens(&self) -> u32 {
-        self.0.len() as u32
+        (self.0.len() / 4).max(1) as u32
     }
+}
+
+/// Returns the char-index (within `text`) at which each word token starts.
+/// `result[i]` is the char start of token `i`; `result.len()` equals the token count.
+/// If `tok < result.len()`, the token starts at `result[tok]` and ends at
+/// `result[tok + 1]` (or at `text.chars().count()` for the last token).
+fn word_token_char_starts(text: &str) -> Vec<usize> {
+    let mut starts = Vec::new();
+    let mut char_pos = 0usize;
+    let mut byte_pos = 0usize;
+    while byte_pos < text.len() {
+        let rest = &text[byte_pos..];
+        let first = rest.chars().next().unwrap();
+        starts.push(char_pos);
+        let end_byte = if first.is_alphanumeric() || first == '_' {
+            rest.char_indices()
+                .take_while(|(_, c)| c.is_alphanumeric() || *c == '_')
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(first.len_utf8())
+        } else {
+            first.len_utf8()
+        };
+        char_pos += rest[..end_byte].chars().count();
+        byte_pos += end_byte;
+    }
+    starts
 }
 
 /// A diff session pairs two views for side-by-side diff comparison.
@@ -52,7 +116,7 @@ pub struct DiffSession {
     /// Shared hunk list. Stored as Arc so callers can take a cheap reference-counted
     /// snapshot for closures and annotations without cloning the full Vec each frame.
     hunks: Arc<Vec<Hunk>>,
-    /// Character-level diff results cached per hunk, parallel to `hunks`.
+    /// Word-level intra-line diff results cached per hunk, parallel to `hunks`.
     /// Stored as Arc so render closures can take a cheap snapshot without cloning.
     /// Populated in `compute_hunks` and replaced on each recomputation.
     /// Pure insertions/deletions store empty vecs (no character diff needed).
@@ -324,8 +388,10 @@ impl InlineChange {
     }
 }
 
-/// Compute character-level diff for a single hunk.
-/// Returns per-line column ranges for each side indicating which characters changed.
+/// Compute word-level intra-line diff for a single hunk.
+/// Returns per-line column ranges for each side indicating which words (or
+/// non-word chars) changed. Whole alphanumeric+underscore runs are treated as
+/// one token, so only the changed words are highlighted rather than individual chars.
 pub fn intra_line_changes(
     rope_a: &Rope,
     rope_b: &Rope,
@@ -339,14 +405,24 @@ pub fn intra_line_changes(
     let text_a: String = rope_a.slice(a_start..a_end).into();
     let text_b: String = rope_b.slice(b_start..b_end).into();
 
-    // Use char-level tokenization so hunk offsets are char indices, not line indices.
-    let chars_a: Vec<char> = text_a.chars().collect();
-    let chars_b: Vec<char> = text_b.chars().collect();
-    let input = InternedInput::new(CharSlice(&chars_a), CharSlice(&chars_b));
+    // Precompute char-start of each word token so token indices can be mapped back
+    // to char-column ranges after the Myers diff produces token-level hunks.
+    let tok_starts_a = word_token_char_starts(&text_a);
+    let tok_starts_b = word_token_char_starts(&text_b);
+    let total_chars_a = text_a.chars().count();
+    let total_chars_b = text_b.chars().count();
+
+    let input = InternedInput::new(WordSlice(&text_a), WordSlice(&text_b));
     let diff = Diff::compute(Algorithm::Myers, &input);
 
-    let char_to_line_col = |base_char: usize, offset: u32, rope: &Rope| -> (usize, usize) {
-        let char_idx = base_char + offset as usize;
+    // Convert a token index into a char offset within the hunk text.
+    // `tok` == number of tokens means "end of text".
+    let tok_to_char = |starts: &[usize], total: usize, tok: u32| -> usize {
+        *starts.get(tok as usize).unwrap_or(&total)
+    };
+
+    let char_to_line_col = |base_char: usize, char_offset: usize, rope: &Rope| -> (usize, usize) {
+        let char_idx = base_char + char_offset;
         let line = rope.char_to_line(char_idx);
         let line_start = rope.line_to_char(line);
         (line, char_idx - line_start)
@@ -355,10 +431,12 @@ pub fn intra_line_changes(
     let mut changes_a = Vec::new();
     let mut changes_b = Vec::new();
 
-    for char_hunk in diff.hunks() {
-        if !char_hunk.before.is_empty() {
-            let (start_line, start_col) = char_to_line_col(a_start, char_hunk.before.start, rope_a);
-            let (end_line, end_col) = char_to_line_col(a_start, char_hunk.before.end, rope_a);
+    for tok_hunk in diff.hunks() {
+        if !tok_hunk.before.is_empty() {
+            let sc = tok_to_char(&tok_starts_a, total_chars_a, tok_hunk.before.start);
+            let ec = tok_to_char(&tok_starts_a, total_chars_a, tok_hunk.before.end);
+            let (start_line, start_col) = char_to_line_col(a_start, sc, rope_a);
+            let (end_line, end_col) = char_to_line_col(a_start, ec, rope_a);
             // Split across lines if the change spans multiple lines
             for line in start_line..=end_line {
                 let cs = if line == start_line { start_col } else { 0 };
@@ -374,9 +452,11 @@ pub fn intra_line_changes(
                 });
             }
         }
-        if !char_hunk.after.is_empty() {
-            let (start_line, start_col) = char_to_line_col(b_start, char_hunk.after.start, rope_b);
-            let (end_line, end_col) = char_to_line_col(b_start, char_hunk.after.end, rope_b);
+        if !tok_hunk.after.is_empty() {
+            let sc = tok_to_char(&tok_starts_b, total_chars_b, tok_hunk.after.start);
+            let ec = tok_to_char(&tok_starts_b, total_chars_b, tok_hunk.after.end);
+            let (start_line, start_col) = char_to_line_col(b_start, sc, rope_b);
+            let (end_line, end_col) = char_to_line_col(b_start, ec, rope_b);
             for line in start_line..=end_line {
                 let cs = if line == start_line { start_col } else { 0 };
                 let ce = if line == end_line {
@@ -946,6 +1026,51 @@ mod tests {
         assert_ne!(
             cached_v1.1, cached_v2.1,
             "cache must reflect updated content"
+        );
+    }
+
+    #[test]
+    fn intra_line_diff_uses_word_granularity() {
+        // "hello world\n" vs "hello earth\n": only the word "world"/"earth" differs.
+        // Word-level diff should highlight exactly col 6..11 on each side,
+        // not multiple sub-word spans as character-level diff would produce.
+        let rope_a = Rope::from("hello world\n");
+        let rope_b = Rope::from("hello earth\n");
+        let hunk = helix_vcs::Hunk {
+            before: 0..1,
+            after: 0..1,
+        };
+        let (changes_a, changes_b) = intra_line_changes(&rope_a, &rope_b, &hunk);
+
+        assert_eq!(
+            changes_a.len(),
+            1,
+            "expected one word-level change on A side"
+        );
+        assert_eq!(
+            changes_b.len(),
+            1,
+            "expected one word-level change on B side"
+        );
+
+        assert_eq!(changes_a[0].doc_line, 0);
+        assert_eq!(
+            changes_a[0].col_start, 6,
+            "change should start at 'w' of 'world'"
+        );
+        assert_eq!(
+            changes_a[0].col_end, 11,
+            "change should end after 'd' of 'world'"
+        );
+
+        assert_eq!(changes_b[0].doc_line, 0);
+        assert_eq!(
+            changes_b[0].col_start, 6,
+            "change should start at 'e' of 'earth'"
+        );
+        assert_eq!(
+            changes_b[0].col_end, 11,
+            "change should end after 'h' of 'earth'"
         );
     }
 }

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -1,0 +1,606 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use helix_core::text_annotations::LineAnnotation;
+use helix_core::{Position, Rope, RopeSlice};
+use helix_vcs::Hunk;
+use imara_diff::{Algorithm, Diff, InternedInput};
+
+use crate::{DocumentId, ViewId};
+
+struct RopeLines<'a>(RopeSlice<'a>);
+
+impl<'a> imara_diff::TokenSource for RopeLines<'a> {
+    type Token = RopeSlice<'a>;
+    type Tokenizer = helix_core::ropey::iter::Lines<'a>;
+
+    fn tokenize(&self) -> Self::Tokenizer {
+        self.0.lines()
+    }
+
+    fn estimate_tokens(&self) -> u32 {
+        self.0.len_lines() as u32
+    }
+}
+
+/// A diff session pairs two views for side-by-side diff comparison.
+/// It holds the computed hunks between their documents and coordinates
+/// scroll synchronization and alignment.
+#[derive(Debug)]
+pub struct DiffSession {
+    view_a: ViewId,
+    view_b: ViewId,
+    doc_a: DocumentId,
+    doc_b: DocumentId,
+    hunks: Vec<Hunk>,
+    /// Tracked document versions for change detection
+    version_a: i32,
+    version_b: i32,
+}
+
+impl DiffSession {
+    pub fn new(view_a: ViewId, view_b: ViewId, doc_a: DocumentId, doc_b: DocumentId) -> Self {
+        Self {
+            view_a,
+            view_b,
+            doc_a,
+            doc_b,
+            hunks: Vec::new(),
+            version_a: -1,
+            version_b: -1,
+        }
+    }
+
+    /// Recompute hunks if either document has changed since the last computation.
+    /// Returns true if hunks were recomputed.
+    pub fn update_if_changed(
+        &mut self,
+        version_a: i32,
+        version_b: i32,
+        rope_a: &Rope,
+        rope_b: &Rope,
+    ) -> bool {
+        if version_a == self.version_a && version_b == self.version_b {
+            return false;
+        }
+        self.version_a = version_a;
+        self.version_b = version_b;
+        self.compute_hunks(rope_a, rope_b);
+        true
+    }
+
+    pub fn view_a(&self) -> ViewId {
+        self.view_a
+    }
+
+    pub fn view_b(&self) -> ViewId {
+        self.view_b
+    }
+
+    pub fn doc_a(&self) -> DocumentId {
+        self.doc_a
+    }
+
+    pub fn doc_b(&self) -> DocumentId {
+        self.doc_b
+    }
+
+    pub fn hunks(&self) -> &[Hunk] {
+        &self.hunks
+    }
+
+    /// Returns true if the given view is part of this diff session.
+    pub fn contains_view(&self, view_id: ViewId) -> bool {
+        self.view_a == view_id || self.view_b == view_id
+    }
+
+    /// Computes line-level hunks between two Ropes using the Histogram diff algorithm.
+    /// `rope_a` corresponds to the left/before side, `rope_b` to the right/after side.
+    pub fn compute_hunks(&mut self, rope_a: &Rope, rope_b: &Rope) {
+        self.hunks.clear();
+        let input = InternedInput::new(RopeLines(rope_a.slice(..)), RopeLines(rope_b.slice(..)));
+        let mut diff = Diff::compute(Algorithm::Histogram, &input);
+        diff.postprocess_with(
+            &input.before,
+            &input.after,
+            imara_diff::IndentHeuristic::new(|token| {
+                imara_diff::IndentLevel::for_ascii_line(input.interner[token].bytes(), 4)
+            }),
+        );
+        self.hunks.extend(diff.hunks());
+    }
+
+    /// Returns the documents in this session.
+    pub fn doc_ids(&self) -> (DocumentId, DocumentId) {
+        (self.doc_a, self.doc_b)
+    }
+
+    /// Returns the partner view ID for the given view, if it belongs to this session.
+    pub fn partner_view(&self, view_id: ViewId) -> Option<ViewId> {
+        if view_id == self.view_a {
+            Some(self.view_b)
+        } else if view_id == self.view_b {
+            Some(self.view_a)
+        } else {
+            None
+        }
+    }
+}
+
+/// A per-line column range that should be highlighted for intra-line changes.
+#[derive(Debug, Clone)]
+pub struct InlineChange {
+    pub doc_line: usize,
+    pub col_start: usize,
+    pub col_end: usize,
+}
+
+impl InlineChange {
+    /// Convert to an absolute char range in the given rope.
+    pub fn to_char_range(&self, rope: &Rope) -> std::ops::Range<usize> {
+        let line_start = rope.line_to_char(self.doc_line);
+        (line_start + self.col_start)..(line_start + self.col_end)
+    }
+}
+
+/// Compute character-level diff for a single hunk.
+/// Returns per-line column ranges for each side indicating which characters changed.
+pub fn intra_line_changes(
+    rope_a: &Rope,
+    rope_b: &Rope,
+    hunk: &Hunk,
+) -> (Vec<InlineChange>, Vec<InlineChange>) {
+    let a_start = rope_a.line_to_char(hunk.before.start as usize);
+    let a_end = rope_a.line_to_char(hunk.before.end as usize);
+    let b_start = rope_b.line_to_char(hunk.after.start as usize);
+    let b_end = rope_b.line_to_char(hunk.after.end as usize);
+
+    let text_a: String = rope_a.slice(a_start..a_end).into();
+    let text_b: String = rope_b.slice(b_start..b_end).into();
+
+    let input = InternedInput::new(text_a.as_str(), text_b.as_str());
+    let diff = Diff::compute(Algorithm::Myers, &input);
+
+    let char_to_line_col = |base_char: usize, offset: u32, rope: &Rope| -> (usize, usize) {
+        let char_idx = base_char + offset as usize;
+        let line = rope.char_to_line(char_idx);
+        let line_start = rope.line_to_char(line);
+        (line, char_idx - line_start)
+    };
+
+    let mut changes_a = Vec::new();
+    let mut changes_b = Vec::new();
+
+    for char_hunk in diff.hunks() {
+        if !char_hunk.before.is_empty() {
+            let (start_line, start_col) = char_to_line_col(a_start, char_hunk.before.start, rope_a);
+            let (end_line, end_col) = char_to_line_col(a_start, char_hunk.before.end, rope_a);
+            // Split across lines if the change spans multiple lines
+            for line in start_line..=end_line {
+                let cs = if line == start_line { start_col } else { 0 };
+                let ce = if line == end_line {
+                    end_col
+                } else {
+                    rope_a.line(line).len_chars()
+                };
+                changes_a.push(InlineChange {
+                    doc_line: line,
+                    col_start: cs,
+                    col_end: ce,
+                });
+            }
+        }
+        if !char_hunk.after.is_empty() {
+            let (start_line, start_col) = char_to_line_col(b_start, char_hunk.after.start, rope_b);
+            let (end_line, end_col) = char_to_line_col(b_start, char_hunk.after.end, rope_b);
+            for line in start_line..=end_line {
+                let cs = if line == start_line { start_col } else { 0 };
+                let ce = if line == end_line {
+                    end_col
+                } else {
+                    rope_b.line(line).len_chars()
+                };
+                changes_b.push(InlineChange {
+                    doc_line: line,
+                    col_start: cs,
+                    col_end: ce,
+                });
+            }
+        }
+    }
+
+    (changes_a, changes_b)
+}
+
+/// Which side of a diff session this alignment annotation is for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiffSide {
+    /// The left/before side (doc_a)
+    A,
+    /// The right/after side (doc_b)
+    B,
+}
+
+/// A `LineAnnotation` that inserts virtual filler lines to keep two
+/// side-by-side diff panes visually aligned at hunk boundaries.
+///
+/// Each side of the diff gets its own `DiffAlignment`. When the "other" side
+/// has more lines in a hunk, this annotation pads with filler lines so both
+/// panes show the same visual height for every hunk.
+pub struct DiffAlignment {
+    hunks: Arc<Vec<Hunk>>,
+    side: DiffSide,
+    cursor: usize,
+}
+
+impl DiffAlignment {
+    pub fn new(hunks: Arc<Vec<Hunk>>, side: DiffSide) -> Self {
+        Self {
+            hunks,
+            side,
+            cursor: 0,
+        }
+    }
+
+    /// Returns (my_range, other_range) for the hunk based on our side.
+    fn ranges_for(&self, hunk: &Hunk) -> (Range<u32>, Range<u32>) {
+        match self.side {
+            DiffSide::A => (hunk.before.clone(), hunk.after.clone()),
+            DiffSide::B => (hunk.after.clone(), hunk.before.clone()),
+        }
+    }
+
+    /// Compute how many filler lines to insert after `doc_line`.
+    /// Returns 0 if no filler is needed at this line.
+    pub fn filler_lines_at(&mut self, doc_line: usize) -> usize {
+        // Advance cursor past hunks that ended before this line
+        while self.cursor < self.hunks.len() {
+            let (my_range, _) = self.ranges_for(&self.hunks[self.cursor]);
+            let trigger = if my_range.is_empty() {
+                // Pure insertion/deletion on our side: trigger at the line
+                // just before the insertion point (or 0 if at start)
+                my_range.start.saturating_sub(1) as usize
+            } else {
+                (my_range.end - 1) as usize
+            };
+            if trigger < doc_line {
+                self.cursor += 1;
+            } else {
+                break;
+            }
+        }
+
+        if self.cursor >= self.hunks.len() {
+            return 0;
+        }
+
+        let (my_range, other_range) = self.ranges_for(&self.hunks[self.cursor]);
+
+        let trigger = if my_range.is_empty() {
+            my_range.start.saturating_sub(1) as usize
+        } else {
+            (my_range.end - 1) as usize
+        };
+
+        if doc_line == trigger {
+            self.cursor += 1;
+            let filler =
+                (other_range.end - other_range.start).saturating_sub(my_range.end - my_range.start);
+            filler as usize
+        } else {
+            0
+        }
+    }
+}
+
+impl LineAnnotation for DiffAlignment {
+    fn reset_pos(&mut self, _char_idx: usize) -> usize {
+        self.cursor = 0;
+        usize::MAX
+    }
+
+    fn insert_virtual_lines(
+        &mut self,
+        _line_end_char_idx: usize,
+        _line_end_visual_pos: Position,
+        doc_line: usize,
+    ) -> Position {
+        let filler = self.filler_lines_at(doc_line);
+        Position::new(filler, 0)
+    }
+}
+
+impl std::fmt::Debug for DiffAlignment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiffAlignment")
+            .field("side", &self.side)
+            .field("cursor", &self.cursor)
+            .field("num_hunks", &self.hunks.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::num::NonZeroUsize;
+
+    fn make_view_ids() -> (ViewId, ViewId) {
+        let mut sm: slotmap::SlotMap<ViewId, ()> = slotmap::SlotMap::with_key();
+        let a = sm.insert(());
+        let b = sm.insert(());
+        (a, b)
+    }
+
+    fn make_doc_id(n: usize) -> DocumentId {
+        DocumentId(NonZeroUsize::new(n).unwrap())
+    }
+
+    #[test]
+    fn stores_paired_view_ids() {
+        let (view_a, view_b) = make_view_ids();
+        let doc_a = make_doc_id(1);
+        let doc_b = make_doc_id(2);
+
+        let session = DiffSession::new(view_a, view_b, doc_a, doc_b);
+
+        assert_eq!(session.view_a(), view_a);
+        assert_eq!(session.view_b(), view_b);
+        assert_eq!(session.doc_a(), doc_a);
+        assert_eq!(session.doc_b(), doc_b);
+    }
+
+    #[test]
+    fn contains_view_returns_true_for_session_members() {
+        let (view_a, view_b) = make_view_ids();
+        let session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+
+        assert!(session.contains_view(view_a));
+        assert!(session.contains_view(view_b));
+    }
+
+    #[test]
+    fn contains_view_returns_false_for_non_members() {
+        let mut sm: slotmap::SlotMap<ViewId, ()> = slotmap::SlotMap::with_key();
+        let view_a = sm.insert(());
+        let view_b = sm.insert(());
+        let view_c = sm.insert(());
+
+        let session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        assert!(!session.contains_view(view_c));
+    }
+
+    #[test]
+    fn partner_view_returns_other_side() {
+        let (view_a, view_b) = make_view_ids();
+        let session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+
+        assert_eq!(session.partner_view(view_a), Some(view_b));
+        assert_eq!(session.partner_view(view_b), Some(view_a));
+    }
+
+    #[test]
+    fn partner_view_returns_none_for_non_member() {
+        let mut sm: slotmap::SlotMap<ViewId, ()> = slotmap::SlotMap::with_key();
+        let view_a = sm.insert(());
+        let view_b = sm.insert(());
+        let view_c = sm.insert(());
+
+        let session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        assert_eq!(session.partner_view(view_c), None);
+    }
+
+    #[test]
+    fn new_session_has_no_hunks() {
+        let (view_a, view_b) = make_view_ids();
+        let session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+
+        assert!(session.hunks().is_empty());
+    }
+
+    fn make_session() -> DiffSession {
+        let (view_a, view_b) = make_view_ids();
+        DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2))
+    }
+
+    #[test]
+    fn compute_hunks_detects_addition() {
+        let mut session = make_session();
+        let rope_a = Rope::from("line1\nline2\nline3\n");
+        let rope_b = Rope::from("line1\nline2\ninserted\nline3\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        assert_eq!(session.hunks().len(), 1);
+        let hunk = &session.hunks()[0];
+        // "inserted" is added after line2 (line index 2) in rope_b
+        assert_eq!(hunk.before.start, 2);
+        assert_eq!(hunk.before.end, 2); // pure insertion: empty range in before
+        assert_eq!(hunk.after.start, 2);
+        assert_eq!(hunk.after.end, 3); // one line added
+    }
+
+    #[test]
+    fn compute_hunks_detects_deletion() {
+        let mut session = make_session();
+        let rope_a = Rope::from("line1\nline2\nline3\nline4\n");
+        let rope_b = Rope::from("line1\nline4\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        assert_eq!(session.hunks().len(), 1);
+        let hunk = &session.hunks()[0];
+        assert_eq!(hunk.before.start, 1);
+        assert_eq!(hunk.before.end, 3); // lines 2 and 3 removed
+        assert_eq!(hunk.after.start, 1);
+        assert_eq!(hunk.after.end, 1); // pure deletion: empty range in after
+    }
+
+    #[test]
+    fn compute_hunks_detects_modification() {
+        let mut session = make_session();
+        let rope_a = Rope::from("line1\nold\nline3\n");
+        let rope_b = Rope::from("line1\nnew\nline3\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        assert_eq!(session.hunks().len(), 1);
+        let hunk = &session.hunks()[0];
+        assert_eq!(hunk.before.start, 1);
+        assert_eq!(hunk.before.end, 2);
+        assert_eq!(hunk.after.start, 1);
+        assert_eq!(hunk.after.end, 2);
+    }
+
+    #[test]
+    fn compute_hunks_identical_files_produces_no_hunks() {
+        let mut session = make_session();
+        let text = "line1\nline2\nline3\n";
+        let rope_a = Rope::from(text);
+        let rope_b = Rope::from(text);
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        assert!(session.hunks().is_empty());
+    }
+
+    #[test]
+    fn compute_hunks_multiple_changes() {
+        let mut session = make_session();
+        let rope_a = Rope::from("aaa\nbbb\nccc\nddd\neee\n");
+        let rope_b = Rope::from("aaa\nBBB\nccc\nddd\nEEE\n");
+
+        session.compute_hunks(&rope_a, &rope_b);
+
+        assert_eq!(session.hunks().len(), 2);
+        // First hunk: bbb -> BBB
+        assert_eq!(session.hunks()[0].before, 1..2);
+        assert_eq!(session.hunks()[0].after, 1..2);
+        // Second hunk: eee -> EEE
+        assert_eq!(session.hunks()[1].before, 4..5);
+        assert_eq!(session.hunks()[1].after, 4..5);
+    }
+
+    #[test]
+    fn compute_hunks_recomputes_on_new_input() {
+        let mut session = make_session();
+
+        let rope_a = Rope::from("aaa\nbbb\n");
+        let rope_b = Rope::from("aaa\nccc\n");
+        session.compute_hunks(&rope_a, &rope_b);
+        assert_eq!(session.hunks().len(), 1);
+
+        // Recompute with identical content: hunks should clear
+        session.compute_hunks(&rope_a, &rope_a);
+        assert!(session.hunks().is_empty());
+    }
+
+    // --- DiffAlignment tests ---
+
+    fn make_hunks(pairs: &[(Range<u32>, Range<u32>)]) -> Arc<Vec<Hunk>> {
+        Arc::new(
+            pairs
+                .iter()
+                .map(|(b, a)| Hunk {
+                    before: b.clone(),
+                    after: a.clone(),
+                })
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn alignment_identical_files_no_fillers() {
+        let hunks = make_hunks(&[]);
+        let mut align = DiffAlignment::new(hunks, DiffSide::A);
+
+        for line in 0..5 {
+            assert_eq!(align.filler_lines_at(line), 0);
+        }
+    }
+
+    #[test]
+    fn alignment_addition_pads_side_a() {
+        // before: 5 lines, after: 8 lines (3 added at lines 2..5 on after)
+        // Hunk: before 2..2 (pure insertion), after 2..5
+        let hunks = make_hunks(&[(2..2, 2..5)]);
+        let mut align = DiffAlignment::new(hunks, DiffSide::A);
+
+        // Side A has 0 lines in hunk, other side has 3
+        // Trigger at doc_line = max(0, 2-1) = 1
+        assert_eq!(align.filler_lines_at(0), 0);
+        assert_eq!(align.filler_lines_at(1), 3); // 3 fillers for side A
+        assert_eq!(align.filler_lines_at(2), 0);
+    }
+
+    #[test]
+    fn alignment_addition_no_pad_on_longer_side() {
+        // Same hunk but from side B's perspective: B has the 3 added lines
+        let hunks = make_hunks(&[(2..2, 2..5)]);
+        let mut align = DiffAlignment::new(hunks, DiffSide::B);
+
+        // Side B has 3 lines, other side has 0. No filler needed.
+        for line in 0..8 {
+            assert_eq!(align.filler_lines_at(line), 0);
+        }
+    }
+
+    #[test]
+    fn alignment_deletion_pads_side_b() {
+        // before has 3 lines (1..4), after has 0 lines (1..1)
+        let hunks = make_hunks(&[(1..4, 1..1)]);
+        let mut align = DiffAlignment::new(hunks, DiffSide::B);
+
+        // Side B (after) has 0 lines, other has 3. Trigger at 1-1=0
+        assert_eq!(align.filler_lines_at(0), 3);
+        assert_eq!(align.filler_lines_at(1), 0);
+    }
+
+    #[test]
+    fn alignment_modification_pads_shorter_side() {
+        // before: 2 lines (1..3), after: 5 lines (1..6)
+        let hunks = make_hunks(&[(1..3, 1..6)]);
+        let mut align_a = DiffAlignment::new(hunks.clone(), DiffSide::A);
+
+        // Side A has 2 lines, other has 5. Need 3 fillers after last line (doc_line 2)
+        assert_eq!(align_a.filler_lines_at(0), 0);
+        assert_eq!(align_a.filler_lines_at(1), 0);
+        assert_eq!(align_a.filler_lines_at(2), 3);
+        assert_eq!(align_a.filler_lines_at(3), 0);
+
+        // Side B has 5 lines, other has 2. No filler needed.
+        let mut align_b = DiffAlignment::new(hunks, DiffSide::B);
+        for line in 0..8 {
+            assert_eq!(align_b.filler_lines_at(line), 0);
+        }
+    }
+
+    #[test]
+    fn alignment_multiple_hunks() {
+        // Two hunks: modification at lines 1 and addition at lines 4
+        let hunks = make_hunks(&[
+            (1..2, 1..4), // 1 line before, 3 after: side A needs 2 fillers
+            (4..4, 6..8), // pure insertion: 0 before, 2 after: side A needs 2 fillers
+        ]);
+        let mut align = DiffAlignment::new(hunks, DiffSide::A);
+
+        assert_eq!(align.filler_lines_at(0), 0);
+        assert_eq!(align.filler_lines_at(1), 2); // end of first hunk
+        assert_eq!(align.filler_lines_at(2), 0);
+        assert_eq!(align.filler_lines_at(3), 2); // trigger for second hunk (4-1=3)
+        assert_eq!(align.filler_lines_at(4), 0);
+    }
+
+    #[test]
+    fn alignment_equal_length_modification_no_fillers() {
+        // Both sides have same number of lines
+        let hunks = make_hunks(&[(2..5, 2..5)]);
+        let mut align_a = DiffAlignment::new(hunks.clone(), DiffSide::A);
+        let mut align_b = DiffAlignment::new(hunks, DiffSide::B);
+
+        for line in 0..8 {
+            assert_eq!(align_a.filler_lines_at(line), 0);
+            assert_eq!(align_b.filler_lines_at(line), 0);
+        }
+    }
+}

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use helix_core::text_annotations::LineAnnotation;
 use helix_core::{Position, Rope, RopeSlice, Tendril, Transaction};
 use helix_vcs::Hunk;
-use imara_diff::{Algorithm, Diff, InternedInput};
+use imara_diff::{Algorithm, Diff, InternedInput, TokenSource};
 
 use crate::{DocumentId, ViewId};
 
@@ -20,6 +20,23 @@ impl<'a> imara_diff::TokenSource for RopeLines<'a> {
 
     fn estimate_tokens(&self) -> u32 {
         self.0.len_lines() as u32
+    }
+}
+
+/// A `TokenSource` that yields individual chars, giving char-level token indices
+/// in imara-diff hunks. Used by `intra_line_changes` for per-character diff.
+struct CharSlice<'a>(&'a [char]);
+
+impl<'a> TokenSource for CharSlice<'a> {
+    type Token = char;
+    type Tokenizer = std::iter::Copied<std::slice::Iter<'a, char>>;
+
+    fn tokenize(&self) -> Self::Tokenizer {
+        self.0.iter().copied()
+    }
+
+    fn estimate_tokens(&self) -> u32 {
+        self.0.len() as u32
     }
 }
 
@@ -287,7 +304,10 @@ pub fn intra_line_changes(
     let text_a: String = rope_a.slice(a_start..a_end).into();
     let text_b: String = rope_b.slice(b_start..b_end).into();
 
-    let input = InternedInput::new(text_a.as_str(), text_b.as_str());
+    // Use char-level tokenization so hunk offsets are char indices, not line indices.
+    let chars_a: Vec<char> = text_a.chars().collect();
+    let chars_b: Vec<char> = text_b.chars().collect();
+    let input = InternedInput::new(CharSlice(&chars_a), CharSlice(&chars_b));
     let diff = Diff::compute(Algorithm::Myers, &input);
 
     let char_to_line_col = |base_char: usize, offset: u32, rope: &Rope| -> (usize, usize) {

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -49,10 +49,11 @@ pub struct DiffSession {
     view_b: ViewId,
     doc_a: DocumentId,
     doc_b: DocumentId,
-    hunks: Vec<Hunk>,
-    /// Tracked document versions for change detection
-    version_a: i32,
-    version_b: i32,
+    /// Shared hunk list. Stored as Arc so callers can take a cheap reference-counted
+    /// snapshot for closures and annotations without cloning the full Vec each frame.
+    hunks: Arc<Vec<Hunk>>,
+    version_a: Option<i32>,
+    version_b: Option<i32>,
 }
 
 impl DiffSession {
@@ -62,30 +63,17 @@ impl DiffSession {
             view_b,
             doc_a,
             doc_b,
-            hunks: Vec::new(),
-            version_a: -1,
-            version_b: -1,
+            hunks: Arc::new(Vec::new()),
+            version_a: None,
+            version_b: None,
         }
     }
 
-    /// Creates a session with pre-computed hunks. Useful for calling transaction helpers
-    /// when the hunk data has already been cloned out of the live session.
-    pub fn new_with_hunks(
-        view_a: ViewId,
-        view_b: ViewId,
-        doc_a: DocumentId,
-        doc_b: DocumentId,
-        hunks: Vec<Hunk>,
-    ) -> Self {
-        Self {
-            view_a,
-            view_b,
-            doc_a,
-            doc_b,
-            hunks,
-            version_a: -1,
-            version_b: -1,
-        }
+    /// Returns true if the stored versions differ from the given ones, meaning
+    /// `update_if_changed` would recompute. Lets callers defer expensive Rope
+    /// clones until they are actually needed.
+    pub fn needs_update(&self, version_a: i32, version_b: i32) -> bool {
+        self.version_a != Some(version_a) || self.version_b != Some(version_b)
     }
 
     /// Recompute hunks if either document has changed since the last computation.
@@ -97,11 +85,11 @@ impl DiffSession {
         rope_a: &Rope,
         rope_b: &Rope,
     ) -> bool {
-        if version_a == self.version_a && version_b == self.version_b {
+        if !self.needs_update(version_a, version_b) {
             return false;
         }
-        self.version_a = version_a;
-        self.version_b = version_b;
+        self.version_a = Some(version_a);
+        self.version_b = Some(version_b);
         self.compute_hunks(rope_a, rope_b);
         true
     }
@@ -126,6 +114,13 @@ impl DiffSession {
         &self.hunks
     }
 
+    /// Returns a cheap reference-counted snapshot of the hunk list.
+    /// Callers that need to hold hunks across a borrow boundary (e.g. render closures)
+    /// should use this instead of `hunks().to_vec()`.
+    pub fn hunks_arc(&self) -> Arc<Vec<Hunk>> {
+        Arc::clone(&self.hunks)
+    }
+
     /// Returns true if the given view is part of this diff session.
     pub fn contains_view(&self, view_id: ViewId) -> bool {
         self.view_a == view_id || self.view_b == view_id
@@ -134,7 +129,6 @@ impl DiffSession {
     /// Computes line-level hunks between two Ropes using the Histogram diff algorithm.
     /// `rope_a` corresponds to the left/before side, `rope_b` to the right/after side.
     pub fn compute_hunks(&mut self, rope_a: &Rope, rope_b: &Rope) {
-        self.hunks.clear();
         let input = InternedInput::new(RopeLines(rope_a.slice(..)), RopeLines(rope_b.slice(..)));
         let mut diff = Diff::compute(Algorithm::Histogram, &input);
         diff.postprocess_with(
@@ -144,7 +138,7 @@ impl DiffSession {
                 imara_diff::IndentLevel::for_ascii_line(input.interner[token].bytes(), 4)
             }),
         );
-        self.hunks.extend(diff.hunks());
+        self.hunks = Arc::new(diff.hunks().collect());
     }
 
     /// Returns the documents in this session.
@@ -184,93 +178,91 @@ impl DiffSession {
             None
         }
     }
+}
 
-    /// Returns an iterator over hunks whose range on `side` intersects any of the given line
-    /// ranges. Line ranges are (start_line, end_line) pairs (inclusive, 0-indexed).
-    ///
-    /// For empty ranges (pure deletions on this side), a hunk matches if its start position
-    /// is at or before the end of the selection range, mirroring VCS `hunks_intersecting_line_ranges`.
-    fn hunks_intersecting<'a>(
-        &'a self,
-        line_ranges: &'a [(usize, usize)],
-        side: DiffSide,
-    ) -> impl Iterator<Item = &'a Hunk> {
-        self.hunks.iter().filter(move |h| {
-            let curr_range = match side {
-                DiffSide::A => &h.before,
-                DiffSide::B => &h.after,
-            };
-            line_ranges.iter().any(|(start, end)| {
-                if curr_range.is_empty() {
-                    // Deletion on this side: the insertion point must be at or before selection end.
-                    curr_range.start as usize <= *end
-                } else {
-                    // Standard half-open range overlap.
-                    curr_range.start as usize <= *end && curr_range.end as usize > *start
-                }
-            })
+/// Returns an iterator over hunks whose range on `side` intersects any of the given line
+/// ranges. Line ranges are (start_line, end_line) pairs (inclusive, 0-indexed).
+///
+/// For empty ranges (pure deletions on this side), a hunk matches if its start position
+/// is at or before the end of the selection range, mirroring VCS `hunks_intersecting_line_ranges`.
+fn hunks_intersecting<'a>(
+    hunks: &'a [Hunk],
+    line_ranges: &'a [(usize, usize)],
+    side: DiffSide,
+) -> impl Iterator<Item = &'a Hunk> {
+    hunks.iter().filter(move |h| {
+        let curr_range = match side {
+            DiffSide::A => &h.before,
+            DiffSide::B => &h.after,
+        };
+        line_ranges.iter().any(|(start, end)| {
+            if curr_range.is_empty() {
+                curr_range.start as usize <= *end
+            } else {
+                curr_range.start as usize <= *end && curr_range.end as usize > *start
+            }
         })
-    }
+    })
+}
 
-    /// Build a transaction on `curr_text` that replaces content at hunks under `line_ranges`
-    /// with content from `partner_text`. This is the `:diffget` operation: pull from partner.
-    /// Returns `(transaction, number_of_changes)`.
-    pub fn build_get_transaction(
-        &self,
-        side: DiffSide,
-        line_ranges: &[(usize, usize)],
-        curr_text: &Rope,
-        partner_text: &Rope,
-    ) -> (Transaction, usize) {
-        let mut changes = 0usize;
-        let transaction = Transaction::change(
-            curr_text,
-            self.hunks_intersecting(line_ranges, side).map(|h| {
-                let (curr_range, partner_range) = match side {
-                    DiffSide::A => (&h.before, &h.after),
-                    DiffSide::B => (&h.after, &h.before),
-                };
-                changes += 1;
-                let curr_start = curr_text.line_to_char(curr_range.start as usize);
-                let curr_end = curr_text.line_to_char(curr_range.end as usize);
-                let p_start = partner_text.line_to_char(partner_range.start as usize);
-                let p_end = partner_text.line_to_char(partner_range.end as usize);
-                let text: Tendril = partner_text.slice(p_start..p_end).chunks().collect();
-                (curr_start, curr_end, (!text.is_empty()).then_some(text))
-            }),
-        );
-        (transaction, changes)
-    }
+/// Build a transaction on `curr_text` that replaces content at hunks under `line_ranges`
+/// with content from `partner_text`. This is the `:diffget` operation: pull from partner.
+/// Returns `(transaction, number_of_changes)`.
+pub fn build_get_transaction(
+    hunks: &[Hunk],
+    side: DiffSide,
+    line_ranges: &[(usize, usize)],
+    curr_text: &Rope,
+    partner_text: &Rope,
+) -> (Transaction, usize) {
+    let mut changes = 0usize;
+    let transaction = Transaction::change(
+        curr_text,
+        hunks_intersecting(hunks, line_ranges, side).map(|h| {
+            let (curr_range, partner_range) = match side {
+                DiffSide::A => (&h.before, &h.after),
+                DiffSide::B => (&h.after, &h.before),
+            };
+            changes += 1;
+            let curr_start = curr_text.line_to_char(curr_range.start as usize);
+            let curr_end = curr_text.line_to_char(curr_range.end as usize);
+            let p_start = partner_text.line_to_char(partner_range.start as usize);
+            let p_end = partner_text.line_to_char(partner_range.end as usize);
+            let text: Tendril = partner_text.slice(p_start..p_end).chunks().collect();
+            (curr_start, curr_end, (!text.is_empty()).then_some(text))
+        }),
+    );
+    (transaction, changes)
+}
 
-    /// Build a transaction on `partner_text` that replaces content at hunks under `line_ranges`
-    /// with content from `curr_text`. This is the `:diffput` operation: push to partner.
-    /// Returns `(transaction, number_of_changes)`.
-    pub fn build_put_transaction(
-        &self,
-        side: DiffSide,
-        line_ranges: &[(usize, usize)],
-        curr_text: &Rope,
-        partner_text: &Rope,
-    ) -> (Transaction, usize) {
-        let mut changes = 0usize;
-        let transaction = Transaction::change(
-            partner_text,
-            self.hunks_intersecting(line_ranges, side).map(|h| {
-                let (curr_range, partner_range) = match side {
-                    DiffSide::A => (&h.before, &h.after),
-                    DiffSide::B => (&h.after, &h.before),
-                };
-                changes += 1;
-                let p_start = partner_text.line_to_char(partner_range.start as usize);
-                let p_end = partner_text.line_to_char(partner_range.end as usize);
-                let c_start = curr_text.line_to_char(curr_range.start as usize);
-                let c_end = curr_text.line_to_char(curr_range.end as usize);
-                let text: Tendril = curr_text.slice(c_start..c_end).chunks().collect();
-                (p_start, p_end, (!text.is_empty()).then_some(text))
-            }),
-        );
-        (transaction, changes)
-    }
+/// Build a transaction on `partner_text` that replaces content at hunks under `line_ranges`
+/// with content from `curr_text`. This is the `:diffput` operation: push to partner.
+/// Returns `(transaction, number_of_changes)`.
+pub fn build_put_transaction(
+    hunks: &[Hunk],
+    side: DiffSide,
+    line_ranges: &[(usize, usize)],
+    curr_text: &Rope,
+    partner_text: &Rope,
+) -> (Transaction, usize) {
+    let mut changes = 0usize;
+    let transaction = Transaction::change(
+        partner_text,
+        hunks_intersecting(hunks, line_ranges, side).map(|h| {
+            let (curr_range, partner_range) = match side {
+                DiffSide::A => (&h.before, &h.after),
+                DiffSide::B => (&h.after, &h.before),
+            };
+            changes += 1;
+            let p_start = partner_text.line_to_char(partner_range.start as usize);
+            let p_end = partner_text.line_to_char(partner_range.end as usize);
+            let c_start = curr_text.line_to_char(curr_range.start as usize);
+            let c_end = curr_text.line_to_char(curr_range.end as usize);
+            let text: Tendril = curr_text.slice(c_start..c_end).chunks().collect();
+            (p_start, p_end, (!text.is_empty()).then_some(text))
+        }),
+    );
+    (transaction, changes)
 }
 
 /// A per-line column range that should be highlighted for intra-line changes.
@@ -768,10 +760,9 @@ mod tests {
         let rope_b = Rope::from("line1\nnew_content\nline3\n");
         session.compute_hunks(&rope_a, &rope_b);
 
-        // Cursor on line 1 (old_content line) in doc_a
         let line_ranges = vec![(1usize, 1usize)];
         let (tx, changes) =
-            session.build_get_transaction(DiffSide::A, &line_ranges, &rope_a, &rope_b);
+            build_get_transaction(session.hunks(), DiffSide::A, &line_ranges, &rope_a, &rope_b);
 
         assert_eq!(changes, 1);
         assert_eq!(apply_tx(&rope_a, tx), rope_b);
@@ -784,10 +775,9 @@ mod tests {
         let rope_b = Rope::from("line1\nnew_content\nline3\n");
         session.compute_hunks(&rope_a, &rope_b);
 
-        // Cursor on line 1 (old_content line) in doc_a: push doc_a's content to doc_b
         let line_ranges = vec![(1usize, 1usize)];
         let (tx, changes) =
-            session.build_put_transaction(DiffSide::A, &line_ranges, &rope_a, &rope_b);
+            build_put_transaction(session.hunks(), DiffSide::A, &line_ranges, &rope_a, &rope_b);
 
         assert_eq!(changes, 1);
         assert_eq!(apply_tx(&rope_b, tx), rope_a);
@@ -800,10 +790,9 @@ mod tests {
         let rope_b = Rope::from("aaa\nBBB\nccc\nDDD\n");
         session.compute_hunks(&rope_a, &rope_b);
 
-        // Cursor on line 2 (ccc) which is unchanged
         let line_ranges = vec![(2usize, 2usize)];
         let (_, changes) =
-            session.build_get_transaction(DiffSide::A, &line_ranges, &rope_a, &rope_b);
+            build_get_transaction(session.hunks(), DiffSide::A, &line_ranges, &rope_a, &rope_b);
 
         assert_eq!(changes, 0);
     }
@@ -820,7 +809,7 @@ mod tests {
         // Cursor on line 1 (line3) in doc_b: after.start=1 <= end_line=1, so it matches.
         let line_ranges = vec![(1usize, 1usize)];
         let (tx, changes) =
-            session.build_get_transaction(DiffSide::B, &line_ranges, &rope_b, &rope_a);
+            build_get_transaction(session.hunks(), DiffSide::B, &line_ranges, &rope_b, &rope_a);
 
         assert_eq!(changes, 1);
         // After diffget on side B: doc_b gains line2 back from doc_a.

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -126,6 +126,11 @@ impl DiffSession {
         self.view_a == view_id || self.view_b == view_id
     }
 
+    /// Returns true if the given document is part of this diff session.
+    pub fn contains_doc(&self, doc_id: DocumentId) -> bool {
+        self.doc_a == doc_id || self.doc_b == doc_id
+    }
+
     /// Computes line-level hunks between two Ropes using the Histogram diff algorithm.
     /// `rope_a` corresponds to the left/before side, `rope_b` to the right/after side.
     pub fn compute_hunks(&mut self, rope_a: &Rope, rope_b: &Rope) {
@@ -814,5 +819,27 @@ mod tests {
         assert_eq!(changes, 1);
         // After diffget on side B: doc_b gains line2 back from doc_a.
         assert_eq!(apply_tx(&rope_b, tx), rope_a);
+    }
+
+    #[test]
+    fn contains_doc_returns_true_for_session_members() {
+        let (view_a, view_b) = make_view_ids();
+        let doc_a = make_doc_id(1);
+        let doc_b = make_doc_id(2);
+        let session = DiffSession::new(view_a, view_b, doc_a, doc_b);
+
+        assert!(session.contains_doc(doc_a));
+        assert!(session.contains_doc(doc_b));
+    }
+
+    #[test]
+    fn contains_doc_returns_false_for_non_members() {
+        let (view_a, view_b) = make_view_ids();
+        let doc_a = make_doc_id(1);
+        let doc_b = make_doc_id(2);
+        let unrelated = make_doc_id(3);
+        let session = DiffSession::new(view_a, view_b, doc_a, doc_b);
+
+        assert!(!session.contains_doc(unrelated));
     }
 }

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -607,6 +607,20 @@ pub enum DiffSide {
     B,
 }
 
+/// Doc-line at which a hunk should emit its filler lines.
+///
+/// For non-empty `my_range` the trigger is the hunk's last line so the filler
+/// renders below the hunk on this side. For an empty `my_range` (the partner
+/// has lines but we don't), the trigger is the line just before the insertion
+/// point so the filler renders in the gap.
+fn trigger_for(my_range: &Range<u32>) -> usize {
+    if my_range.is_empty() {
+        my_range.start.saturating_sub(1) as usize
+    } else {
+        (my_range.end - 1) as usize
+    }
+}
+
 /// A `LineAnnotation` that inserts virtual filler lines to keep two
 /// side-by-side diff panes visually aligned at hunk boundaries.
 ///
@@ -638,44 +652,36 @@ impl DiffAlignment {
 
     /// Compute how many filler lines to insert after `doc_line`.
     /// Returns 0 if no filler is needed at this line.
+    ///
+    /// Multiple hunks can share a trigger position (e.g. a non-empty hunk
+    /// ending at line X and a pure insertion immediately after at `[X..X)` -
+    /// both trigger at line `X - 1`). We accumulate fillers across every hunk
+    /// at the current trigger before returning, otherwise the second hunk's
+    /// fillers would be silently dropped when the cursor advances past it on
+    /// the next call.
     pub fn filler_lines_at(&mut self, doc_line: usize) -> usize {
-        // Advance cursor past hunks that ended before this line
+        // Advance cursor past hunks that ended before this line.
         while self.cursor < self.hunks.len() {
             let (my_range, _) = self.ranges_for(&self.hunks[self.cursor]);
-            let trigger = if my_range.is_empty() {
-                // Pure insertion/deletion on our side: trigger at the line
-                // just before the insertion point (or 0 if at start)
-                my_range.start.saturating_sub(1) as usize
-            } else {
-                (my_range.end - 1) as usize
-            };
-            if trigger < doc_line {
+            if trigger_for(&my_range) < doc_line {
                 self.cursor += 1;
             } else {
                 break;
             }
         }
 
-        if self.cursor >= self.hunks.len() {
-            return 0;
-        }
-
-        let (my_range, other_range) = self.ranges_for(&self.hunks[self.cursor]);
-
-        let trigger = if my_range.is_empty() {
-            my_range.start.saturating_sub(1) as usize
-        } else {
-            (my_range.end - 1) as usize
-        };
-
-        if doc_line == trigger {
+        // Sum fillers from every remaining hunk whose trigger matches doc_line.
+        let mut total = 0usize;
+        while self.cursor < self.hunks.len() {
+            let (my_range, other_range) = self.ranges_for(&self.hunks[self.cursor]);
+            if trigger_for(&my_range) != doc_line {
+                break;
+            }
             self.cursor += 1;
-            let filler =
-                (other_range.end - other_range.start).saturating_sub(my_range.end - my_range.start);
-            filler as usize
-        } else {
-            0
+            total += (other_range.end - other_range.start)
+                .saturating_sub(my_range.end - my_range.start) as usize;
         }
+        total
     }
 }
 
@@ -988,6 +994,93 @@ mod tests {
             assert_eq!(align_a.filler_lines_at(line), 0);
             assert_eq!(align_b.filler_lines_at(line), 0);
         }
+    }
+
+    // --- alignment-invariant tests (issue C: drift on archseer-shaped diffs) ---
+
+    /// Sum filler counts produced for `total_lines` consecutive doc lines.
+    fn total_fillers(hunks: Arc<Vec<Hunk>>, side: DiffSide, total_lines: u32) -> u32 {
+        let mut align = DiffAlignment::new(hunks, side);
+        let mut sum = 0u32;
+        for line in 0..total_lines {
+            sum += align.filler_lines_at(line as usize) as u32;
+        }
+        sum
+    }
+
+    /// `len_a + fillers_a == len_b + fillers_b` must hold for alignment to work.
+    fn assert_aligned(hunks: &[(Range<u32>, Range<u32>)], len_a: u32, len_b: u32) {
+        let arc = make_hunks(hunks);
+        let fa = total_fillers(Arc::clone(&arc), DiffSide::A, len_a);
+        let fb = total_fillers(arc, DiffSide::B, len_b);
+        assert_eq!(
+            len_a + fa,
+            len_b + fb,
+            "alignment broken: A has {len_a} lines + {fa} fillers, B has {len_b} lines + {fb} fillers",
+        );
+    }
+
+    #[test]
+    fn alignment_holds_with_three_replace_hunks() {
+        // Three pure replacements at increasing positions; symmetric sizes -> no fillers needed.
+        assert_aligned(&[(2..3, 2..3), (10..11, 10..11), (20..21, 20..21)], 30, 30);
+    }
+
+    #[test]
+    fn alignment_holds_with_three_pure_deletions() {
+        // archseer-like: deletions only. A has 30 lines, B has 25 (lost 5 across 3 hunks).
+        assert_aligned(&[(3..5, 3..3), (10..12, 8..8), (20..21, 16..16)], 30, 25);
+    }
+
+    #[test]
+    fn alignment_holds_with_mixed_asymmetric_hunks() {
+        // Mix of replace, pure-insert, pure-delete at increasing positions.
+        // A: 30 lines.
+        // Hunk 1 at A[5..7) -> B[5..10): replace 2 with 5  -> B gains 3
+        // Hunk 2 at A[12..15) -> B[15..15): delete 3 lines -> B loses 3
+        // Hunk 3 at A[22..22) -> B[22..27): pure insert 5  -> B gains 5
+        // Net: B has 30 + 3 - 3 + 5 = 35 lines.
+        assert_aligned(&[(5..7, 5..10), (12..15, 15..15), (22..22, 22..27)], 30, 35);
+    }
+
+    #[test]
+    fn alignment_holds_when_replace_is_adjacent_to_pure_insert() {
+        // The shape that produces colliding triggers on side A:
+        // A: replace at [10..15) and immediately a pure insert at [15..15).
+        // Both empty's trigger = start-1 = 14, AND the replace's trigger = end-1 = 14.
+        // Side A's filler_lines_at(14) must emit fillers for BOTH hunks.
+        assert_aligned(
+            &[(10..15, 10..15), (15..15, 15..18)],
+            // A: 15 lines through hunk 1 + 15 + 0 (hunk 2 empty on A) + ... = arbitrary; use 30.
+            30,
+            // B: hunk 1 same length, hunk 2 inserts 3. So 30 + 3 = 33.
+            33,
+        );
+    }
+
+    #[test]
+    fn alignment_holds_when_pure_insert_is_adjacent_to_replace() {
+        // Symmetric flavor on side B: a pure-insert on A immediately before a replace.
+        assert_aligned(
+            &[(10..10, 10..13), (10..15, 13..18)],
+            30,
+            // A inserts 3 (B gains 3) + replace same length = 33.
+            33,
+        );
+    }
+
+    #[test]
+    fn alignment_holds_with_consecutive_deletions_on_one_side() {
+        // Two pure deletions on side B (same as deletions on A's perspective: empty B ranges).
+        // The B-side empty ranges have triggers at start-1; consecutive deletions can
+        // share the same B-side trigger when their A-side spans differ but B-side
+        // accumulator doesn't advance.
+        assert_aligned(
+            &[(5..7, 5..5), (10..13, 5..5)],
+            30,
+            // B loses (2 + 3) = 5 lines.
+            25,
+        );
     }
 
     // --- map_line / map_to_real_line tests ---

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -285,6 +285,88 @@ impl DiffSession {
             None
         }
     }
+
+    /// Map a line on `from_side` to its corresponding position on the partner side.
+    ///
+    /// Walks the hunk list once with a running offset (sum of `other_len - my_len`
+    /// for hunks fully above the input line):
+    ///
+    /// - Outside any hunk: 1:1 with the running offset applied.
+    /// - Inside a hunk where the partner has lines: clamp the within-hunk offset
+    ///   to `other_range.end - 1` so an asymmetric replace doesn't run past the
+    ///   partner's last line.
+    /// - Inside a hunk where the partner is empty (deletion-on-partner): return
+    ///   [`MappedLine::Filler`] anchored at `other_range.start - 1`. The partner
+    ///   has no real line for this position.
+    ///
+    /// All arithmetic uses saturating ops so `u32::MAX` and other adversarial
+    /// inputs don't panic.
+    pub fn map_line(&self, from_side: DiffSide, line: u32) -> MappedLine {
+        let mut offset: i64 = 0;
+        for hunk in self.hunks.iter() {
+            let (my_range, other_range) = match from_side {
+                DiffSide::A => (hunk.before.clone(), hunk.after.clone()),
+                DiffSide::B => (hunk.after.clone(), hunk.before.clone()),
+            };
+
+            if line < my_range.start {
+                return MappedLine::Real(apply_offset(line, offset));
+            }
+
+            // `line < my_range.end` only when my_range is non-empty (else
+            // start == end and the previous branch already handled it).
+            if line < my_range.end {
+                if other_range.is_empty() {
+                    return MappedLine::Filler {
+                        after: other_range.start.saturating_sub(1),
+                    };
+                }
+                let within_offset = line.saturating_sub(my_range.start);
+                let other_last = other_range
+                    .end
+                    .saturating_sub(other_range.start)
+                    .saturating_sub(1);
+                let clamped = within_offset.min(other_last);
+                return MappedLine::Real(other_range.start.saturating_add(clamped));
+            }
+
+            let my_len = my_range.end as i64 - my_range.start as i64;
+            let other_len = other_range.end as i64 - other_range.start as i64;
+            offset += other_len - my_len;
+        }
+
+        MappedLine::Real(apply_offset(line, offset))
+    }
+
+    /// Map a line and clamp the result to the partner document's line count.
+    ///
+    /// Filler positions collapse to the line they sit after. Useful for cursor
+    /// placement, where a real partner line is always required.
+    pub fn map_to_real_line(&self, from_side: DiffSide, line: u32, partner_line_count: u32) -> u32 {
+        let last = partner_line_count.saturating_sub(1);
+        let mapped = match self.map_line(from_side, line) {
+            MappedLine::Real(n) => n,
+            MappedLine::Filler { after } => after,
+        };
+        mapped.min(last)
+    }
+}
+
+/// Result of [`DiffSession::map_line`]. The partner side may have a real line at
+/// the mapped position, or only a filler if the input lands inside a deletion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MappedLine {
+    /// The partner has a real line at this index.
+    Real(u32),
+    /// The partner has no line for the input position; conceptually the input
+    /// sits in a filler row just after partner line `after`.
+    Filler { after: u32 },
+}
+
+/// Apply a signed offset to a line index, saturating at the `u32` bounds.
+fn apply_offset(line: u32, offset: i64) -> u32 {
+    let result = line as i64 + offset;
+    result.clamp(0, u32::MAX as i64) as u32
 }
 
 /// Returns an iterator over hunks whose range on `side` intersects any of the given line
@@ -906,6 +988,141 @@ mod tests {
             assert_eq!(align_a.filler_lines_at(line), 0);
             assert_eq!(align_b.filler_lines_at(line), 0);
         }
+    }
+
+    // --- map_line / map_to_real_line tests ---
+
+    fn session_with_hunks(pairs: &[(Range<u32>, Range<u32>)]) -> DiffSession {
+        let mut session = make_session();
+        session.hunks = make_hunks(pairs);
+        session
+    }
+
+    #[test]
+    fn map_line_identical_files_is_identity() {
+        // M1: With no hunks the mapping is 1:1 in both directions.
+        let session = session_with_hunks(&[]);
+        for line in [0u32, 5, 100] {
+            assert_eq!(session.map_line(DiffSide::A, line), MappedLine::Real(line));
+            assert_eq!(session.map_line(DiffSide::B, line), MappedLine::Real(line));
+        }
+    }
+
+    #[test]
+    fn map_line_pure_insert_on_partner_shifts_lines_after_hunk() {
+        // M2: side A has no lines for the hunk, side B inserts 3 lines at row 5.
+        // Lines on A before row 5 are unchanged on B; lines at/after row 5 shift +3.
+        let session = session_with_hunks(&[(5..5, 5..8)]);
+
+        // Before the insert: 1:1.
+        assert_eq!(session.map_line(DiffSide::A, 0), MappedLine::Real(0));
+        assert_eq!(session.map_line(DiffSide::A, 4), MappedLine::Real(4));
+
+        // After the insert: shift by other_len - my_len = 3.
+        assert_eq!(session.map_line(DiffSide::A, 5), MappedLine::Real(8));
+        assert_eq!(session.map_line(DiffSide::A, 10), MappedLine::Real(13));
+    }
+
+    #[test]
+    fn map_line_pure_delete_on_partner_yields_filler() {
+        // M3: side A has 2 lines (3..5) that side B doesn't have. From A's perspective
+        // those lines have no real partner row, so map_line returns Filler.
+        let session = session_with_hunks(&[(3..5, 3..3)]);
+
+        // Before the delete: 1:1.
+        assert_eq!(session.map_line(DiffSide::A, 0), MappedLine::Real(0));
+        assert_eq!(session.map_line(DiffSide::A, 2), MappedLine::Real(2));
+
+        // Inside the deleted range (no partner row): Filler anchored at start - 1.
+        assert_eq!(
+            session.map_line(DiffSide::A, 3),
+            MappedLine::Filler { after: 2 }
+        );
+        assert_eq!(
+            session.map_line(DiffSide::A, 4),
+            MappedLine::Filler { after: 2 }
+        );
+
+        // After the delete: shift by -2 (other_len 0 - my_len 2).
+        assert_eq!(session.map_line(DiffSide::A, 5), MappedLine::Real(3));
+        assert_eq!(session.map_line(DiffSide::A, 10), MappedLine::Real(8));
+    }
+
+    #[test]
+    fn map_line_pure_delete_filler_anchors_at_zero_when_at_file_start() {
+        // Edge: deletion at line 0; saturating_sub keeps `after` at 0.
+        let session = session_with_hunks(&[(0..2, 0..0)]);
+        assert_eq!(
+            session.map_line(DiffSide::A, 0),
+            MappedLine::Filler { after: 0 }
+        );
+        assert_eq!(
+            session.map_line(DiffSide::A, 1),
+            MappedLine::Filler { after: 0 }
+        );
+    }
+
+    #[test]
+    fn map_line_multiple_delete_only_hunks_accumulate_offset() {
+        // M4: archseer's repro shape - several deletion-only hunks at increasing
+        // positions. After each, the running offset shrinks by the deletion size.
+        let session = session_with_hunks(&[
+            (3..5, 3..3),     // delete 2 lines on B
+            (10..12, 8..8),   // delete 2 more
+            (20..21, 16..16), // delete 1 more
+        ]);
+
+        // After the third hunk: cumulative offset is -5 (lost 5 lines on B).
+        assert_eq!(session.map_line(DiffSide::A, 30), MappedLine::Real(25));
+
+        // Between hunks the offset reflects only the previous deletions.
+        assert_eq!(session.map_line(DiffSide::A, 6), MappedLine::Real(4));
+        assert_eq!(session.map_line(DiffSide::A, 13), MappedLine::Real(9));
+    }
+
+    #[test]
+    fn map_line_asymmetric_replace_clamps_within_hunk_offset() {
+        // M5: side A has 3 lines (5..8), side B has 5 lines (5..10).
+        // Within the hunk, A row 5 -> B row 5, A row 6 -> B row 6, A row 7 -> B row 7
+        // (clamped to other_range.end - 1 = 9, but 7 is below that anyway).
+        let session = session_with_hunks(&[(5..8, 5..10)]);
+        assert_eq!(session.map_line(DiffSide::A, 5), MappedLine::Real(5));
+        assert_eq!(session.map_line(DiffSide::A, 6), MappedLine::Real(6));
+        assert_eq!(session.map_line(DiffSide::A, 7), MappedLine::Real(7));
+
+        // Reverse: B has more lines; B row 5..10 maps onto A row 5..8 with clamp.
+        assert_eq!(session.map_line(DiffSide::B, 5), MappedLine::Real(5));
+        assert_eq!(session.map_line(DiffSide::B, 6), MappedLine::Real(6));
+        assert_eq!(session.map_line(DiffSide::B, 7), MappedLine::Real(7));
+        assert_eq!(session.map_line(DiffSide::B, 8), MappedLine::Real(7)); // clamped
+        assert_eq!(session.map_line(DiffSide::B, 9), MappedLine::Real(7)); // clamped
+    }
+
+    #[test]
+    fn map_to_real_line_clamps_to_partner_line_count() {
+        // M6: a row that maps past the partner doc's last line is clamped, no panic.
+        let session = session_with_hunks(&[]);
+        // Partner has 3 lines (indices 0..2). Asking for line 100 returns last line.
+        assert_eq!(session.map_to_real_line(DiffSide::A, 100, 3), 2);
+
+        // Even with partner_line_count = 0, we return 0 instead of underflowing.
+        assert_eq!(session.map_to_real_line(DiffSide::A, 5, 0), 0);
+
+        // Filler positions also clamp.
+        let session = session_with_hunks(&[(3..5, 3..3)]);
+        assert_eq!(session.map_to_real_line(DiffSide::A, 3, 1), 0);
+    }
+
+    #[test]
+    fn map_line_does_not_panic_on_extreme_inputs() {
+        // M7: u32::MAX as an input must not panic.
+        let session = session_with_hunks(&[(3..5, 3..3)]);
+        let result = session.map_line(DiffSide::A, u32::MAX);
+        // Past all hunks, offset is -2; result is u32::MAX - 2.
+        assert_eq!(result, MappedLine::Real(u32::MAX - 2));
+
+        // map_to_real_line clamps to the partner's last line.
+        assert_eq!(session.map_to_real_line(DiffSide::A, u32::MAX, 10), 9);
     }
 
     // --- find_next_hunk / find_prev_hunk tests ---

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -1,8 +1,9 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use helix_core::text_annotations::LineAnnotation;
-use helix_core::{Position, Rope, RopeSlice, Tendril, Transaction};
+use helix_core::doc_formatter::TextFormat;
+use helix_core::text_annotations::{LineAnnotation, TextAnnotations};
+use helix_core::{visual_offset_from_block, Position, Rope, RopeSlice, Tendril, Transaction};
 use helix_vcs::Hunk;
 use imara_diff::{Algorithm, Diff, InternedInput, TokenSource};
 
@@ -640,23 +641,79 @@ fn trigger_for(my_range: &Range<u32>) -> usize {
     }
 }
 
-/// A `LineAnnotation` that inserts virtual filler lines to keep two
+/// Visual height of `range` in `rope` under `text_fmt`. Counts wrapped rows,
+/// not just doc lines, so a single long line that soft-wraps to four rows
+/// reports four. Empty ranges report zero.
+pub fn visual_height(rope: &Rope, range: &Range<u32>, text_fmt: &TextFormat) -> u32 {
+    if range.is_empty() {
+        return 0;
+    }
+    let start_char = rope.line_to_char(range.start as usize);
+    let end_char = rope.line_to_char(range.end as usize);
+    let (pos, _) = visual_offset_from_block(
+        rope.slice(..),
+        start_char,
+        end_char,
+        text_fmt,
+        &TextAnnotations::default(),
+    );
+    pos.row as u32
+}
+
+/// Per-hunk filler counts on `my_side`, in visual rows.
+///
+/// Each entry is `max(0, partner_visual_height - my_visual_height)`. Visual
+/// heights are computed with each side's own `TextFormat`, so wrap widths
+/// and tab settings can differ between panes. The result is parallel to
+/// `hunks`.
+pub fn compute_visual_fillers(
+    hunks: &[Hunk],
+    my_side: DiffSide,
+    my_rope: &Rope,
+    partner_rope: &Rope,
+    my_text_fmt: &TextFormat,
+    partner_text_fmt: &TextFormat,
+) -> Vec<u32> {
+    hunks
+        .iter()
+        .map(|hunk| {
+            let (my_range, other_range) = match my_side {
+                DiffSide::A => (&hunk.before, &hunk.after),
+                DiffSide::B => (&hunk.after, &hunk.before),
+            };
+            let my_height = visual_height(my_rope, my_range, my_text_fmt);
+            let partner_height = visual_height(partner_rope, other_range, partner_text_fmt);
+            partner_height.saturating_sub(my_height)
+        })
+        .collect()
+}
+
+/// `LineAnnotation` that inserts virtual filler lines to keep two
 /// side-by-side diff panes visually aligned at hunk boundaries.
 ///
-/// Each side of the diff gets its own `DiffAlignment`. When the "other" side
-/// has more lines in a hunk, this annotation pads with filler lines so both
-/// panes show the same visual height for every hunk.
+/// Each side of the diff has its own `DiffAlignment`. The filler count for
+/// each hunk is precomputed (usually by [`compute_visual_fillers`]) and
+/// passed in at construction; `filler_lines_at` looks it up as the renderer
+/// walks doc lines.
 pub struct DiffAlignment {
     hunks: Arc<Vec<Hunk>>,
     side: DiffSide,
+    /// Per-hunk filler row counts on this side, parallel to `hunks`.
+    fillers: Arc<Vec<u32>>,
     cursor: usize,
 }
 
 impl DiffAlignment {
-    pub fn new(hunks: Arc<Vec<Hunk>>, side: DiffSide) -> Self {
+    pub fn new(hunks: Arc<Vec<Hunk>>, side: DiffSide, fillers: Arc<Vec<u32>>) -> Self {
+        debug_assert_eq!(
+            hunks.len(),
+            fillers.len(),
+            "fillers must be parallel to hunks",
+        );
         Self {
             hunks,
             side,
+            fillers,
             cursor: 0,
         }
     }
@@ -669,7 +726,7 @@ impl DiffAlignment {
         }
     }
 
-    /// How many filler lines to insert after `doc_line`. Returns 0 if no
+    /// How many filler rows to insert after `doc_line`. Returns 0 if no
     /// filler is needed at this line.
     ///
     /// Multiple hunks can share a trigger position. A non-empty hunk ending
@@ -688,16 +745,15 @@ impl DiffAlignment {
             }
         }
 
-        // Sum fillers from every remaining hunk whose trigger matches doc_line.
+        // Sum precomputed fillers from every hunk whose trigger matches doc_line.
         let mut total = 0usize;
         while self.cursor < self.hunks.len() {
-            let (my_range, other_range) = self.ranges_for(&self.hunks[self.cursor]);
+            let (my_range, _) = self.ranges_for(&self.hunks[self.cursor]);
             if trigger_for(&my_range) != doc_line {
                 break;
             }
+            total += self.fillers[self.cursor] as usize;
             self.cursor += 1;
-            total += (other_range.end - other_range.start)
-                .saturating_sub(my_range.end - my_range.start) as usize;
         }
         total
     }
@@ -919,10 +975,27 @@ mod tests {
         )
     }
 
+    /// Build a DiffAlignment whose fillers come from doc-line differences,
+    /// matching the original (pre-soft-wrap-aware) behavior. Render code uses
+    /// compute_visual_fillers instead, which is exercised in helix-term tests.
+    fn alignment_with_doc_line_fillers(hunks: Arc<Vec<Hunk>>, side: DiffSide) -> DiffAlignment {
+        let fillers: Vec<u32> = hunks
+            .iter()
+            .map(|h| {
+                let (my, other) = match side {
+                    DiffSide::A => (&h.before, &h.after),
+                    DiffSide::B => (&h.after, &h.before),
+                };
+                (other.end - other.start).saturating_sub(my.end - my.start)
+            })
+            .collect();
+        DiffAlignment::new(hunks, side, Arc::new(fillers))
+    }
+
     #[test]
     fn alignment_identical_files_no_fillers() {
         let hunks = make_hunks(&[]);
-        let mut align = DiffAlignment::new(hunks, DiffSide::A);
+        let mut align = alignment_with_doc_line_fillers(hunks, DiffSide::A);
 
         for line in 0..5 {
             assert_eq!(align.filler_lines_at(line), 0);
@@ -934,7 +1007,7 @@ mod tests {
         // before: 5 lines, after: 8 lines (3 added at lines 2..5 on after)
         // Hunk: before 2..2 (pure insertion), after 2..5
         let hunks = make_hunks(&[(2..2, 2..5)]);
-        let mut align = DiffAlignment::new(hunks, DiffSide::A);
+        let mut align = alignment_with_doc_line_fillers(hunks, DiffSide::A);
 
         // Side A has 0 lines in hunk, other side has 3
         // Trigger at doc_line = max(0, 2-1) = 1
@@ -947,7 +1020,7 @@ mod tests {
     fn alignment_addition_no_pad_on_longer_side() {
         // Same hunk but from side B's perspective: B has the 3 added lines
         let hunks = make_hunks(&[(2..2, 2..5)]);
-        let mut align = DiffAlignment::new(hunks, DiffSide::B);
+        let mut align = alignment_with_doc_line_fillers(hunks, DiffSide::B);
 
         // Side B has 3 lines, other side has 0. No filler needed.
         for line in 0..8 {
@@ -959,7 +1032,7 @@ mod tests {
     fn alignment_deletion_pads_side_b() {
         // before has 3 lines (1..4), after has 0 lines (1..1)
         let hunks = make_hunks(&[(1..4, 1..1)]);
-        let mut align = DiffAlignment::new(hunks, DiffSide::B);
+        let mut align = alignment_with_doc_line_fillers(hunks, DiffSide::B);
 
         // Side B (after) has 0 lines, other has 3. Trigger at 1-1=0
         assert_eq!(align.filler_lines_at(0), 3);
@@ -970,7 +1043,7 @@ mod tests {
     fn alignment_modification_pads_shorter_side() {
         // before: 2 lines (1..3), after: 5 lines (1..6)
         let hunks = make_hunks(&[(1..3, 1..6)]);
-        let mut align_a = DiffAlignment::new(hunks.clone(), DiffSide::A);
+        let mut align_a = alignment_with_doc_line_fillers(hunks.clone(), DiffSide::A);
 
         // Side A has 2 lines, other has 5. Need 3 fillers after last line (doc_line 2)
         assert_eq!(align_a.filler_lines_at(0), 0);
@@ -979,7 +1052,7 @@ mod tests {
         assert_eq!(align_a.filler_lines_at(3), 0);
 
         // Side B has 5 lines, other has 2. No filler needed.
-        let mut align_b = DiffAlignment::new(hunks, DiffSide::B);
+        let mut align_b = alignment_with_doc_line_fillers(hunks, DiffSide::B);
         for line in 0..8 {
             assert_eq!(align_b.filler_lines_at(line), 0);
         }
@@ -992,7 +1065,7 @@ mod tests {
             (1..2, 1..4), // 1 line before, 3 after: side A needs 2 fillers
             (4..4, 6..8), // pure insertion: 0 before, 2 after: side A needs 2 fillers
         ]);
-        let mut align = DiffAlignment::new(hunks, DiffSide::A);
+        let mut align = alignment_with_doc_line_fillers(hunks, DiffSide::A);
 
         assert_eq!(align.filler_lines_at(0), 0);
         assert_eq!(align.filler_lines_at(1), 2); // end of first hunk
@@ -1005,8 +1078,8 @@ mod tests {
     fn alignment_equal_length_modification_no_fillers() {
         // Both sides have same number of lines
         let hunks = make_hunks(&[(2..5, 2..5)]);
-        let mut align_a = DiffAlignment::new(hunks.clone(), DiffSide::A);
-        let mut align_b = DiffAlignment::new(hunks, DiffSide::B);
+        let mut align_a = alignment_with_doc_line_fillers(hunks.clone(), DiffSide::A);
+        let mut align_b = alignment_with_doc_line_fillers(hunks, DiffSide::B);
 
         for line in 0..8 {
             assert_eq!(align_a.filler_lines_at(line), 0);
@@ -1014,11 +1087,95 @@ mod tests {
         }
     }
 
+    // --- visual_height / compute_visual_fillers tests (soft-wrap awareness) ---
+
+    /// Build a TextFormat that wraps at `viewport_width` columns.
+    fn wrap_text_fmt(viewport_width: u16) -> TextFormat {
+        TextFormat {
+            soft_wrap: true,
+            tab_width: 4,
+            max_wrap: 1,
+            max_indent_retain: 0,
+            wrap_indicator: "".into(),
+            wrap_indicator_highlight: None,
+            viewport_width,
+            soft_wrap_at_text_width: false,
+        }
+    }
+
+    #[test]
+    fn visual_height_no_wrap_matches_doc_line_count() {
+        // 3 lines, all short. With wide viewport no wrap kicks in.
+        let rope = Rope::from("aaa\nbbb\nccc\n");
+        let fmt = wrap_text_fmt(80);
+        assert_eq!(visual_height(&rope, &(0..3), &fmt), 3);
+        assert_eq!(visual_height(&rope, &(1..3), &fmt), 2);
+    }
+
+    #[test]
+    fn visual_height_counts_wrapped_rows() {
+        // One long line, narrow viewport.
+        let rope = Rope::from("aaaaaaaaaaaaaaaaaaaa\nbbb\n");
+        let fmt = wrap_text_fmt(5);
+        // First line (20 chars) wraps at width 5: at least 4 visual rows.
+        // Second line (3 chars) takes 1 row.
+        let h = visual_height(&rope, &(0..2), &fmt);
+        assert!(
+            h > 2,
+            "wrapped first line should produce more than 2 rows, got {h}"
+        );
+    }
+
+    #[test]
+    fn visual_height_empty_range_is_zero() {
+        let rope = Rope::from("aaa\nbbb\n");
+        let fmt = wrap_text_fmt(80);
+        assert_eq!(visual_height(&rope, &(2..2), &fmt), 0);
+    }
+
+    #[test]
+    fn compute_visual_fillers_matches_doc_line_diff_when_no_wrap() {
+        // Without wrap, visual fillers should equal what the old doc-line
+        // subtraction produced. This is the regression guarantee.
+        let hunks = make_hunks(&[(5..7, 5..10), (12..15, 15..15)]);
+        let rope_a = Rope::from("a\n".repeat(20));
+        let rope_b = Rope::from("b\n".repeat(20));
+        let fmt = wrap_text_fmt(80);
+
+        let fillers_a = compute_visual_fillers(&hunks, DiffSide::A, &rope_a, &rope_b, &fmt, &fmt);
+        // Hunk 0: A has 2 lines, B has 5 -> A needs 3 fillers.
+        // Hunk 1: A has 3 lines, B has 0 -> A needs 0 fillers (saturating).
+        assert_eq!(fillers_a, vec![3, 0]);
+
+        let fillers_b = compute_visual_fillers(&hunks, DiffSide::B, &rope_b, &rope_a, &fmt, &fmt);
+        assert_eq!(fillers_b, vec![0, 3]);
+    }
+
+    #[test]
+    fn compute_visual_fillers_inflates_when_partner_wraps() {
+        // Side A has 1 short line, side B has 1 very long line that wraps.
+        // From A's perspective, A's range visually consumes 1 row but B's range
+        // consumes several. A needs extra fillers to keep aligned.
+        let hunks = make_hunks(&[(0..1, 0..1)]);
+        let rope_a = Rope::from("short\n");
+        let rope_b = Rope::from("aaaaaaaaaaaaaaaaaaaaaaaaa\n"); // 25 chars
+        let fmt = wrap_text_fmt(5);
+
+        let fillers_a = compute_visual_fillers(&hunks, DiffSide::A, &rope_a, &rope_b, &fmt, &fmt);
+        // Doc-line subtraction would say 0 (both ranges are 1 line). With wrap
+        // awareness it must be > 0 because B's content wraps.
+        assert!(
+            fillers_a[0] > 0,
+            "wrapped partner line should require fillers on the unwrapped side, got {}",
+            fillers_a[0]
+        );
+    }
+
     // --- alignment-invariant tests (issue C: drift on archseer-shaped diffs) ---
 
     /// Sum filler counts produced for `total_lines` consecutive doc lines.
     fn total_fillers(hunks: Arc<Vec<Hunk>>, side: DiffSide, total_lines: u32) -> u32 {
-        let mut align = DiffAlignment::new(hunks, side);
+        let mut align = alignment_with_doc_line_fillers(hunks, side);
         let mut sum = 0u32;
         for line in 0..total_lines {
             sum += align.filler_lines_at(line as usize) as u32;

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -368,6 +368,26 @@ fn apply_offset(line: u32, offset: i64) -> u32 {
     result.clamp(0, u32::MAX as i64) as u32
 }
 
+/// Side of the session that holds `source`, but only when `source` and `dest`
+/// are paired partners in the same `DiffSession`. Returns `None` when no
+/// session contains `source`, or when `source`'s partner is some other view.
+///
+/// This is the gating predicate for cursor-sync writes: returning a side
+/// authorizes the caller to write to `dest`'s selection. Returning `None`
+/// means the caller must skip - either no session pairs them, or the session
+/// has changed shape since the focus event arrived.
+pub fn paired_side(sessions: &[DiffSession], source: ViewId, dest: ViewId) -> Option<DiffSide> {
+    sessions
+        .iter()
+        .find(|s| s.contains_view(source))
+        .and_then(|s| {
+            if s.partner_view(source) != Some(dest) {
+                return None;
+            }
+            s.side_for_view(source)
+        })
+}
+
 /// Returns an iterator over hunks whose range on `side` intersects any of the given line
 /// ranges. Line ranges are (start_line, end_line) pairs (inclusive, 0-indexed).
 ///
@@ -1079,6 +1099,83 @@ mod tests {
             // B loses (2 + 3) = 5 lines.
             25,
         );
+    }
+
+    // --- paired_side gating tests (D's cursor-sync predicate) ---
+
+    #[test]
+    fn paired_side_returns_source_side_when_views_are_partners() {
+        let (view_a, view_b) = make_view_ids();
+        let session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        let sessions = vec![session];
+
+        // Source on side A, partner on side B: returns A.
+        assert_eq!(paired_side(&sessions, view_a, view_b), Some(DiffSide::A));
+        // Reverse direction also resolves.
+        assert_eq!(paired_side(&sessions, view_b, view_a), Some(DiffSide::B));
+    }
+
+    #[test]
+    fn paired_side_returns_none_when_dest_is_not_partner() {
+        // AB4: two sessions exist, but source and dest are in different ones.
+        let mut sm: slotmap::SlotMap<ViewId, ()> = slotmap::SlotMap::with_key();
+        let view_a = sm.insert(());
+        let view_b = sm.insert(());
+        let view_c = sm.insert(());
+        let view_d = sm.insert(());
+
+        let sessions = vec![
+            DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2)),
+            DiffSession::new(view_c, view_d, make_doc_id(3), make_doc_id(4)),
+        ];
+
+        // view_a's partner is view_b, not view_c. Cross-session sync is denied.
+        assert_eq!(paired_side(&sessions, view_a, view_c), None);
+        assert_eq!(paired_side(&sessions, view_a, view_d), None);
+        assert_eq!(paired_side(&sessions, view_c, view_a), None);
+    }
+
+    #[test]
+    fn paired_side_returns_none_when_source_is_not_in_any_session() {
+        // Source view exists but is not a member of any session. No write.
+        // All three IDs come from the same slotmap so they really are
+        // distinct: keys from different slotmaps can collide on the integer.
+        let mut sm: slotmap::SlotMap<ViewId, ()> = slotmap::SlotMap::with_key();
+        let view_a = sm.insert(());
+        let view_b = sm.insert(());
+        let outsider = sm.insert(());
+
+        let sessions = vec![DiffSession::new(
+            view_a,
+            view_b,
+            make_doc_id(1),
+            make_doc_id(2),
+        )];
+        assert_eq!(paired_side(&sessions, outsider, view_a), None);
+        assert_eq!(paired_side(&sessions, outsider, view_b), None);
+    }
+
+    #[test]
+    fn paired_side_returns_none_when_no_sessions_exist() {
+        let (view_a, view_b) = make_view_ids();
+        let sessions: Vec<DiffSession> = vec![];
+        assert_eq!(paired_side(&sessions, view_a, view_b), None);
+    }
+
+    #[test]
+    fn paired_side_returns_none_when_source_equals_dest() {
+        // Defensive: a focus event from a view to itself shouldn't sync.
+        // partner_view returns the other view, never self, so source==dest
+        // always falls into the "not partner" branch.
+        let (view_a, view_b) = make_view_ids();
+        let sessions = vec![DiffSession::new(
+            view_a,
+            view_b,
+            make_doc_id(1),
+            make_doc_id(2),
+        )];
+        assert_eq!(paired_side(&sessions, view_a, view_a), None);
+        assert_eq!(paired_side(&sessions, view_b, view_b), None);
     }
 
     // --- map_line / map_to_real_line tests ---

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -312,6 +312,46 @@ fn hunks_intersecting<'a>(
     })
 }
 
+/// Index of the first hunk strictly after `cursor_line` on `side`.
+///
+/// "Strictly after" means: if the cursor sits inside or at the start of a
+/// hunk, that hunk is skipped. This matches `helix-vcs`'s `next_hunk` and is
+/// the predicate behind `]g` when a `DiffSession` is active. Returns `None`
+/// when no later hunk exists.
+///
+/// Empty ranges (deletions on this side) are handled by the same predicate:
+/// the deletion's filler renders between line `start - 1` and `start`, so a
+/// cursor at line `start` is already past the filler and the deletion should
+/// not match.
+pub fn find_next_hunk(hunks: &[Hunk], side: DiffSide, cursor_line: u32) -> Option<usize> {
+    hunks.iter().position(|h| {
+        let r = match side {
+            DiffSide::A => &h.before,
+            DiffSide::B => &h.after,
+        };
+        r.start > cursor_line
+    })
+}
+
+/// Index of the last hunk strictly before `cursor_line` on `side`.
+///
+/// Symmetric to [`find_next_hunk`]: a cursor inside or at the end of a hunk
+/// skips that hunk. Used by `[g` when a `DiffSession` is active. Returns
+/// `None` when no earlier hunk exists.
+pub fn find_prev_hunk(hunks: &[Hunk], side: DiffSide, cursor_line: u32) -> Option<usize> {
+    hunks.iter().rposition(|h| {
+        let r = match side {
+            DiffSide::A => &h.before,
+            DiffSide::B => &h.after,
+        };
+        if r.is_empty() {
+            r.start < cursor_line
+        } else {
+            r.end <= cursor_line
+        }
+    })
+}
+
 /// Build a transaction on `curr_text` that replaces content at hunks under `line_ranges`
 /// with content from `partner_text`. This is the `:diffget` operation: pull from partner.
 /// Returns `(transaction, number_of_changes)`.
@@ -866,6 +906,108 @@ mod tests {
             assert_eq!(align_a.filler_lines_at(line), 0);
             assert_eq!(align_b.filler_lines_at(line), 0);
         }
+    }
+
+    // --- find_next_hunk / find_prev_hunk tests ---
+
+    #[test]
+    fn find_next_hunk_advances_when_cursor_inside_hunk() {
+        // Hunk spans lines 5..8 (lines 5, 6, 7) on side A; another at 12..14.
+        // Cursor on line 6 (middle of first hunk) should advance past it.
+        let hunks = make_hunks(&[(5..8, 5..8), (12..14, 12..14)]);
+        let next = find_next_hunk(&hunks, DiffSide::A, 6);
+        assert_eq!(next, Some(1));
+    }
+
+    #[test]
+    fn find_next_hunk_advances_when_cursor_at_hunk_start() {
+        // Cursor exactly on the first line of a hunk: still considered "inside",
+        // so the predicate should advance to the next hunk.
+        let hunks = make_hunks(&[(5..8, 5..8), (12..14, 12..14)]);
+        let next = find_next_hunk(&hunks, DiffSide::A, 5);
+        assert_eq!(next, Some(1));
+    }
+
+    #[test]
+    fn find_next_hunk_returns_first_hunk_when_cursor_before_all() {
+        let hunks = make_hunks(&[(5..8, 5..8), (12..14, 12..14)]);
+        let next = find_next_hunk(&hunks, DiffSide::A, 0);
+        assert_eq!(next, Some(0));
+    }
+
+    #[test]
+    fn find_next_hunk_returns_none_when_cursor_past_all_hunks() {
+        let hunks = make_hunks(&[(5..8, 5..8), (12..14, 12..14)]);
+        let next = find_next_hunk(&hunks, DiffSide::A, 20);
+        assert_eq!(next, None);
+    }
+
+    #[test]
+    fn find_next_hunk_handles_empty_range_deletion() {
+        // Deletion on side A: empty range at start=5. Cursor at 4 should match,
+        // cursor at 5 should NOT match (already at/past the filler position).
+        let hunks = make_hunks(&[(5..5, 5..7)]);
+        assert_eq!(find_next_hunk(&hunks, DiffSide::A, 4), Some(0));
+        assert_eq!(find_next_hunk(&hunks, DiffSide::A, 5), None);
+    }
+
+    #[test]
+    fn find_prev_hunk_retreats_when_cursor_inside_hunk() {
+        // Cursor on line 6 (middle of second hunk 5..8); should retreat to first hunk.
+        let hunks = make_hunks(&[(0..2, 0..2), (5..8, 5..8)]);
+        let prev = find_prev_hunk(&hunks, DiffSide::A, 6);
+        assert_eq!(prev, Some(0));
+    }
+
+    #[test]
+    fn find_prev_hunk_retreats_when_cursor_at_hunk_end_minus_one() {
+        // Cursor on the last line of a hunk (5..8 means lines 5, 6, 7). Cursor on 7
+        // is still inside; should retreat.
+        let hunks = make_hunks(&[(0..2, 0..2), (5..8, 5..8)]);
+        let prev = find_prev_hunk(&hunks, DiffSide::A, 7);
+        assert_eq!(prev, Some(0));
+    }
+
+    #[test]
+    fn find_prev_hunk_includes_hunk_just_above_cursor() {
+        // Cursor at line 8: a hunk ending at 8 (exclusive) covers lines 5..7.
+        // The hunk is fully above the cursor, so it should match.
+        let hunks = make_hunks(&[(5..8, 5..8)]);
+        let prev = find_prev_hunk(&hunks, DiffSide::A, 8);
+        assert_eq!(prev, Some(0));
+    }
+
+    #[test]
+    fn find_prev_hunk_returns_none_when_cursor_before_all() {
+        let hunks = make_hunks(&[(5..8, 5..8)]);
+        let prev = find_prev_hunk(&hunks, DiffSide::A, 0);
+        assert_eq!(prev, None);
+    }
+
+    #[test]
+    fn find_prev_hunk_handles_empty_range_deletion() {
+        // Deletion on side A at line 5 (empty range). Cursor at 5 should retreat past it
+        // (we're at or past the filler), cursor at 6 should match (filler is above us).
+        let hunks = make_hunks(&[(0..1, 0..1), (5..5, 5..7)]);
+        assert_eq!(find_prev_hunk(&hunks, DiffSide::A, 5), Some(0));
+        assert_eq!(find_prev_hunk(&hunks, DiffSide::A, 6), Some(1));
+    }
+
+    #[test]
+    fn find_next_and_prev_use_correct_side_range() {
+        // Hunk where before and after differ in placement:
+        // before: lines 5..6, after: lines 10..11.
+        let hunks = make_hunks(&[(5..6, 10..11)]);
+
+        // Side A: cursor at 4 sees hunk at line 5.
+        assert_eq!(find_next_hunk(&hunks, DiffSide::A, 4), Some(0));
+        // Side B: same cursor (4) sees hunk at line 10.
+        assert_eq!(find_next_hunk(&hunks, DiffSide::B, 4), Some(0));
+
+        // Side A: cursor at 7 has hunk behind it at line 5.
+        assert_eq!(find_prev_hunk(&hunks, DiffSide::A, 7), Some(0));
+        // Side B: cursor at 7 has hunk ahead of it at line 10, none behind.
+        assert_eq!(find_prev_hunk(&hunks, DiffSide::B, 7), None);
     }
 
     // --- build_get_transaction / build_put_transaction tests ---

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -530,10 +530,36 @@ impl InlineChange {
     }
 }
 
+/// Trim leading/trailing whitespace off the char range `[col_start, col_end)`
+/// of `line`, returning the tightened range or `None` if nothing non-whitespace
+/// remains. The whole-hunk word diff can emit spans that begin or end inside a
+/// line's indentation (identical tab tokens get threaded through the Myers LCS);
+/// trimming them keeps only the changed words and removes the scattered "tab
+/// staircase" highlights, while a mixed span like `<tabs>return` keeps `return`.
+fn trim_whitespace_cols(line: &str, col_start: usize, col_end: usize) -> Option<(usize, usize)> {
+    let chars: Vec<char> = line.chars().collect();
+    let mut start = col_start;
+    let mut end = col_end.min(chars.len());
+    while start < end && chars[start].is_whitespace() {
+        start += 1;
+    }
+    while end > start && chars[end - 1].is_whitespace() {
+        end -= 1;
+    }
+    (start < end).then_some((start, end))
+}
+
 /// Compute word-level intra-line diff for a single hunk.
 /// Returns per-line column ranges for each side indicating which words (or
 /// non-word chars) changed. Whole alphanumeric+underscore runs are treated as
 /// one token, so only the changed words are highlighted rather than individual chars.
+///
+/// The Myers diff runs over the whole hunk block (concatenated lines) so that
+/// token alignment survives however `compute_hunks` chopped the line-hunk
+/// boundaries. Each emitted span is split at line boundaries and then trimmed of
+/// leading/trailing whitespace: this strips the indentation-only spans that the
+/// LCS produces when it threads through identical leading tabs (the "tab
+/// staircase"), while keeping the genuine changed words.
 pub fn intra_line_changes(
     rope_a: &Rope,
     rope_b: &Rope,
@@ -573,45 +599,60 @@ pub fn intra_line_changes(
     let mut changes_a = Vec::new();
     let mut changes_b = Vec::new();
 
-    for tok_hunk in diff.hunks() {
-        if !tok_hunk.before.is_empty() {
-            let sc = tok_to_char(&tok_starts_a, total_chars_a, tok_hunk.before.start);
-            let ec = tok_to_char(&tok_starts_a, total_chars_a, tok_hunk.before.end);
-            let (start_line, start_col) = char_to_line_col(a_start, sc, rope_a);
-            let (end_line, end_col) = char_to_line_col(a_start, ec, rope_a);
-            // Split across lines if the change spans multiple lines
-            for line in start_line..=end_line {
-                let cs = if line == start_line { start_col } else { 0 };
-                let ce = if line == end_line {
-                    end_col
-                } else {
-                    rope_a.line(line).len_chars()
-                };
-                changes_a.push(InlineChange {
+    // Push a span split at line boundaries, trimming whitespace off each piece so
+    // indentation never gets highlighted.
+    let push_trimmed = |changes: &mut Vec<InlineChange>,
+                        rope: &Rope,
+                        start_line: usize,
+                        start_col: usize,
+                        end_line: usize,
+                        end_col: usize| {
+        for line in start_line..=end_line {
+            let cs = if line == start_line { start_col } else { 0 };
+            let ce = if line == end_line {
+                end_col
+            } else {
+                rope.line(line).len_chars()
+            };
+            let line_text: String = rope.line(line).into();
+            if let Some((cs, ce)) = trim_whitespace_cols(&line_text, cs, ce) {
+                changes.push(InlineChange {
                     doc_line: line,
                     col_start: cs,
                     col_end: ce,
                 });
             }
         }
+    };
+
+    for tok_hunk in diff.hunks() {
+        if !tok_hunk.before.is_empty() {
+            let sc = tok_to_char(&tok_starts_a, total_chars_a, tok_hunk.before.start);
+            let ec = tok_to_char(&tok_starts_a, total_chars_a, tok_hunk.before.end);
+            let (start_line, start_col) = char_to_line_col(a_start, sc, rope_a);
+            let (end_line, end_col) = char_to_line_col(a_start, ec, rope_a);
+            push_trimmed(
+                &mut changes_a,
+                rope_a,
+                start_line,
+                start_col,
+                end_line,
+                end_col,
+            );
+        }
         if !tok_hunk.after.is_empty() {
             let sc = tok_to_char(&tok_starts_b, total_chars_b, tok_hunk.after.start);
             let ec = tok_to_char(&tok_starts_b, total_chars_b, tok_hunk.after.end);
             let (start_line, start_col) = char_to_line_col(b_start, sc, rope_b);
             let (end_line, end_col) = char_to_line_col(b_start, ec, rope_b);
-            for line in start_line..=end_line {
-                let cs = if line == start_line { start_col } else { 0 };
-                let ce = if line == end_line {
-                    end_col
-                } else {
-                    rope_b.line(line).len_chars()
-                };
-                changes_b.push(InlineChange {
-                    doc_line: line,
-                    col_start: cs,
-                    col_end: ce,
-                });
-            }
+            push_trimmed(
+                &mut changes_b,
+                rope_b,
+                start_line,
+                start_col,
+                end_line,
+                end_col,
+            );
         }
     }
 
@@ -1775,6 +1816,223 @@ mod tests {
         assert_eq!(
             changes_b[0].col_end, 11,
             "change should end after 'h' of 'earth'"
+        );
+    }
+
+    #[test]
+    fn intra_line_diff_unbalanced_tab_hunk_emits_no_whitespace_spans() {
+        // 3 tab-indented lines replaced by a larger nested block. The whole-block
+        // word diff threads the Myers LCS through the wall of identical TAB tokens,
+        // which used to emit "changed" spans sitting entirely in the leading
+        // indentation (the gold staircase). Every emitted span must now be trimmed
+        // to non-whitespace content; that is the anti-staircase invariant.
+        let rope_a = Rope::from("\tif err != nil {\n\t\treturn err\n\t}\n");
+        let rope_b = Rope::from(
+            "\tif err != nil {\n\t\tlog.Println(err)\n\t\tif retry {\n\t\t\treturn retryErr\n\t\t}\n\t}\n",
+        );
+        let hunk = helix_vcs::Hunk {
+            before: 0..3,
+            after: 0..6,
+        };
+        let (changes_a, changes_b) = intra_line_changes(&rope_a, &rope_b, &hunk);
+
+        let span_text = |rope: &Rope, c: &InlineChange| -> String {
+            let line: String = rope.line(c.doc_line).into();
+            line.chars()
+                .skip(c.col_start)
+                .take(c.col_end - c.col_start)
+                .collect()
+        };
+        for c in &changes_a {
+            assert!(
+                !span_text(&rope_a, c).trim().is_empty(),
+                "A-side span is whitespace-only: {c:?}"
+            );
+        }
+        for c in &changes_b {
+            assert!(
+                !span_text(&rope_b, c).trim().is_empty(),
+                "B-side span is whitespace-only: {c:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn intra_line_diff_pairs_lines_within_balanced_multiline_hunk() {
+        // A balanced 3-line hunk where only the middle line changes a word.
+        // This exercises per-line pairing for i > 0: the change must land on
+        // doc_line = start + 1 with line-relative columns, not be offset by the
+        // earlier lines of the block.
+        let rope_a = Rope::from("\tfoo()\n\tbar()\n\tbaz()\n");
+        let rope_b = Rope::from("\tfoo()\n\tqux()\n\tbaz()\n");
+        let hunk = helix_vcs::Hunk {
+            before: 0..3,
+            after: 0..3,
+        };
+        let (changes_a, changes_b) = intra_line_changes(&rope_a, &rope_b, &hunk);
+
+        // Only the middle line differs ("bar" vs "qux"), one token each side.
+        assert_eq!(
+            changes_a.len(),
+            1,
+            "expected one A-side change, got {changes_a:?}"
+        );
+        assert_eq!(
+            changes_b.len(),
+            1,
+            "expected one B-side change, got {changes_b:?}"
+        );
+
+        // "\tbar()" -> tab at col 0, "bar" token starts at col 1, ends at col 4.
+        assert_eq!(
+            changes_a[0].doc_line, 1,
+            "change is on the second line of the hunk"
+        );
+        assert_eq!(changes_a[0].col_start, 1, "leading tab is unchanged");
+        assert_eq!(changes_a[0].col_end, 4);
+
+        assert_eq!(changes_b[0].doc_line, 1);
+        assert_eq!(changes_b[0].col_start, 1);
+        assert_eq!(changes_b[0].col_end, 4);
+    }
+
+    #[test]
+    fn intra_line_diff_ignores_indentation_only_change() {
+        // Two single lines differing only by one extra leading tab. An
+        // indentation-only change has matching trimmed content, so the line is
+        // aligned as a match and gets no intra-line highlight at all. The
+        // full-line background still conveys that the line changed; highlighting
+        // the tab itself is exactly the scatter we want to avoid.
+        let rope_a = Rope::from("\t\tif err\n");
+        let rope_b = Rope::from("\t\t\tif err\n");
+        let hunk = helix_vcs::Hunk {
+            before: 0..1,
+            after: 0..1,
+        };
+        let (changes_a, changes_b) = intra_line_changes(&rope_a, &rope_b, &hunk);
+
+        assert!(
+            changes_a.is_empty(),
+            "indentation-only change must not highlight A, got {changes_a:?}"
+        );
+        assert!(
+            changes_b.is_empty(),
+            "indentation-only change must not highlight B, got {changes_b:?}"
+        );
+    }
+
+    #[test]
+    fn intra_line_diff_pairs_lines_when_hunk_sides_start_at_different_lines() {
+        // A balanced hunk whose two sides begin on different document lines, as
+        // happens when an earlier unbalanced hunk has shifted the line numbers.
+        // The pairing must use each side's own start (before.start + i and
+        // after.start + i independently), landing the change on the right line
+        // of each document.
+        let rope_a = Rope::from("a\n\tfoo()\n\tbar()\n");
+        let rope_b = Rope::from("a\nb\n\tfoo()\n\tqux()\n");
+        let hunk = helix_vcs::Hunk {
+            before: 1..3,
+            after: 2..4,
+        };
+        let (changes_a, changes_b) = intra_line_changes(&rope_a, &rope_b, &hunk);
+
+        // Only the second paired line differs ("bar" vs "qux").
+        assert_eq!(changes_a.len(), 1, "got {changes_a:?}");
+        assert_eq!(changes_b.len(), 1, "got {changes_b:?}");
+        assert_eq!(changes_a[0].doc_line, 2, "A side: before.start + 1");
+        assert_eq!(changes_b[0].doc_line, 3, "B side: after.start + 1");
+        assert_eq!((changes_a[0].col_start, changes_a[0].col_end), (1, 4));
+        assert_eq!((changes_b[0].col_start, changes_b[0].col_end), (1, 4));
+    }
+
+    #[test]
+    fn intra_line_diff_highlights_words_when_block_is_reindented() {
+        // Real-world shape: side B wraps the body in `if len(items) > 0 {`, so
+        // every body line gains a tab. The genuine word change on the lines that
+        // correspond ("item" -> "value") must still be highlighted, and no span may
+        // fall on pure indentation (the tab-staircase regression). This is the
+        // end-to-end path (compute_hunks -> cache) that artificial-hunk tests
+        // cannot exercise. (Println/Printf land in separate add/delete hunks, so
+        // they show as full-line backgrounds, not word spans, just as upstream.)
+        let rope_a = Rope::from(concat!(
+            "package main\n",
+            "\n",
+            "import \"fmt\"\n",
+            "\n",
+            "func process(items []int) error {\n",
+            "\tfor _, item := range items {\n",
+            "\t\tif item < 0 {\n",
+            "\t\t\treturn fmt.Errorf(\"negative item: %d\", item)\n",
+            "\t\t}\n",
+            "\t\tfmt.Println(item)\n",
+            "\t}\n",
+            "\treturn nil\n",
+            "}\n",
+        ));
+        let rope_b = Rope::from(concat!(
+            "package main\n",
+            "\n",
+            "import \"fmt\"\n",
+            "\n",
+            "func process(items []int) error {\n",
+            "\tif len(items) > 0 {\n",
+            "\t\tfor _, item := range items {\n",
+            "\t\t\tif item < 0 {\n",
+            "\t\t\t\treturn fmt.Errorf(\"negative value: %d\", item)\n",
+            "\t\t\t}\n",
+            "\t\t\tfmt.Printf(\"got %d\\n\", item)\n",
+            "\t\t}\n",
+            "\t}\n",
+            "\treturn nil\n",
+            "}\n",
+        ));
+
+        let (view_a, view_b) = make_view_ids();
+        let mut session = DiffSession::new(view_a, view_b, make_doc_id(1), make_doc_id(2));
+        session.compute_hunks(&rope_a, &rope_b);
+
+        let mut all_a = Vec::new();
+        let mut all_b = Vec::new();
+        for i in 0..session.hunks().len() {
+            let (ca, cb) = session.intra_line_changes_for(i).unwrap();
+            all_a.extend(ca.iter().cloned());
+            all_b.extend(cb.iter().cloned());
+        }
+
+        let text_at = |rope: &Rope, c: &InlineChange| -> String {
+            let line: String = rope.line(c.doc_line).into();
+            line.chars()
+                .skip(c.col_start)
+                .take(c.col_end - c.col_start)
+                .collect()
+        };
+
+        // No intra-line span may be whitespace-only (that was the tab staircase).
+        for c in &all_a {
+            let t = text_at(&rope_a, c);
+            assert!(
+                !t.trim().is_empty(),
+                "A-side span is whitespace-only: {c:?} = {t:?}"
+            );
+        }
+        for c in &all_b {
+            let t = text_at(&rope_b, c);
+            assert!(
+                !t.trim().is_empty(),
+                "B-side span is whitespace-only: {c:?} = {t:?}"
+            );
+        }
+
+        // The genuine word changes on the corresponding lines are highlighted.
+        let a_texts: Vec<String> = all_a.iter().map(|c| text_at(&rope_a, c)).collect();
+        let b_texts: Vec<String> = all_b.iter().map(|c| text_at(&rope_b, c)).collect();
+        assert!(
+            a_texts.iter().any(|t| t == "item"),
+            "expected 'item' highlighted on A, got {a_texts:?}"
+        );
+        assert!(
+            b_texts.iter().any(|t| t == "value"),
+            "expected 'value' highlighted on B, got {b_texts:?}"
         );
     }
 }

--- a/helix-view/src/diff_session.rs
+++ b/helix-view/src/diff_session.rs
@@ -299,8 +299,7 @@ impl DiffSession {
     ///   [`MappedLine::Filler`] anchored at `other_range.start - 1`. The partner
     ///   has no real line for this position.
     ///
-    /// All arithmetic uses saturating ops so `u32::MAX` and other adversarial
-    /// inputs don't panic.
+    /// Saturating arithmetic throughout so `u32::MAX` inputs do not panic.
     pub fn map_line(&self, from_side: DiffSide, line: u32) -> MappedLine {
         let mut offset: i64 = 0;
         for hunk in self.hunks.iter() {
@@ -650,15 +649,14 @@ impl DiffAlignment {
         }
     }
 
-    /// Compute how many filler lines to insert after `doc_line`.
-    /// Returns 0 if no filler is needed at this line.
+    /// How many filler lines to insert after `doc_line`. Returns 0 if no
+    /// filler is needed at this line.
     ///
-    /// Multiple hunks can share a trigger position (e.g. a non-empty hunk
-    /// ending at line X and a pure insertion immediately after at `[X..X)` -
-    /// both trigger at line `X - 1`). We accumulate fillers across every hunk
-    /// at the current trigger before returning, otherwise the second hunk's
-    /// fillers would be silently dropped when the cursor advances past it on
-    /// the next call.
+    /// Multiple hunks can share a trigger position. A non-empty hunk ending
+    /// at line X and a pure insertion at `[X..X)` both trigger at `X - 1`,
+    /// for example. We accumulate fillers from every hunk at the current
+    /// trigger in a single call. Otherwise the cursor advances past them on
+    /// the next call and their fillers go missing.
     pub fn filler_lines_at(&mut self, doc_line: usize) -> usize {
         // Advance cursor past hunks that ended before this line.
         while self.cursor < self.hunks.len() {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1292,6 +1292,8 @@ pub struct Editor {
     pub diagnostics: Diagnostics,
     pub diff_providers: DiffProviderRegistry,
     pub diff_sessions: Vec<crate::diff_session::DiffSession>,
+    /// Holds the first view that called `:diffthis`, waiting for a second call to complete the pair.
+    pub pending_diff_this: Option<ViewId>,
 
     pub debug_adapters: dap::registry::Registry,
     pub breakpoints: HashMap<PathBuf, Vec<Breakpoint>>,
@@ -1443,6 +1445,7 @@ impl Editor {
             diagnostics: Diagnostics::new(),
             diff_providers: DiffProviderRegistry::default(),
             diff_sessions: Vec::new(),
+            pending_diff_this: None,
             debug_adapters: dap::registry::Registry::new(),
             breakpoints: HashMap::new(),
             syn_loader,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2156,6 +2156,11 @@ impl Editor {
             doc.remove_view(id);
         }
         self.tree.remove(id);
+        // Prune any diff sessions whose view or pending marker matches the closed view.
+        self.diff_sessions.retain(|s| !s.contains_view(id));
+        if self.pending_diff_this == Some(id) {
+            self.pending_diff_this = None;
+        }
         self._refresh();
     }
 
@@ -2170,6 +2175,8 @@ impl Editor {
 
         // This will also disallow any follow-up writes
         self.saves.remove(&doc_id);
+        // Prune any diff sessions that reference the document being closed.
+        self.diff_sessions.retain(|s| !s.contains_doc(doc_id));
 
         enum Action {
             Close(ViewId),

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2328,9 +2328,9 @@ impl Editor {
     /// diff session's hunks. No-op when the two views aren't paired in the
     /// same `DiffSession`.
     fn sync_diff_cursor(&mut self, source_view_id: ViewId, dest_view_id: ViewId) {
-        // Gate: source and dest must be paired in the same diff session.
-        // partner_view(src) returning Some(dst) is the binding contract; if
-        // either side has been closed or the sessions differ, skip.
+        // Only sync when source and dest are actual partners in the same
+        // session. If either view was closed or they belong to different
+        // sessions, skip - we must not write to a foreign view's selection.
         let source_side = self
             .diff_sessions
             .iter()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2500,11 +2500,16 @@ impl Editor {
         let mut partner_offset = self.documents[&partner_doc_id].view_offset(partner_id);
         if partner_offset.anchor == partner_anchor
             && partner_offset.vertical_offset == source_offset.vertical_offset
+            && partner_offset.horizontal_offset == source_offset.horizontal_offset
         {
             return;
         }
         partner_offset.anchor = partner_anchor;
         partner_offset.vertical_offset = source_offset.vertical_offset;
+        // Mirror the source's horizontal scroll. Without this the panes drift
+        // sideways the moment the user scrolls right past wrap width on one
+        // side; with soft-wrap off, that's any line longer than the viewport.
+        partner_offset.horizontal_offset = source_offset.horizontal_offset;
         self.documents
             .get_mut(&partner_doc_id)
             .unwrap()

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2374,9 +2374,7 @@ impl Editor {
 
     /// Returns the DiffSession containing the given view, if one exists.
     pub fn diff_session_for(&self, view_id: ViewId) -> Option<&crate::diff_session::DiffSession> {
-        self.diff_sessions
-            .iter()
-            .find(|s| s.contains_view(view_id))
+        self.diff_sessions.iter().find(|s| s.contains_view(view_id))
     }
 
     /// Returns a mutable reference to the DiffSession containing the given view.

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2376,7 +2376,7 @@ impl Editor {
     pub fn diff_session_for(&self, view_id: ViewId) -> Option<&crate::diff_session::DiffSession> {
         self.diff_sessions
             .iter()
-            .find(|s: &&crate::diff_session::DiffSession| s.contains_view(view_id))
+            .find(|s| s.contains_view(view_id))
     }
 
     /// Returns a mutable reference to the DiffSession containing the given view.
@@ -2386,33 +2386,27 @@ impl Editor {
     ) -> Option<&mut crate::diff_session::DiffSession> {
         self.diff_sessions
             .iter_mut()
-            .find(|s: &&mut crate::diff_session::DiffSession| s.contains_view(view_id))
+            .find(|s| s.contains_view(view_id))
     }
 
     /// Synchronize the partner view's scroll position to match the source view.
     /// Copies the source view's anchor line to the partner view's document.
     pub fn sync_diff_scroll(&mut self, source_view_id: ViewId) {
-        let session = self
+        let Some(partner_id) = self
             .diff_sessions
             .iter()
-            .find(|s: &&crate::diff_session::DiffSession| s.contains_view(source_view_id));
-        let Some(session) = session else {
+            .find(|s| s.contains_view(source_view_id))
+            .and_then(|s| s.partner_view(source_view_id))
+        else {
             return;
-        };
-        let partner_id = match session.partner_view(source_view_id) {
-            Some(id) => id,
-            None => return,
         };
 
         let source_view = self.tree.get(source_view_id);
         let source_doc_id = source_view.doc;
         let source_offset = self.documents[&source_doc_id].view_offset(source_view_id);
-
-        // Get the line number at the source view's anchor
         let source_text = self.documents[&source_doc_id].text().slice(..);
         let source_line = source_text.char_to_line(source_offset.anchor);
 
-        // Set the partner view's anchor to the same line in its document
         let partner_view = self.tree.get(partner_id);
         let partner_doc_id = partner_view.doc;
         let partner_text = self.documents[&partner_doc_id].text().slice(..);
@@ -2420,6 +2414,11 @@ impl Editor {
         let partner_anchor = partner_text.line_to_char(partner_line);
 
         let mut partner_offset = self.documents[&partner_doc_id].view_offset(partner_id);
+        if partner_offset.anchor == partner_anchor
+            && partner_offset.vertical_offset == source_offset.vertical_offset
+        {
+            return;
+        }
         partner_offset.anchor = partner_anchor;
         partner_offset.vertical_offset = source_offset.vertical_offset;
         self.documents

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1291,6 +1291,7 @@ pub struct Editor {
     pub language_servers: helix_lsp::Registry,
     pub diagnostics: Diagnostics,
     pub diff_providers: DiffProviderRegistry,
+    pub diff_sessions: Vec<crate::diff_session::DiffSession>,
 
     pub debug_adapters: dap::registry::Registry,
     pub breakpoints: HashMap<PathBuf, Vec<Breakpoint>>,
@@ -1441,6 +1442,7 @@ impl Editor {
             language_servers,
             diagnostics: Diagnostics::new(),
             diff_providers: DiffProviderRegistry::default(),
+            diff_sessions: Vec::new(),
             debug_adapters: dap::registry::Registry::new(),
             breakpoints: HashMap::new(),
             syn_loader,
@@ -2333,7 +2335,8 @@ impl Editor {
         let config = self.config();
         let view = self.tree.get(id);
         let doc = doc_mut!(self, &view.doc);
-        view.ensure_cursor_in_view(doc, config.scrolloff)
+        view.ensure_cursor_in_view(doc, config.scrolloff);
+        self.sync_diff_scroll(id);
     }
 
     #[inline]
@@ -2364,6 +2367,62 @@ impl Editor {
     pub fn document_by_path_mut<P: AsRef<Path>>(&mut self, path: P) -> Option<&mut Document> {
         self.documents_mut()
             .find(|doc| doc.path().is_some_and(|p| p == path.as_ref()))
+    }
+
+    /// Returns the DiffSession containing the given view, if one exists.
+    pub fn diff_session_for(&self, view_id: ViewId) -> Option<&crate::diff_session::DiffSession> {
+        self.diff_sessions
+            .iter()
+            .find(|s: &&crate::diff_session::DiffSession| s.contains_view(view_id))
+    }
+
+    /// Returns a mutable reference to the DiffSession containing the given view.
+    pub fn diff_session_for_mut(
+        &mut self,
+        view_id: ViewId,
+    ) -> Option<&mut crate::diff_session::DiffSession> {
+        self.diff_sessions
+            .iter_mut()
+            .find(|s: &&mut crate::diff_session::DiffSession| s.contains_view(view_id))
+    }
+
+    /// Synchronize the partner view's scroll position to match the source view.
+    /// Copies the source view's anchor line to the partner view's document.
+    pub fn sync_diff_scroll(&mut self, source_view_id: ViewId) {
+        let session = self
+            .diff_sessions
+            .iter()
+            .find(|s: &&crate::diff_session::DiffSession| s.contains_view(source_view_id));
+        let Some(session) = session else {
+            return;
+        };
+        let partner_id = match session.partner_view(source_view_id) {
+            Some(id) => id,
+            None => return,
+        };
+
+        let source_view = self.tree.get(source_view_id);
+        let source_doc_id = source_view.doc;
+        let source_offset = self.documents[&source_doc_id].view_offset(source_view_id);
+
+        // Get the line number at the source view's anchor
+        let source_text = self.documents[&source_doc_id].text().slice(..);
+        let source_line = source_text.char_to_line(source_offset.anchor);
+
+        // Set the partner view's anchor to the same line in its document
+        let partner_view = self.tree.get(partner_id);
+        let partner_doc_id = partner_view.doc;
+        let partner_text = self.documents[&partner_doc_id].text().slice(..);
+        let partner_line = source_line.min(partner_text.len_lines().saturating_sub(1));
+        let partner_anchor = partner_text.line_to_char(partner_line);
+
+        let mut partner_offset = self.documents[&partner_doc_id].view_offset(partner_id);
+        partner_offset.anchor = partner_anchor;
+        partner_offset.vertical_offset = source_offset.vertical_offset;
+        self.documents
+            .get_mut(&partner_doc_id)
+            .unwrap()
+            .set_view_offset(partner_id, partner_offset);
     }
 
     /// Returns all supported diagnostics for the document

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2401,14 +2401,16 @@ impl Editor {
             return;
         };
 
-        let source_view = self.tree.get(source_view_id);
-        let source_doc_id = source_view.doc;
+        let Some(source_doc_id) = self.tree.try_get(source_view_id).map(|v| v.doc) else {
+            return;
+        };
         let source_offset = self.documents[&source_doc_id].view_offset(source_view_id);
         let source_text = self.documents[&source_doc_id].text().slice(..);
         let source_line = source_text.char_to_line(source_offset.anchor);
 
-        let partner_view = self.tree.get(partner_id);
-        let partner_doc_id = partner_view.doc;
+        let Some(partner_doc_id) = self.tree.try_get(partner_id).map(|v| v.doc) else {
+            return;
+        };
         let partner_text = self.documents[&partner_doc_id].text().slice(..);
         let partner_line = source_line.min(partner_text.len_lines().saturating_sub(1));
         let partner_anchor = partner_text.line_to_char(partner_line);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2397,12 +2397,16 @@ impl Editor {
     /// Synchronize the partner view's scroll position to match the source view.
     /// Copies the source view's anchor line to the partner view's document.
     pub fn sync_diff_scroll(&mut self, source_view_id: ViewId) {
-        let Some(partner_id) = self
+        let session_info = self
             .diff_sessions
             .iter()
             .find(|s| s.contains_view(source_view_id))
-            .and_then(|s| s.partner_view(source_view_id))
-        else {
+            .and_then(|s| {
+                let partner = s.partner_view(source_view_id)?;
+                let side = s.side_for_view(source_view_id)?;
+                Some((partner, side))
+            });
+        let Some((partner_id, source_side)) = session_info else {
             return;
         };
 
@@ -2411,13 +2415,25 @@ impl Editor {
         };
         let source_offset = self.documents[&source_doc_id].view_offset(source_view_id);
         let source_text = self.documents[&source_doc_id].text().slice(..);
-        let source_line = source_text.char_to_line(source_offset.anchor);
+        let source_line = source_text.char_to_line(source_offset.anchor) as u32;
 
         let Some(partner_doc_id) = self.tree.try_get(partner_id).map(|v| v.doc) else {
             return;
         };
         let partner_text = self.documents[&partner_doc_id].text().slice(..);
-        let partner_line = source_line.min(partner_text.len_lines().saturating_sub(1));
+        let partner_line_count = partner_text.len_lines() as u32;
+
+        // Map through the hunks so the partner anchor lands on the matching
+        // logical line, not just the same line index. Without this, asymmetric
+        // hunks above the anchor would scroll the panes out of sync.
+        let partner_line = self
+            .diff_sessions
+            .iter()
+            .find(|s| s.contains_view(source_view_id))
+            .map(|s| s.map_to_real_line(source_side, source_line, partner_line_count) as usize)
+            .unwrap_or_else(|| {
+                (source_line as usize).min(partner_line_count.saturating_sub(1) as usize)
+            });
         let partner_anchor = partner_text.line_to_char(partner_line);
 
         let mut partner_offset = self.documents[&partner_doc_id].view_offset(partner_id);

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2293,10 +2293,19 @@ impl Editor {
             return;
         }
 
+        let prev_id = self.tree.focus;
+
         // Reset mode to normal and ensure any pending changes are committed in the old document.
         self.enter_normal_mode();
         let (view, doc) = current!(self);
         doc.append_changes_to_history(view);
+
+        // If the source and destination are paired in a diff session, move the
+        // destination's cursor to the corresponding partner line before scroll
+        // sync so ensure_cursor_in_view scrolls to the new position rather than
+        // the partner view's last-known cursor.
+        self.sync_diff_cursor(prev_id, view_id);
+
         self.ensure_cursor_in_view(view_id);
         // Update jumplist selections with new document changes.
         for (view, _focused) in self.tree.views_mut() {
@@ -2304,7 +2313,7 @@ impl Editor {
             view.sync_changes(doc);
         }
 
-        let prev_id = std::mem::replace(&mut self.tree.focus, view_id);
+        self.tree.focus = view_id;
         doc_mut!(self).mark_as_focused();
 
         let focus_lost = self.tree.get(prev_id).doc;
@@ -2312,6 +2321,65 @@ impl Editor {
             editor: self,
             doc: focus_lost,
         });
+    }
+
+    /// Place `dest_view_id`'s primary cursor at the line on its document that
+    /// corresponds to `source_view_id`'s primary cursor, mapped through the
+    /// diff session's hunks. No-op when the two views aren't paired in the
+    /// same `DiffSession`.
+    fn sync_diff_cursor(&mut self, source_view_id: ViewId, dest_view_id: ViewId) {
+        // Gate: source and dest must be paired in the same diff session.
+        // partner_view(src) returning Some(dst) is the binding contract; if
+        // either side has been closed or the sessions differ, skip.
+        let source_side = self
+            .diff_sessions
+            .iter()
+            .find(|s| s.contains_view(source_view_id))
+            .and_then(|s| {
+                if s.partner_view(source_view_id) != Some(dest_view_id) {
+                    return None;
+                }
+                s.side_for_view(source_view_id)
+            });
+        let Some(source_side) = source_side else {
+            return;
+        };
+
+        let Some(source_doc_id) = self.tree.try_get(source_view_id).map(|v| v.doc) else {
+            return;
+        };
+        let source_doc = &self.documents[&source_doc_id];
+        let source_text = source_doc.text().slice(..);
+        let source_cursor = source_doc
+            .selection(source_view_id)
+            .primary()
+            .cursor(source_text);
+        let source_line = source_text.char_to_line(source_cursor) as u32;
+
+        let Some(dest_doc_id) = self.tree.try_get(dest_view_id).map(|v| v.doc) else {
+            return;
+        };
+
+        let dest_char = {
+            let dest_text = self.documents[&dest_doc_id].text().slice(..);
+            let dest_line_count = dest_text.len_lines() as u32;
+            let Some(mapped_line) = self
+                .diff_sessions
+                .iter()
+                .find(|s| s.contains_view(source_view_id))
+                .map(|s| s.map_to_real_line(source_side, source_line, dest_line_count))
+            else {
+                return;
+            };
+            let safe_line = (mapped_line as usize).min(dest_line_count.saturating_sub(1) as usize);
+            dest_text.line_to_char(safe_line)
+        };
+
+        let new_selection = helix_core::Selection::point(dest_char);
+        self.documents
+            .get_mut(&dest_doc_id)
+            .unwrap()
+            .set_selection(dest_view_id, new_selection);
     }
 
     pub fn focus_next(&mut self) {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -2331,17 +2331,9 @@ impl Editor {
         // Only sync when source and dest are actual partners in the same
         // session. If either view was closed or they belong to different
         // sessions, skip - we must not write to a foreign view's selection.
-        let source_side = self
-            .diff_sessions
-            .iter()
-            .find(|s| s.contains_view(source_view_id))
-            .and_then(|s| {
-                if s.partner_view(source_view_id) != Some(dest_view_id) {
-                    return None;
-                }
-                s.side_for_view(source_view_id)
-            });
-        let Some(source_side) = source_side else {
+        let Some(source_side) =
+            crate::diff_session::paired_side(&self.diff_sessions, source_view_id, dest_view_id)
+        else {
             return;
         };
 
@@ -2493,15 +2485,16 @@ impl Editor {
 
         // Map through the hunks so the partner anchor lands on the matching
         // logical line, not just the same line index. Without this, asymmetric
-        // hunks above the anchor would scroll the panes out of sync.
+        // hunks above the anchor would scroll the panes out of sync. The
+        // session lookup must succeed - the early-return at the top already
+        // proved it exists, and we have not mutated diff_sessions since.
         let partner_line = self
             .diff_sessions
             .iter()
             .find(|s| s.contains_view(source_view_id))
-            .map(|s| s.map_to_real_line(source_side, source_line, partner_line_count) as usize)
-            .unwrap_or_else(|| {
-                (source_line as usize).min(partner_line_count.saturating_sub(1) as usize)
-            });
+            .expect("session was just resolved above")
+            .map_to_real_line(source_side, source_line, partner_line_count)
+            as usize;
         let partner_anchor = partner_text.line_to_char(partner_line);
 
         let mut partner_offset = self.documents[&partner_doc_id].view_offset(partner_id);

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -4,6 +4,7 @@ pub mod macros;
 pub mod action;
 pub mod annotations;
 pub mod clipboard;
+pub mod diff_session;
 pub mod document;
 pub mod editor;
 pub mod events;

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -763,4 +763,37 @@ mod tests {
         let highlight = Highlight::new(Theme::rgb_highlight(0, 0, 0).get() - 1);
         Theme::default().highlight(highlight);
     }
+
+    #[test]
+    fn default_theme_defines_diff_view_scopes() {
+        // The diff viewer pulls its line backgrounds from the `.view` namespace.
+        // Each key must resolve via try_get_exact (no rsplit cascade) so the
+        // diff viewer never silently picks up a bare `diff.*` style intended
+        // for the VCS gutter or the diff language grammar.
+        let theme = DEFAULT_THEME.clone();
+        for key in [
+            "diff.plus.view",
+            "diff.minus.view",
+            "diff.delta.view",
+            "diff.delta.view.text",
+        ] {
+            assert!(
+                theme.try_get_exact(key).is_some(),
+                "default theme is missing required diff viewer scope `{key}`",
+            );
+        }
+    }
+
+    #[test]
+    fn default_theme_keeps_legacy_diff_scopes() {
+        // The bare scopes back the VCS gutter and the diff language grammar.
+        // They MUST stay defined so existing consumers keep working.
+        let theme = DEFAULT_THEME.clone();
+        for key in ["diff.plus", "diff.minus", "diff.delta"] {
+            assert!(
+                theme.try_get_exact(key).is_some(),
+                "default theme dropped legacy diff scope `{key}`",
+            );
+        }
+    }
 }

--- a/theme.toml
+++ b/theme.toml
@@ -1,6 +1,6 @@
 attribute = "lilac"
 keyword = "almond"
-"keyword.directive" = "lilac" # -- preprocessor comments (#if in C)
+"keyword.directive" = "lilac"        # -- preprocessor comments (#if in C)
 namespace = "lilac"
 punctuation = "lavender"
 "punctuation.delimiter" = "lavender"
@@ -13,7 +13,7 @@ variable = "lavender"
 "variable.parameter" = { fg = "lavender" }
 "variable.builtin" = "mint"
 type = "white"
-"type.builtin" = "white" # TODO: distinguish?
+"type.builtin" = "white"                   # TODO: distinguish?
 constructor = "lilac"
 function = "white"
 "function.macro" = "lilac"
@@ -40,6 +40,18 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 "diff.plus" = "#35bf86"
 "diff.minus" = "#f22c86"
 "diff.delta" = "#6f44f0"
+
+# Diff viewer (vimdiff-style two-file compare). Distinct from the bare
+# `diff.*` scopes above, which are also used by the VCS gutter and the
+# diff language grammar.
+"diff.plus.view" = { bg = "#1f6f4e" }
+"diff.minus.view" = { bg = "#ad0b55" }
+"diff.delta.view" = { bg = "#41288c" }
+"diff.delta.view.text" = { bg = "#5e3bc6" }
+"diff.delta.conflict" = { fg = "#f22c86", bg = "#6a2038" }
+"diff.plus.gutter" = { fg = "#35bf86" }
+"diff.minus.gutter" = { fg = "#f22c86" }
+"diff.delta.gutter" = { fg = "#6f44f0" }
 
 # TODO: differentiate doc comment
 # concat (ERROR) @error.syntax and "MISSING ;" selectors for errors


### PR DESCRIPTION
A vimdiff-style side-by-side diff viewer.

<img width="1129" height="623" alt="image" src="https://github.com/user-attachments/assets/a3584bfa-2c27-4c44-9cd6-0457b22ee640" />

**Usage**

- `:diff-open file1 file2` opens both files in a vertical split and starts a diff session. Alias: `:diffs`.
- `hx --diff file1 file2` (or `-d`) does the same from the command line.
- `:diff-this` marks a view; call it in a second view to pair them.

**Inside a session**

- `:diffget` / `reset-diff-change` pulls the hunk at the cursor from the partner file.
- `:diffput` pushes the current selection's hunk the other way.
- `:diff-off` tears the session down, leaving both views open.
- `]g` and `[g` jump between hunks, using session hunks and falling back to VCS hunks when outside a session.

**How it works**

The renderer recomputes hunks when `Document::version()` changes. A `LineAnnotation` inserts virtual filler lines so both sides line up by logical row. Line backgrounds come from `diff.plus`, `diff.minus`, and `diff.delta`. Intra-line highlights use an `OverlayHighlights` layer keyed on `diff.delta.text`, falling back to `diff.delta` when unset. Changed regions are diffed at the word level (alphanumeric runs), so `foo_bar` vs `baz_bar` highlights `foo` rather than a run of character edits.

**Theme**

`diff.delta.text` is a new scope for intra-line changed characters; it falls back to `diff.delta` when unset. The default `theme.toml` defines it with an explicit `bg` so whitespace changes are visible against the `diff.delta` line background.

**Tests**

23 unit tests in `helix-view/src/diff_session.rs` cover alignment, hunk intersection, and the diffget/diffput transaction builders. Integration tests in `helix-term/tests/test/diff_mode.rs` exercise `:diff-open`, `:diff-this`, `:diff-off`, `:diffget`, and `:diffput` against tempfile-backed documents.

**Known rough edges**

- Clicking on a filler line places the cursor above the intended row; click coordinates need remapping for virtual lines.
- Intra-line highlights won't show up well if the active theme has low contrast between `diff.delta`'s fg and bg.
- A pure insertion at line 0 renders filler after the first line rather than before it.
- Horizontal scroll, tabs, and wide characters aren't accounted for in filler column math.
