### PR TITLE
fix(queries): incorrect query captures

### DIFF
--- a/runtime/queries/bass/highlights.scm
+++ b/runtime/queries/bass/highlights.scm
@@ -69,8 +69,8 @@
 (list . (symbol) @function.macro (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|for|\\$|linux)$"))
 (cons . (symbol) @function.macro (#match? @function.macro "^(op|fn|current-scope|quote|let|provide|module|or|and|->|curryfn|for|\\$|linux)$"))
 
-(list . (symbol) @keyword.builtin (#match? @keyword.builtin "^(do|doc)$"))
-(cons . (symbol) @keyword.builtin (#match? @keyword.builtin "^(do|doc)$"))
+(list . (symbol) @keyword (#match? @keyword "^(do|doc)$"))
+(cons . (symbol) @keyword (#match? @keyword "^(do|doc)$"))
 
 (list . (symbol) @keyword.control.import (#match? @keyword.control.import "^(use|import|load)$"))
 (cons . (symbol) @keyword.control.import (#match? @keyword.control.import "^(use|import|load)$"))

--- a/runtime/queries/bicep/highlights.scm
+++ b/runtime/queries/bicep/highlights.scm
@@ -183,7 +183,7 @@
 
 (escape_sequence) @constant.character
 
-(number) @constant.number
+(number) @constant.numeric
 
 (boolean) @constant.builtin.boolean
 

--- a/runtime/queries/chuck/highlights.scm
+++ b/runtime/queries/chuck/highlights.scm
@@ -4,7 +4,7 @@
 "do" @keyword.control.repeat
 "fun" @keyword.function
 "function" @keyword.function
-"if" @keyword.control.conditionl
+"if" @keyword.control.conditional
 "repeat" @keyword.control.repeat
 "return" @keyword.control.return
 "spork" @function.builtin

--- a/runtime/queries/elixir/highlights.scm
+++ b/runtime/queries/elixir/highlights.scm
@@ -99,9 +99,9 @@
 
 (sigil
   (sigil_name) @__name__
-  quoted_start: _ @string.regex
-  quoted_end: _ @string.regex
-  (#match? @__name__ "^[rR]$")) @string.regex
+  quoted_start: _ @string.regexp
+  quoted_end: _ @string.regexp
+  (#match? @__name__ "^[rR]$")) @string.regexp
 
 ; Calls
 

--- a/runtime/queries/graphql/highlights.scm
+++ b/runtime/queries/graphql/highlights.scm
@@ -100,11 +100,11 @@
 
 (string_value) @string
 
-(int_value) @constants.numeric.integer
+(int_value) @constant.numeric.integer
 
-(float_value) @constants.numeric.float
+(float_value) @constant.numeric.float
 
-(boolean_value) @constants.builtin.boolean
+(boolean_value) @constant.builtin.boolean
 
 ; Literals
 ;---------

--- a/runtime/queries/haskell/highlights.scm
+++ b/runtime/queries/haskell/highlights.scm
@@ -429,10 +429,10 @@
 ; Fields
 
 (field_name
-  (variable) @variable.member)
+  (variable) @variable.other.member)
 
 (import_name
   (name)
   .
   (children
-    (variable) @variable.member))
+    (variable) @variable.other.member))

--- a/runtime/queries/hurl/highlights.scm
+++ b/runtime/queries/hurl/highlights.scm
@@ -23,7 +23,7 @@
 (quoted_string) @string
 (json_string) @string
 (file_value) @string.special.path
-(regex) @string.regex
+(regex) @string.regexp
 
 [
   "\\"

--- a/runtime/queries/ink/highlights.scm
+++ b/runtime/queries/ink/highlights.scm
@@ -1,6 +1,6 @@
 ; tags and labels
 (label) @label
-(tag (identifier) @commment)
+(tag (identifier) @comment)
 (tag) @comment
 
 ; values

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -204,7 +204,7 @@
 ((generic_command
   command: (command_name) @_name
   .
-  arg: (curly_group (_) @markup.link.uri))
+  arg: (curly_group (_) @markup.link.url))
   (#match? @_name "^(\\\\url|\\\\href)$"))
 
 ;; File inclusion commands

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -228,7 +228,7 @@
   command: _ @keyword.control.import
   path: (curly_group_path) @string)
 (biblatex_include
-  "\\addbibresource" @include
+  "\\addbibresource" @keyword.control.import
   glob: (curly_group_glob_pattern) @string.regex)
 
 (graphics_include

--- a/runtime/queries/latex/highlights.scm
+++ b/runtime/queries/latex/highlights.scm
@@ -229,7 +229,7 @@
   path: (curly_group_path) @string)
 (biblatex_include
   "\\addbibresource" @keyword.control.import
-  glob: (curly_group_glob_pattern) @string.regex)
+  glob: (curly_group_glob_pattern) @string.regexp)
 
 (graphics_include
   command: _ @keyword.control.import

--- a/runtime/queries/lean/highlights.scm
+++ b/runtime/queries/lean/highlights.scm
@@ -72,7 +72,7 @@
 
 ["for" "in" "do"] @keyword.control.repeat
 
-(import) @include
+"import" @keyword.control.import
 
 ; Tokens
 

--- a/runtime/queries/pascal/highlights.scm
+++ b/runtime/queries/pascal/highlights.scm
@@ -154,7 +154,7 @@
 
 ; -- Literals
 
-(literalNumber)   @constant.builtin.numeric
+(literalNumber)   @constant.numeric
 (literalString)   @string
 
 ; -- Builtin constants

--- a/runtime/queries/php-only/highlights.scm
+++ b/runtime/queries/php-only/highlights.scm
@@ -66,8 +66,8 @@
 ] @string
 (boolean) @constant.builtin.boolean
 (null) @constant.builtin
-(integer) @constant.builtin.integer
-(float) @constant.builtin.float
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
 (comment) @comment
 
 "$" @operator

--- a/runtime/queries/ripple/highlights.scm
+++ b/runtime/queries/ripple/highlights.scm
@@ -117,7 +117,7 @@
   "${" @punctuation.special
   "}" @punctuation.special)
 
-(number) @number
+(number) @constant.numeric
 (true) @constant.builtin.boolean
 (false) @constant.builtin.boolean
 (null) @constant.builtin

--- a/runtime/queries/scheme/highlights.scm
+++ b/runtime/queries/scheme/highlights.scm
@@ -124,8 +124,8 @@
 
 (list
   .
-  ((symbol) @keyword.conditional
-   (#any-of? @keyword.conditional "if" "cond" "case" "when" "unless")))
+  ((symbol) @keyword.control.conditional
+   (#any-of? @keyword.control.conditional "if" "cond" "case" "when" "unless")))
 
 (list
   .

--- a/runtime/queries/t32/highlights.scm
+++ b/runtime/queries/t32/highlights.scm
@@ -143,13 +143,13 @@
 ; Returns
 (
   (command_expression
-    command: (identifier) @keyword.return)
-  (#match? @keyword.return "^[eE][nN][dD]([dD][oO])?$")
+    command: (identifier) @keyword.control.return)
+  (#match? @keyword.control.return "^[eE][nN][dD]([dD][oO])?$")
 )
 (
   (command_expression
-    command: (identifier) @keyword.return)
-  (#match? @keyword.return "^[rR][eE][tT][uU][rR][nN]$")
+    command: (identifier) @keyword.control.return)
+  (#match? @keyword.control.return "^[rR][eE][tT][uU][rR][nN]$")
 )
 
 
@@ -213,14 +213,14 @@
 
 ; Control flow
 (if_block
-  command: (identifier) @keyword.control.conditional.if)
+  command: (identifier) @keyword.control.conditional)
 (else_block
-  command: (identifier) @keyword.control.control.else)
+  command: (identifier) @keyword.control.conditional)
 
 (while_block
-  command: (identifier) @keyword.control.repeat.while)
+  command: (identifier) @keyword.control.repeat)
 (repeat_block
-  command: (identifier) @keyword.control.loop)
+  command: (identifier) @keyword.control.repeat)
 
 
 

--- a/runtime/queries/v/highlights.scm
+++ b/runtime/queries/v/highlights.scm
@@ -159,7 +159,7 @@
 
 [
   "fn"
-] @keyword.control.function
+] @keyword.function
 
 
 [

--- a/runtime/queries/vhdl/highlights.scm
+++ b/runtime/queries/vhdl/highlights.scm
@@ -249,7 +249,7 @@
   ","
   "."
   ";"
-] @punctuation.delimiters
+] @punctuation.delimiter
 
 [
   "("

--- a/runtime/queries/vim/highlights.scm
+++ b/runtime/queries/vim/highlights.scm
@@ -17,7 +17,7 @@
   "finally"
   "endtry"
   "throw"
-] @keyword.control.except
+] @keyword.control.exception
 
 [
   "for"


### PR DESCRIPTION
i made a small script to go through the [theme scopes](https://docs.helix-editor.com/master/themes.html#scopes) and collect all valid scopes and then go through the queries to see if there are captures, that aren't valid. i then went through those and fixed them to use the correct captures. a lot of these were just typos or captures used by other editors like neovim.

there's still a bunch more invalid queries to go through, but i thought it would make it easier to review if it wasn't even bigger than it already is.