### PR TITLE
Improve readability and grammar of workspace trust docs and popup

### DIFF
--- a/book/src/workspace-trust.md
+++ b/book/src/workspace-trust.md
@@ -18,7 +18,7 @@ You can always make the current workspace trusted by running the `:workspace-tru
 Lists of trusted and excluded workspaces, delimited by newline characters, are stored in:
 
 - Linux and macOS: `~/.local/share/helix/trusted_workspaces` and `~/.local/share/helix/excluded_workspaces`
-- Windows: `%AppData%/Roaming/helix/trusted_workspaces` and `%AppData%/Roaming/helix/excluded_workspaces` 
+- Windows: `%AppData%\Roaming\helix\trusted_workspaces` and `%AppData%\Roaming\helix\excluded_workspaces`
 
 ## Configuration
 

--- a/book/src/workspace-trust.md
+++ b/book/src/workspace-trust.md
@@ -1,25 +1,28 @@
 # Workspace trust
 
-Helix has two potentially dangerous features: language servers (LSP) and local workspace configurations, both of which can execute arbitrary code. To protect against this, Helix includes workspace trust protection, which prevents these features from running automatically unless the workspace is explicitly trusted.
+Helix includes two potentially dangerous features, both of which can execute arbitrary code:
+
+- Language servers (LSP)
+- Local workspace configurations (`.helix/config.toml` and `.helix/languages.toml`)
+
+To protect against this, Helix includes workspace trust protection, which prevents these features from running automatically unless the workspace is explicitly trusted.
 
 ## Default trust behavior
 
 Helix does not trust any workspace by default and will prompt you to choose the trust level when you open a file in a workspace where trust has not yet been set.
 
-If you decide not to trust a workspace and want to avoid repeated trust prompts when starting new sessions, you can exclude it by selecting `Never` in the trust selection window.
-
 ## Changing workspace trust status
 
 You can always make the current workspace trusted by running the `:workspace-trust` command, and untrust it using `:workspace-untrust`.
 
-## Where trust settings are stored
+Lists of trusted and excluded workspaces, delimited by newline characters, are stored in:
 
-Lists of trusted and excluded workspaces, delimited by newline characters, are stored in `~/.local/share/helix/trusted_workspaces` and `~/.local/share/helix/excluded_workspaces` correspondingly.
-<!-- TODO: Windows paths -->
+- Linux and macOS: `~/.local/share/helix/trusted_workspaces` and `~/.local/share/helix/excluded_workspaces`
+- Windows: `%AppData%/Roaming/helix/trusted_workspaces` and `%AppData%/Roaming/helix/excluded_workspaces` 
 
 ## Configuration
 
-You can return to the old behaviour of loading every local `.helix/config.toml` and `.helix/languages.toml` and starting language servers without an explicit permission by setting the following option:
+You can disable workspace trust completely with:
 
 ```toml
 [editor]

--- a/book/src/workspace-trust.md
+++ b/book/src/workspace-trust.md
@@ -1,21 +1,25 @@
 # Workspace trust
 
-Helix has a number of potentially dangerous features, namely LSP and ability to use local to workspace configurations. Those features can lead to unexpected code execution. To protect against code execution in dangerous contexts, Helix has a workspace trust protection, which will prevent these potentially dangerous features from running automatically.
+Helix has two potentially dangerous features: language servers (LSP) and local workspace configurations, both of which can execute arbitrary code. To protect against this, Helix includes workspace trust protection, which prevents these features from running automatically unless the workspace is explicitly trusted.
 
-Helix will not trust any workspace by default.
+## Default trust behavior
 
-By default, it will prompt about trust when you open new file in a workspace where you didn't make a decision about trust yet.
+Helix does not trust any workspace by default and will prompt you to choose the trust level when you open a file in a workspace where trust has not yet been set.
 
-If you decide not to trust a workspace and don't want to be prompted about trust every time you start a new session in it, you can exclude the workspace by choosing `Never` option in trust selection window.
+If you decide not to trust a workspace and want to avoid repeated trust prompts when starting new sessions, you can exclude it by selecting `Never` in the trust selection window.
 
-You can always make current workspace trusted by running `:workspace-trust` command, and untrust it with `:workspace-untrust`.
+## Changing workspace trust status
+
+You can always make the current workspace trusted by running the `:workspace-trust` command, and untrust it using `:workspace-untrust`.
+
+## Where trust settings are stored
 
 Lists of trusted and excluded workspaces, delimited by newline characters, are stored in `~/.local/share/helix/trusted_workspaces` and `~/.local/share/helix/excluded_workspaces` correspondingly.
 <!-- TODO: Windows paths -->
 
-# Configuration
+## Configuration
 
-You can return to the old behaviour of loading every local `.helix/config.toml` and `.helix/languages.toml` and starting LSP's without an explicit permission by setting following option:
+You can return to the old behaviour of loading every local `.helix/config.toml` and `.helix/languages.toml` and starting language servers without an explicit permission by setting the following option:
 
 ```toml
 [editor]

--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -46,7 +46,7 @@ pub fn prompt(path: PathBuf, compositor: &mut Compositor) {
 
 const TRUST_MESSAGE: &str = "Trust this workspace?
 
-Trusted workspaces may load local config files and auto-start language servers. Config and language servers can execute arbitrary code. Only trust workspaces which you know contain harmless config and code.";
+Trusted workspaces can load local Helix config files and automatically start language servers, both of which may execute arbitrary code. Only trust workspaces you know are safe.";
 
 fn select() -> ui::Select<TrustUntrustStatus> {
     ui::Select::new(


### PR DESCRIPTION
I made improvements to the readability and grammar of the workspace trust docs and popup.

I think in the long run it would benefit from screenshots of the popup dialogue, but I don't think the Helix docs has the capability for that with responsive design requirements.

@xe-nul I hope I have your blessings on this, let me know if I need to make any changes, great job on the workspace trust!
 