### PR TITLE
fix(queries:ecma): proper numeric values

### DIFF
--- a/runtime/queries/ecma/highlights.scm
+++ b/runtime/queries/ecma/highlights.scm
@@ -241,7 +241,15 @@
 (escape_sequence) @constant.character.escape
 
 (regex) @string.regexp
-(number) @constant.numeric.integer
+
+; future-proof fall-back, and `TypedArray` values (looks like float, but is int)
+(number) @constant.numeric
+; https://tc39.es/ecma262/multipage/ecmascript-language-lexical-grammar.html#prod-NumericLiteral
+((number) @constant.numeric.float
+  (#match? @constant.numeric.float "[^n]$"))
+((number) @constant.numeric.integer
+  (#match? @constant.numeric.integer "^[^.][^.\-]*n$"))
+
 
 ; Special identifiers
 ;--------------------


### PR DESCRIPTION
#15283 reopened, because the TS org is taking too long.

---

Unlike the previous PR, I decided to use smaller regexes that assume literals are valid. This makes them much more readable, at the expense of false positives (and a bit of false negatives).

Now everything is `float` unless it's clearly a `bigint`

---

To test, create a buffer with content:
```js
1 // float
0x1e1n // int
1e1m // float then var (grammar err, should be float)
1e1n // float then var (grammar err, should be num)
0x1e1m // float then var (grammar err, should be num or float)
1e-1 // float
1e-0 // float
1e0 // float
0x1e-1 // 2 individual floats
```
and use the `zenburn` theme, as that theme is the only one that distinguishes the 3 cases by default