### PR TITLE
fix(queries): more consistently highlight booleans as `@constant.builtin.boolean`

### DIFF
--- a/runtime/queries/adl/highlights.scm
+++ b/runtime/queries/adl/highlights.scm
@@ -28,10 +28,10 @@
 (number) @constant.numeric
 
 [
-  (null)
   (true)
   (false)
-] @constant.builtin
+] @constant.builtin.boolean
+(null) @constant.builtin
 
 (escape_sequence) @constant.character.escape
 

--- a/runtime/queries/clarity/highlights.scm
+++ b/runtime/queries/clarity/highlights.scm
@@ -7,10 +7,8 @@
   (uint_lit)
 ] @constant.numeric.integer
 
-[
-  (bool_lit)
-  (none_lit)
-] @constant.builtin
+(none_lit) @constant.builtin
+(bool_lit) @constant.builtin.boolean
 
 [
   (ascii_string_lit)

--- a/runtime/queries/clojure/highlights.scm
+++ b/runtime/queries/clojure/highlights.scm
@@ -6,7 +6,8 @@
 
 (num_lit) @constant.numeric
 
-[(bool_lit) (nil_lit)] @constant.builtin
+(bool_lit) @constant.builtin.boolean
+(nil_lit) @constant.builtin
 
 (comment) @comment
 

--- a/runtime/queries/codeql/highlights.scm
+++ b/runtime/queries/codeql/highlights.scm
@@ -37,13 +37,11 @@
   "then"
   "where"
 
-  (false)
   (predicate)
   (result)
   (specialId)
   (super)
   (this)
-  (true)
 ] @keyword
 
 [
@@ -91,6 +89,11 @@
 
 (integer) @constant.numeric.integer
 (float) @constant.numeric.float
+
+[
+  (false)
+  (true)
+] @constant.builtin.boolean
 
 (string) @string
 

--- a/runtime/queries/ink/highlights.scm
+++ b/runtime/queries/ink/highlights.scm
@@ -6,7 +6,7 @@
 ; values
 (identifier) @function
 (string) @string
-(boolean) @constant
+(boolean) @constant.builtin.boolean
 (number) @constant.numeric
 
 ; headers

--- a/runtime/queries/java/highlights.scm
+++ b/runtime/queries/java/highlights.scm
@@ -82,8 +82,8 @@
 [
   (true)
   (false)
-  (null_literal)
-] @constant.builtin
+] @constant.builtin.boolean
+(null_literal) @constant.builtin
 
 (line_comment) @comment
 (block_comment) @comment

--- a/runtime/queries/lean/highlights.scm
+++ b/runtime/queries/lean/highlights.scm
@@ -191,13 +191,13 @@
   "mut"
 ] @keyword
 
-[(true) (false)] @boolean
+[(true) (false)] @constant.builtin.boolean
 
 (number) @constant.numeric.integer
 (float) @constant.numeric.float
 
 (comment) @comment
-(char) @character
+(char) @constant.character
 (string) @string
 (interpolated_string) @string
 ; (escape_sequence) @string.escape

--- a/runtime/queries/rescript/highlights.scm
+++ b/runtime/queries/rescript/highlights.scm
@@ -117,7 +117,7 @@
 [
   (true)
   (false)
-] @constant.builtin
+] @constant.builtin.boolean
 
 (number) @constant.numeric
 (polyvar) @constant

--- a/runtime/queries/ruby/highlights.scm
+++ b/runtime/queries/ruby/highlights.scm
@@ -66,10 +66,10 @@
 ] @constant.numeric.integer
 
 [
-  (nil)
   (true)
   (false)
-] @constant.builtin
+] @constant.builtin.boolean
+(nil) @constant.builtin
 
 (interpolation
   "#{" @punctuation.special

--- a/runtime/queries/sourcepawn/highlights.scm
+++ b/runtime/queries/sourcepawn/highlights.scm
@@ -200,10 +200,8 @@
 (float_literal) @constant.numeric.float
 (string_literal) @string
 (array_literal) @punctuation.bracket
-[
-  (bool_literal)
-  (null)
-] @constant.builtin
+(null) @constant.builtin
+(bool_literal) @constant.builtin.boolean
 ((identifier) @constant
   (#match? @constant "INVALID_HANDLE"))
 


### PR DESCRIPTION
followup to #15264, but fixing the highlighting for booleans and not null/nil values.