### PR TITLE
Use Helix's workspace trust model in git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,7 @@ dependencies = [
  "gix",
  "helix-core",
  "helix-event",
+ "helix-loader",
  "imara-diff 0.2.0",
  "log",
  "parking_lot",

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3541,16 +3541,18 @@ fn changed_file_picker(cx: &mut Context) {
     .with_preview(|_editor, meta| Some((meta.path().into(), None)));
     let injector = picker.injector();
 
-    cx.editor
-        .diff_providers
-        .clone()
-        .for_each_changed_file(cwd, move |change| match change {
+    let insecure = cx.editor.config().insecure;
+    cx.editor.diff_providers.clone().for_each_changed_file(
+        cwd,
+        insecure,
+        move |change| match change {
             Ok(change) => injector.push(change).is_ok(),
             Err(err) => {
                 status::report_blocking(err);
                 true
             }
-        });
+        },
+    );
     cx.push_layer(Box::new(overlaid(picker)));
 }
 

--- a/helix-vcs/Cargo.toml
+++ b/helix-vcs/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 [dependencies]
 helix-core = { path = "../helix-core" }
 helix-event = { path = "../helix-event" }
+helix-loader = { path = "../helix-loader" }
 
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync", "parking_lot", "macros"] }
 parking_lot.workspace = true

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -1,6 +1,8 @@
 use anyhow::{bail, Context, Result};
 use arc_swap::ArcSwap;
 use gix::filter::plumbing::driver::apply::Delay;
+use helix_loader::find_workspace_in;
+use helix_loader::workspace_trust::{quick_query_workspace, TrustStatus};
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
@@ -27,7 +29,7 @@ fn get_repo_dir(file: &Path) -> Result<&Path> {
     file.parent().context("file has no parent directory")
 }
 
-pub fn get_diff_base(file: &Path) -> Result<Vec<u8>> {
+pub fn get_diff_base(file: &Path, insecure: bool) -> Result<Vec<u8>> {
     debug_assert!(!file.exists() || file.is_file());
     debug_assert!(file.is_absolute());
     let file = gix::path::realpath(file).context("resolve symlinks")?;
@@ -35,7 +37,7 @@ pub fn get_diff_base(file: &Path) -> Result<Vec<u8>> {
     // TODO cache repository lookup
 
     let repo_dir = get_repo_dir(&file)?;
-    let repo = open_repo(repo_dir)
+    let repo = open_repo(repo_dir, insecure)
         .context("failed to open git repo")?
         .to_thread_local();
     let head = repo.head_commit()?;
@@ -59,13 +61,13 @@ pub fn get_diff_base(file: &Path) -> Result<Vec<u8>> {
     }
 }
 
-pub fn get_current_head_name(file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
+pub fn get_current_head_name(file: &Path, insecure: bool) -> Result<Arc<ArcSwap<Box<str>>>> {
     debug_assert!(!file.exists() || file.is_file());
     debug_assert!(file.is_absolute());
     let file = gix::path::realpath(file).context("resolve symlinks")?;
 
     let repo_dir = get_repo_dir(&file)?;
-    let repo = open_repo(repo_dir)
+    let repo = open_repo(repo_dir, insecure)
         .context("failed to open git repo")?
         .to_thread_local();
     let head_ref = repo.head_ref()?;
@@ -79,13 +81,17 @@ pub fn get_current_head_name(file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
     Ok(Arc::new(ArcSwap::from_pointee(name.into_boxed_str())))
 }
 
-pub fn for_each_changed_file(cwd: &Path, f: impl Fn(Result<FileChange>) -> bool) -> Result<()> {
-    status(&open_repo(cwd)?.to_thread_local(), f)
+pub fn for_each_changed_file(
+    cwd: &Path,
+    insecure: bool,
+    f: impl Fn(Result<FileChange>) -> bool,
+) -> Result<()> {
+    status(&open_repo(cwd, insecure)?.to_thread_local(), f)
 }
 
-fn open_repo(path: &Path) -> Result<ThreadSafeRepository> {
+fn open_repo(path: &Path, insecure: bool) -> Result<ThreadSafeRepository> {
     // custom open options
-    let mut git_open_opts_map = gix::sec::trust::Mapping::<gix::open::Options>::default();
+    let git_open_opts_map = gix::sec::trust::Mapping::<gix::open::Options>::default();
 
     // On windows various configuration options are bundled as part of the installations
     // This path depends on the install location of git and therefore requires some overhead to lookup
@@ -99,30 +105,24 @@ fn open_repo(path: &Path) -> Result<ThreadSafeRepository> {
         includes: true,
         git_binary: cfg!(windows),
     };
-    // change options for config permissions without touching anything else
-    git_open_opts_map.reduced = git_open_opts_map
-        .reduced
-        .permissions(gix::open::Permissions {
-            config,
-            ..gix::open::Permissions::default_for_level(gix::sec::Trust::Reduced)
-        });
-    git_open_opts_map.full = git_open_opts_map.full.permissions(gix::open::Permissions {
-        config,
-        ..gix::open::Permissions::default_for_level(gix::sec::Trust::Full)
-    });
 
-    let open_options = gix::discover::upwards::Options {
-        dot_git_only: true,
-        ..Default::default()
+    let opts = if let TrustStatus::Trusted = quick_query_workspace(insecure) {
+        git_open_opts_map.full.permissions(gix::open::Permissions {
+            config,
+            ..gix::open::Permissions::default_for_level(gix::sec::Trust::Full)
+        })
+    } else {
+        git_open_opts_map
+            .reduced
+            .permissions(gix::open::Permissions {
+                config,
+                ..gix::open::Permissions::default_for_level(gix::sec::Trust::Reduced)
+            })
     };
 
-    let res = ThreadSafeRepository::discover_with_environment_overrides_opts(
-        path,
-        open_options,
-        git_open_opts_map,
-    )?;
+    let (workspace, _) = find_workspace_in(path);
 
-    Ok(res)
+    Ok(ThreadSafeRepository::open_opts(workspace, opts)?)
 }
 
 /// Emulates the result of running `git status` from the command line.

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -54,7 +54,7 @@ fn missing_file() {
     let file = temp_git.path().join("file.txt");
     File::create(&file).unwrap().write_all(b"foo").unwrap();
 
-    assert!(git::get_diff_base(&file).is_err());
+    assert!(git::get_diff_base(&file, true).is_err());
 }
 
 #[test]
@@ -64,7 +64,10 @@ fn unmodified_file() {
     let contents = b"foo".as_slice();
     File::create(&file).unwrap().write_all(contents).unwrap();
     create_commit(temp_git.path(), true);
-    assert_eq!(git::get_diff_base(&file).unwrap(), Vec::from(contents));
+    assert_eq!(
+        git::get_diff_base(&file, true).unwrap(),
+        Vec::from(contents)
+    );
 }
 
 #[test]
@@ -76,7 +79,10 @@ fn modified_file() {
     create_commit(temp_git.path(), true);
     File::create(&file).unwrap().write_all(b"bar").unwrap();
 
-    assert_eq!(git::get_diff_base(&file).unwrap(), Vec::from(contents));
+    assert_eq!(
+        git::get_diff_base(&file, true).unwrap(),
+        Vec::from(contents)
+    );
 }
 
 /// Test that `get_file_head` does not return content for a directory.
@@ -95,7 +101,7 @@ fn directory() {
 
     std::fs::remove_dir_all(&dir).unwrap();
     File::create(&dir).unwrap().write_all(b"bar").unwrap();
-    assert!(git::get_diff_base(&dir).is_err());
+    assert!(git::get_diff_base(&dir, true).is_err());
 }
 
 /// Test that `get_diff_base` resolves symlinks so that the same diff base is
@@ -122,8 +128,8 @@ fn symlink() {
     symlink("file.txt", &file_link).unwrap();
     create_commit(temp_git.path(), true);
 
-    assert_eq!(git::get_diff_base(&file_link).unwrap(), contents);
-    assert_eq!(git::get_diff_base(&file).unwrap(), contents);
+    assert_eq!(git::get_diff_base(&file_link, true).unwrap(), contents);
+    assert_eq!(git::get_diff_base(&file, true).unwrap(), contents);
 }
 
 /// Test that `get_diff_base` returns content when the file is a symlink to
@@ -147,6 +153,6 @@ fn symlink_to_git_repo() {
     let file_link = temp_dir.path().join("file_link.txt");
     symlink(&file, &file_link).unwrap();
 
-    assert_eq!(git::get_diff_base(&file_link).unwrap(), contents);
-    assert_eq!(git::get_diff_base(&file).unwrap(), contents);
+    assert_eq!(git::get_diff_base(&file_link, true).unwrap(), contents);
+    assert_eq!(git::get_diff_base(&file, true).unwrap(), contents);
 }

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -30,10 +30,10 @@ pub struct DiffProviderRegistry {
 impl DiffProviderRegistry {
     /// Get the given file from the VCS. This provides the unedited document as a "base"
     /// for a diff to be created.
-    pub fn get_diff_base(&self, file: &Path) -> Option<Vec<u8>> {
+    pub fn get_diff_base(&self, file: &Path, insecure: bool) -> Option<Vec<u8>> {
         self.providers
             .iter()
-            .find_map(|provider| match provider.get_diff_base(file) {
+            .find_map(|provider| match provider.get_diff_base(file, insecure) {
                 Ok(res) => Some(res),
                 Err(err) => {
                     log::debug!("{err:#?}");
@@ -44,17 +44,21 @@ impl DiffProviderRegistry {
     }
 
     /// Get the current name of the current [HEAD](https://stackoverflow.com/questions/2304087/what-is-head-in-git).
-    pub fn get_current_head_name(&self, file: &Path) -> Option<Arc<ArcSwap<Box<str>>>> {
-        self.providers
-            .iter()
-            .find_map(|provider| match provider.get_current_head_name(file) {
+    pub fn get_current_head_name(
+        &self,
+        file: &Path,
+        insecure: bool,
+    ) -> Option<Arc<ArcSwap<Box<str>>>> {
+        self.providers.iter().find_map(|provider| {
+            match provider.get_current_head_name(file, insecure) {
                 Ok(res) => Some(res),
                 Err(err) => {
                     log::debug!("{err:#?}");
                     log::debug!("failed to obtain current head name for {}", file.display());
                     None
                 }
-            })
+            }
+        })
     }
 
     /// Fire-and-forget changed file iteration. Runs everything in a background task. Keeps
@@ -62,13 +66,14 @@ impl DiffProviderRegistry {
     pub fn for_each_changed_file(
         self,
         cwd: PathBuf,
+        insecure: bool,
         f: impl Fn(Result<FileChange>) -> bool + Send + 'static,
     ) {
         tokio::task::spawn_blocking(move || {
             if self
                 .providers
                 .iter()
-                .find_map(|provider| provider.for_each_changed_file(&cwd, &f).ok())
+                .find_map(|provider| provider.for_each_changed_file(&cwd, insecure, &f).ok())
                 .is_none()
             {
                 f(Err(anyhow!("no diff provider returns success")));
@@ -102,18 +107,18 @@ enum DiffProvider {
 }
 
 impl DiffProvider {
-    fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>> {
+    fn get_diff_base(&self, file: &Path, insecure: bool) -> Result<Vec<u8>> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git => git::get_diff_base(file),
+            Self::Git => git::get_diff_base(file, insecure),
             Self::None => bail!("No diff support compiled in"),
         }
     }
 
-    fn get_current_head_name(&self, file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
+    fn get_current_head_name(&self, file: &Path, insecure: bool) -> Result<Arc<ArcSwap<Box<str>>>> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git => git::get_current_head_name(file),
+            Self::Git => git::get_current_head_name(file, insecure),
             Self::None => bail!("No diff support compiled in"),
         }
     }
@@ -121,11 +126,12 @@ impl DiffProvider {
     fn for_each_changed_file(
         &self,
         cwd: &Path,
+        insecure: bool,
         f: impl Fn(Result<FileChange>) -> bool,
     ) -> Result<()> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git => git::for_each_changed_file(cwd, f),
+            Self::Git => git::for_each_changed_file(cwd, insecure, f),
             Self::None => bail!("No diff support compiled in"),
         }
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1297,12 +1297,13 @@ impl Document {
         self.pickup_last_saved_time();
         self.detect_indent_and_line_ending();
 
-        match provider_registry.get_diff_base(&path) {
+        let insecure = self.config.load().insecure;
+        match provider_registry.get_diff_base(&path, insecure) {
             Some(diff_base) => self.set_diff_base(diff_base),
             None => self.diff_handle = None,
         }
 
-        self.version_control_head = provider_registry.get_current_head_name(&path);
+        self.version_control_head = provider_registry.get_current_head_name(&path, insecure);
 
         Ok(())
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1945,10 +1945,13 @@ impl Editor {
                 Editor::doc_diagnostics(&self.language_servers, &self.diagnostics, &doc);
             doc.replace_diagnostics(diagnostics, &[], None);
 
-            if let Some(diff_base) = self.diff_providers.get_diff_base(&path) {
+            let insecure = self.config().insecure;
+            if let Some(diff_base) = self.diff_providers.get_diff_base(&path, insecure) {
                 doc.set_diff_base(diff_base);
             }
-            doc.set_version_control_head(self.diff_providers.get_current_head_name(&path));
+            doc.set_version_control_head(
+                self.diff_providers.get_current_head_name(&path, insecure),
+            );
 
             let id = self.new_document(doc);
             self.launch_language_servers(id);


### PR DESCRIPTION
Fixes #15594.

It is kinda messy since I need to pass around `config.insecure`, sorry about that. I don't see a reliable and clean way of mitigating the need for that variable.

I did consider falling back to the old model of trust if `config.insecure = true`, but I don't see where one might want that. I don't have a strong opinion on it, so let me know if you want that, I can patch it in.

This might have a regression in case `.helix/` dir is not in a repository root, but somewhere down the directory tree...
I'm not sure why anyone would do that, and that will probably break LSP in some way.