### PR TITLE
fix(lints): clippy 1.95

### DIFF
--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, fs, path::PathBuf};
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use crate::{data_dir, workspace_exclude_file, workspace_trust_file};
 
@@ -144,7 +148,7 @@ pub fn quick_query_workspace(insecure: bool) -> TrustStatus {
     match fs::read_to_string(workspace_trust_file()) {
         Ok(workspace_trust_file) => {
             for line in workspace_trust_file.split('\n') {
-                if PathBuf::from(line) == workspace {
+                if Path::new(line) == workspace {
                     return TrustStatus::Trusted;
                 }
             }
@@ -164,7 +168,7 @@ pub fn quick_query_workspace_with_explicit_untrust(insecure: bool) -> TrustUntru
     match fs::read_to_string(workspace_trust_file()) {
         Ok(workspace_trust_file) => {
             for line in workspace_trust_file.split('\n') {
-                if PathBuf::from(line) == workspace {
+                if Path::new(line) == workspace {
                     return TrustUntrustStatus::AllowAlways;
                 }
             }
@@ -176,7 +180,7 @@ pub fn quick_query_workspace_with_explicit_untrust(insecure: bool) -> TrustUntru
     match fs::read_to_string(workspace_exclude_file()) {
         Ok(workspace_untrust_file) => {
             for line in workspace_untrust_file.split('\n') {
-                if PathBuf::from(line) == workspace {
+                if Path::new(line) == workspace {
                     return TrustUntrustStatus::DenyAlways;
                 }
             }

--- a/helix-term/src/handlers/document_highlight.rs
+++ b/helix-term/src/handlers/document_highlight.rs
@@ -81,7 +81,7 @@ fn document_highlight_ranges(
         })
         .collect();
 
-    ranges.sort_by(|a, b| (a.start, a.end).cmp(&(b.start, b.end)));
+    ranges.sort_by_key(|a| (a.start, a.end));
 
     let mut merged: Vec<std::ops::Range<usize>> = Vec::with_capacity(ranges.len());
     for range in ranges {

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -336,10 +336,8 @@ pub(super) fn register_hooks(handlers: &Handlers) {
                     compositor.remove(SignatureHelp::ID);
                 }));
             }
-            (_, Mode::Insert) => {
-                if event.cx.editor.config().lsp.auto_signature_help {
-                    send_blocking(&tx, SignatureHelpEvent::Trigger);
-                }
+            (_, Mode::Insert) if event.cx.editor.config().lsp.auto_signature_help => {
+                send_blocking(&tx, SignatureHelpEvent::Trigger);
             }
             _ => (),
         }

--- a/helix-term/src/ui/markdown.rs
+++ b/helix-term/src/ui/markdown.rs
@@ -306,7 +306,7 @@ impl Markdown {
                             &self.config_loader.load(),
                             None,
                         );
-                        lines.extend(tui_text.lines.into_iter());
+                        lines.extend(tui_text.lines);
                     } else {
                         let style = match tags.last() {
                             Some(Tag::Heading { level, .. }) => match level {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -345,9 +345,9 @@ impl<T: Component> Component for Popup<T> {
         let max_offset = child_height.saturating_sub(inner.height) as usize;
         let half_page_size = (inner.height / 2) as usize;
         let scroll = max_offset.min(self.scroll_half_pages * half_page_size);
-        if half_page_size > 0 {
-            self.scroll_half_pages = scroll / half_page_size;
-        }
+        self.scroll_half_pages = scroll
+            .checked_div(half_page_size)
+            .unwrap_or(self.scroll_half_pages);
         cx.scroll = Some(scroll);
         self.contents.render(inner, surface, cx);
 


### PR DESCRIPTION
This was done with a mix of automated `cargo clippy` fix, and manual changes. I manually changed the `PathBuf` to `Path`, and changed the `if half_page_size > 0` check to the `checked_div` version. 