### PR TITLE
Update slint grammar revision

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3029,7 +3029,7 @@ language-servers = [ "slint-lsp" ]
 
 [[grammar]]
 name = "slint"
-source = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "f11da7e62051ba8b9d4faa299c26de8aeedfc1cd" }
+source = { git = "https://github.com/slint-ui/tree-sitter-slint", rev = "68b25244cec6eb9d7f8f790ef781c29c822d8f84" }
 
 [[language]]
 name = "task"


### PR DESCRIPTION
Update the revision for the slint tree-sitter parser to the latest from slint-ui/tree-sitter-slint.