### PR TITLE
Add option to disable shell output formatting

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -68,6 +68,7 @@
 | `editor-config` | Whether to read settings from [EditorConfig](https://editorconfig.org) files | `true` |
 | `rainbow-brackets` | Whether to render rainbow colors for matching brackets. Requires tree-sitter `rainbows.scm` queries for the language. | `false` |
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
+| `format-shell-output` | Shell output formatting | `true` |
 
 [^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
 

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -6,6 +6,7 @@ use crate::job::Job;
 
 use super::*;
 
+use arc_swap::access::DynAccess;
 use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
@@ -2557,16 +2558,20 @@ fn run_shell_command(
 
     let shell = cx.editor.config().shell.clone();
     let args = args.join(" ");
+    let format_shell_output = cx.editor.config.load().format_shell_output.clone();
 
     let callback = async move {
         let output = shell_impl_async(&shell, &args, None).await?;
         let call: job::Callback = Callback::EditorCompositor(Box::new(
             move |editor: &mut Editor, compositor: &mut Compositor| {
                 if !output.trim().is_empty() {
-                    let contents = ui::Markdown::new(
-                        format!("```sh\n{}\n```", output.trim_end()),
-                        editor.syn_loader.clone(),
-                    );
+                    let trimmed = output.trim_end();
+                    let output_formatted = if format_shell_output {
+                        format!("```sh\n{trimmed}\n```")
+                    } else {
+                        trimmed.to_string()
+                    };
+                    let contents = ui::Markdown::new(output_formatted, editor.syn_loader.clone());
                     let popup = Popup::new("shell", contents).position(Some(
                         helix_core::Position::new(editor.cursor().0.unwrap_or_default().row, 2),
                     ));

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -434,6 +434,9 @@ pub struct Config {
     pub buffer_picker: BufferPickerConfig,
     /// Whether to implicitly trust every workspace or not
     pub insecure: bool,
+    /// Whether to format the shell output in markdown.
+    /// Defaults to `true`.
+    pub format_shell_output: bool,
 }
 
 #[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, Clone, Copy)]
@@ -1157,6 +1160,7 @@ impl Default for Config {
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
             insecure: false,
+            format_shell_output: true,
         }
     }
 }


### PR DESCRIPTION
Hi, I'm using the shell feature quite extensively for stuff like git blame etc. Here's [the script I use](https://github.com/DawidPietrykowski/dotfiles/blob/master/helix/.config/helix/helix_blame.fish) as an example.

What started getting in the way of formatting the output of those commands correctly is the default `sh` formatting of the output that's then passed to the markdown formatter. I believe it should be possible to disable the default formatting to allow the user to set their own one or use other markdown features.

A good use case is the git diff command. Markdown supports `diff` formatting so it correctly colors the additions/deletions as green/red. Here's an example popup from my script:
<img width="1067" height="676" alt="image" src="https://github.com/user-attachments/assets/3b1ea297-9296-4da3-9401-6d02e688a5c0" />

All I need to do in my script is to prefix and suffix the git command with backticks and `diff` keyword like so:

```fish
echo ```diff
git show $commit_sha_prev --minimal --cc -- $file
echo ```
```

The default should still be kept as it works for most stuff.