### PR TITLE
fix(tui): use ○ instead of ◯ for unverified breakpoints

### DIFF
--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -264,7 +264,7 @@ pub fn breakpoints<'doc>(
                 breakpoint_style
             };
 
-            let sym = if breakpoint.verified { "●" } else { "◯" };
+            let sym = if breakpoint.verified { "●" } else { "○" };
             write!(out, "{}", sym).unwrap();
             Some(style)
         },


### PR DESCRIPTION
◯ (U+25EF) is either absent from most fonts or is rendered with inconsistent metrics across those that do have it, which makes it appear oversized and occasionally overlap adjacent lines.

Replace it with ○ (U+25CB), which has a more consistent appearance across fonts.

### With ◯
<img width="400" height="100" alt="helix1" src="https://github.com/user-attachments/assets/8af89e66-e7da-4af6-8440-5841b5590979" />

### With ○
<img width="400" height="100" alt="helix2" src="https://github.com/user-attachments/assets/a8f9c3a1-c9fa-4069-a78a-09eb6c776e4e" />

