### PR TITLE
ecma/injections: fix regressions

### DIFF
--- a/runtime/queries/ecma/injections.scm
+++ b/runtime/queries/ecma/injections.scm
@@ -7,7 +7,7 @@
     (member_expression
       property: (property_identifier) @injection.language)
   ]
-  arguments: (template_string) @injection.content
+  arguments: (template_string (string_fragment) @injection.content)
   (#any-of? @injection.language "html" "css" "json" "sql" "js" "ts" "bash"))
 
 ; Parse the contents of $ template literals as shell commands
@@ -18,7 +18,7 @@
     (member_expression
       property: (property_identifier) @_template_function_name)
   ]
-  arguments: (template_string) @injection.content
+  arguments: (template_string (string_fragment) @injection.content)
  (#eq? @_template_function_name "$")
  (#set! injection.language "bash"))
 
@@ -58,10 +58,13 @@
 
 ; Parse the contents of strings and tagged template literals with leading ECMAScript comments '/* GraphQL */'
 (
-  ((comment) @_ecma_comment [
+  ((comment) @_ecma_comment) . [
     (string (string_fragment) @injection.content)
     (template_string (string_fragment) @injection.content)
-  ])
+    (call_expression
+      arguments: (template_string (string_fragment) @injection.content)
+    )
+  ]
   (#eq? @_ecma_comment "/* GraphQL */")
   (#set! injection.language "graphql")
 )


### PR DESCRIPTION
1. Fixes algorithmic complexity regression because of GraphQL injection based on comments introduced by https://github.com/helix-editor/helix/pull/14727
2. Fixes broken nested language highlighting introduced by https://github.com/helix-editor/helix/pull/14568

I noticed a MASSIVE performance degradation on Helix master, which was caused by 1.
And it happened for the most stupid reason ever, because someone forgot to put a dot.....
Without this change on a typical not a very big typescript file with a lot of comments it takes a couple seconds to input a single character....

Example test input:

```tsx
const lol = css`
  .lol {
    background-color: red;
  }
`;

const shell = $`echo lol $LMAO`

gql`query { foo }`;

gql('query { foo }');
gql(`query { foo }`);

graphql`query { foo }`;
graphql('query { foo }');
graphql(`query { foo }`);

const x = '#graphql query { foo }';
const x = `#graphql
  query { foo }
`;

const x = `query { foo }`;
const x = /* GraphQL */ 'query { foo }';
const x = /* GraphQL */ h'query { foo }';
const x = /* GraphQL */ h`query { foo }`;
```

