### PR TITLE
docs: clarify file-picker and file-explorer option descriptions

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -205,14 +205,14 @@ All git related options are only enabled in a git repository.
 
 | Key | Description | Default |
 |--|--|---------|
-|`hidden` | Enables ignoring hidden files | `true`
+|`hidden` | Omit hidden files from the picker | `true`
 |`follow-symlinks` | Follow symlinks instead of ignoring them | `true`
 |`deduplicate-links` | Ignore symlinks that point at files already shown in the picker | `true`
-|`parents` | Enables reading ignore files from parent directories | `true`
-|`ignore` | Enables reading `.ignore` files | `true`
-|`git-ignore` | Enables reading `.gitignore` files | `true`
-|`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`
-|`git-exclude` | Enables reading `.git/info/exclude` files | `true`
+|`parents` | Read ignore files from parent directories | `true`
+|`ignore` | Use `.ignore` files to omit entries | `true`
+|`git-ignore` | Use `.gitignore` files to omit entries | `true`
+|`git-global` | Use global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`
+|`git-exclude` | Use `.git/info/exclude` to omit entries | `true`
 |`max-depth` | Set with an integer value for maximum depth to recurse | Unset by default
 
 Ignore files can be placed locally as `.ignore` or put in your home directory as `~/.ignore`. They support the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.
@@ -239,13 +239,13 @@ Note that the ignore files consulted by the file explorer when `ignore` is set t
 
 | Key | Description | Default |
 |--|--|---------|
-|`hidden` | Enables ignoring hidden files | `false`
+|`hidden` | Omit hidden files from the explorer | `false`
 |`follow-symlinks` | Follow symlinks instead of ignoring them | `false`
-|`parents` | Enables reading ignore files from parent directories | `false`
-|`ignore` | Enables reading `.ignore` files | `false`
-|`git-ignore` | Enables reading `.gitignore` files | `false`
-|`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `false`
-|`git-exclude` | Enables reading `.git/info/exclude` files | `false`
+|`parents` | Read ignore files from parent directories | `false`
+|`ignore` | Use `.ignore` files to omit entries | `false`
+|`git-ignore` | Use `.gitignore` files to omit entries | `false`
+|`git-global` | Use global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `false`
+|`git-exclude` | Use `.git/info/exclude` to omit entries | `false`
 |`flatten-dirs` | Enables flattening single child directories | `true`
 
 ### `[editor.buffer-picker]` Section

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -179,28 +179,21 @@ impl Default for GutterLineNumbersConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FilePickerConfig {
-    /// IgnoreOptions
-    /// Enables ignoring hidden files.
     /// Whether to hide hidden files in file picker and global search results. Defaults to true.
     pub hidden: bool,
-    /// Enables following symlinks.
     /// Whether to follow symbolic links in file picker and file or directory completions. Defaults to true.
     pub follow_symlinks: bool,
     /// Hides symlinks that point into the current directory. Defaults to true.
     pub deduplicate_links: bool,
-    /// Enables reading ignore files from parent directories. Defaults to true.
+    /// Read ignore files from parent directories. Defaults to true.
     pub parents: bool,
-    /// Enables reading `.ignore` files.
-    /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to true.
+    /// Use `.ignore` files to omit entries from file picker and global search results. Defaults to true.
     pub ignore: bool,
-    /// Enables reading `.gitignore` files.
-    /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to true.
+    /// Use `.gitignore` files to omit entries from file picker and global search results. Defaults to true.
     pub git_ignore: bool,
-    /// Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
-    /// Whether to hide files listed in global .gitignore in file picker and global search results. Defaults to true.
+    /// Use global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option. Defaults to true.
     pub git_global: bool,
-    /// Enables reading `.git/info/exclude` files.
-    /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to true.
+    /// Use `.git/info/exclude` to omit entries from file picker and global search results. Defaults to true.
     pub git_exclude: bool,
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
@@ -226,26 +219,19 @@ impl Default for FilePickerConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct FileExplorerConfig {
-    /// IgnoreOptions
-    /// Enables ignoring hidden files.
     /// Whether to hide hidden files in file explorer and global search results. Defaults to false.
     pub hidden: bool,
-    /// Enables following symlinks.
-    /// Whether to follow symbolic links in file picker and file or directory completions. Defaults to false.
+    /// Whether to follow symbolic links in file explorer and file or directory completions. Defaults to false.
     pub follow_symlinks: bool,
-    /// Enables reading ignore files from parent directories. Defaults to false.
+    /// Read ignore files from parent directories. Defaults to false.
     pub parents: bool,
-    /// Enables reading `.ignore` files.
-    /// Whether to hide files listed in .ignore in file picker and global search results. Defaults to false.
+    /// Use `.ignore` files to omit entries from file explorer and global search results. Defaults to false.
     pub ignore: bool,
-    /// Enables reading `.gitignore` files.
-    /// Whether to hide files listed in .gitignore in file picker and global search results. Defaults to false.
+    /// Use `.gitignore` files to omit entries from file explorer and global search results. Defaults to false.
     pub git_ignore: bool,
-    /// Enables reading global .gitignore, whose path is specified in git's config: `core.excludefile` option.
-    /// Whether to hide files listed in global .gitignore in file picker and global search results. Defaults to false.
+    /// Use global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option. Defaults to false.
     pub git_global: bool,
-    /// Enables reading `.git/info/exclude` files.
-    /// Whether to hide files listed in .git/info/exclude in file picker and global search results. Defaults to false.
+    /// Use `.git/info/exclude` to omit entries from file explorer and global search results. Defaults to false.
     pub git_exclude: bool,
     /// Whether to flatten single-child directories in file explorer. Defaults to true.
     pub flatten_dirs: bool,


### PR DESCRIPTION
## Summary

Improves the descriptions for `[editor.file-picker]` and `[editor.file-explorer]` configuration options to be clearer about their behavior.

The previous descriptions were confusing because:
1. `"Enables ignoring hidden files"` is misleading — setting `hidden = false` *shows* hidden files, requiring a double take
2. `"Enables reading .ignore files"` is ambiguous — it could mean either "use .ignore to hide files" or "show .ignore itself"

Changes:
- `"Enables ignoring hidden files"` → `"Omit hidden files from the picker"` / `"Omit hidden files from the explorer"`
- `"Enables reading .ignore files"` → `"Use .ignore files to omit entries"`
- `"Enables reading .gitignore files"` → `"Use .gitignore files to omit entries"`
- `"Enables reading .git/info/exclude files"` → `"Use .git/info/exclude to omit entries"`
- Similar updates to parent and git-global options
- Also cleaned up redundant doc comments in `helix-view/src/editor.rs`

Closes #15568