### PR TITLE
docs(themes): fix typos in aurara theme comments

### DIFF
--- a/runtime/themes/aurara.toml
+++ b/runtime/themes/aurara.toml
@@ -195,7 +195,7 @@
 
 'type' = { fg = "blue-aqua" } # Variable type, like integer or string, including program defined classes, structs etc..
   # NOTE: sometimes there's class / end, which looks odd not bolded like other control/end statements
-  # doesn't seperate declaration, parameters, instantiation (though there is constructor), so it's difficult to italicize
+  # doesn't separate declaration, parameters, instantiation (though there is constructor), so it's difficult to italicize
 'type.builtin' = { fg = "green-sea", modifiers = ["italic"] } # Primitive types of the language (string, int, float).
 'type.enum.variant' = { fg = "green-sea" } # A variant of an enum.
   # vs match constant color
@@ -276,7 +276,7 @@
 'keyword.operator' = { fg = "purple", modifiers = ["bold"] } # 'or', 'and', 'in'.
   # TODO: doesn't look like it's working..??
 'keyword.directive' = { fg = "purple", modifiers = ["italic"] } # Preprocessor directives (#if, #include in C).
-'keyword.function' = { fg = "purple", modifiers = ["bold"] } # The keyword to define a funtion: 'def', 'fun', 'fn'.
+'keyword.function' = { fg = "purple", modifiers = ["bold"] } # The keyword to define a function: 'def', 'fun', 'fn'.
 'keyword.storage' = { fg = "purple" } # let and var in rust.. these should be more visible..
 'keyword.storage.modifier' = { fg = "purple-dimmer", modifiers = ["italic"] } # function and type modifiers/accessors: public/private, mut, dyn, ref, &, internal, readonly, const, etc.
   # these should be less visible


### PR DESCRIPTION

**Repo:** helix-editor/helix (⭐ 33000)
**Type:** docs
**Files changed:** 1
**Lines:** +2/-2

## What
Corrects two spelling mistakes in the inline comments of `runtime/themes/aurara.toml`: "seperate" → "separate" and "funtion" → "function". Theme styles are unchanged.

## Why
These comments serve as guidance for theme authors and contributors reading the file as a reference. Fixing typos makes the documentation more professional and easier to grep, with no risk to functionality.

## Testing
The change is comment-only inside a TOML file; theme parsing is unaffected. Verified the diff is limited to two comment lines via `git diff --stat`.

## Risk
Low — comment-only change in a single theme file.
