### PR TITLE
feat(queries/r): update grammar to latest commit and adjust / improve queries

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -236,7 +236,7 @@
 | qmv |  |  |  |  |  |  |
 | quarto | ✓ |  | ✓ |  |  |  |
 | quint | ✓ |  |  |  |  | `quint-language-server` |
-| r | ✓ |  |  |  |  | `R` |
+| r | ✓ | ✓ |  | ✓ | ✓ | `R` |
 | racket | ✓ |  | ✓ |  | ✓ | `racket` |
 | regex | ✓ |  |  |  | ✓ |  |
 | rego | ✓ |  |  |  |  | `regols` |

--- a/languages.toml
+++ b/languages.toml
@@ -2513,7 +2513,7 @@ language-servers = [ "r" ]
 
 [[grammar]]
 name = "r"
-source = { git = "https://github.com/r-lib/tree-sitter-r", rev = "cc04302e1bff76fa02e129f332f44636813b0c3c" }
+source = { git = "https://github.com/r-lib/tree-sitter-r", rev = "0e6ef7741712c09dc3ee6e81c42e919820cc65ef" }
 
 [[language]]
 name = "rmarkdown"

--- a/runtime/queries/r/highlights.scm
+++ b/runtime/queries/r/highlights.scm
@@ -12,6 +12,7 @@
 [
   (float)
   (nan)
+  (inf)
 ] @constant.numeric.float
 
 [
@@ -22,88 +23,76 @@
 [
   (na)
   (null)
+  (dots)
+  (dot_dot_i)
 ] @constant.builtin
 
 (string) @string
-(string (escape_sequence) @constant.character.escape)
+(string (string_content (escape_sequence) @constant.character.escape))
+
+; Comments
 
 (comment) @comment
 
-(formal_parameters (identifier) @variable.parameter)
-(formal_parameters (default_parameter (identifier) @variable.parameter))
-
 ; Operators
+
 [
- "="
- "<-"
- "<<-"
- "->>"
- "->"
+  "!" "!=" "$" "&" "&&" "*" "**" "+" "-" "->" "->>" "/" ":" ":::" ":::" ":=" "<"
+  "<-" "<<-" "<=" "=" "==" ">" ">=" "?" "@" "^" "special" "|" "|>" "||" "~"
 ] @operator
 
-(unary operator: [
-  "-"
-  "+"
-  "!"
-  "~"
-] @operator)
+(function_definition name: "\\" @operator)
 
-(binary operator: [
-  "-"
-  "+"
-  "*"
-  "/"
-  "^"
-  "<"
-  ">"
-  "<="
-  ">="
-  "=="
-  "!="
-  "||"
-  "|"
-  "&&"
-  "&"
-  ":"
-  "~"
-] @operator)
+; Punctuation
 
 [
-  "|>"
-  (special)
-] @operator
-
-(lambda_function "\\" @operator)
-
-[
- "("
- ")"
- "["
- "]"
- "{"
- "}"
+  "(" ")"
+  "[" "]"
+  "{" "}"
+  "[[" "]]"
 ] @punctuation.bracket
 
-(dollar "$" @operator)
+(comma) @punctuation.delimiter
 
-(subset2
- [
-  "[["
-  "]]"
- ] @punctuation.bracket)
+; Functions
+
+(binary_operator
+  lhs: (identifier) @function
+  operator: "<-"
+  rhs: (function_definition))
+
+(binary_operator
+  lhs: (identifier) @function
+  operator: "="
+  rhs: (function_definition))
+
+; Calls
+
+(call function: (identifier) @function)
+(call function: (namespace_operator rhs: (identifier) @function))
+
+; Parameters
+
+(parameters (parameter name: (identifier) @variable.parameter))
+(arguments (argument name: (identifier) @variable.parameter))
+
+; Namespaces
+
+(namespace_operator lhs: (identifier) @namespace)
+
+; Keywords
 
 [
- "in"
- (dots)
- (break)
- (next)
- (inf)
+  "in"
+  (next)
+  (break)
 ] @keyword
+
+(return) @keyword.control.return
 
 [
   "if"
   "else"
-  "switch"
 ] @keyword.control.conditional
 
 [
@@ -114,14 +103,3 @@
 
 "function" @keyword.function
 
-(call function: (identifier) @function)
-(default_argument name: (identifier) @variable.parameter)
-
-
-(namespace_get namespace: (identifier) @namespace
- "::" @operator)
-(namespace_get_internal namespace: (identifier) @namespace
- ":::" @operator)
-
-(namespace_get function: (identifier) @function.method)
-(namespace_get_internal function: (identifier) @function.method)

--- a/runtime/queries/r/locals.scm
+++ b/runtime/queries/r/locals.scm
@@ -2,6 +2,6 @@
 
 (function_definition) @local.scope
 
-(formal_parameters (identifier) @local.definition.variable.parameter)
+(parameters (parameter name: (identifier) @local.definition.variable.parameter))
 
 (identifier) @local.reference

--- a/runtime/queries/r/rainbows.scm
+++ b/runtime/queries/r/rainbows.scm
@@ -1,0 +1,16 @@
+[
+  (parameters)
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (braced_expression)
+  (parenthesized_expression)
+  (arguments)
+] @rainbow.scope
+
+[
+  "(" ")"
+  "[" "]"
+  "{" "}"
+  "[[" "]]"
+] @rainbow.bracket

--- a/runtime/queries/r/tags.scm
+++ b/runtime/queries/r/tags.scm
@@ -1,0 +1,9 @@
+(binary_operator
+  lhs: [(identifier) (string)] @name
+  operator: "<-"
+  rhs: (function_definition)) @definition.function
+
+(binary_operator
+  lhs: [(identifier) (string)] @name
+  operator: "="
+  rhs: (function_definition)) @definition.function

--- a/runtime/queries/r/textobjects.scm
+++ b/runtime/queries/r/textobjects.scm
@@ -1,0 +1,16 @@
+; Comments
+
+(comment) @comment.inside
+(comment)+ @comment.around
+
+; Functions
+
+(function_definition body: (_) @function.inside) @function.around
+
+; Parameters
+
+(parameters
+  ((_) @parameter.inside . (comma)? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . (comma)? @parameter.around) @parameter.around)


### PR DESCRIPTION
updates the grammar revision to the latest commit and update the queries. additionally also adds tag, textobject and rainbow queries. however this does not add indent queries, as they are very different from the neovim ones and i don't like writing them, so i'll delegate that to someone else in the future.

fixes #15664