### PR TITLE
Add ctrl-enter in file pickers to open all matched entries

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -465,6 +465,7 @@ See the documentation page on [pickers](./pickers.md) for more info.
 | `End`                        | Go to last entry                                           |
 | `Enter`                      | Open selected                                              |
 | `Alt-Enter`                  | Open selected in the background without closing the picker |
+| `Ctrl-Enter`                 | Open all matched entries (e.g. files) with selected active |
 | `Ctrl-s`                     | Open horizontally                                          |
 | `Ctrl-v`                     | Open vertically                                            |
 | `Ctrl-t`                     | Toggle preview                                             |

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1109,6 +1109,22 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     (self.callback_fn)(ctx, option, self.default_action);
                 }
             }
+            ctrl!(Enter) => {
+                for matched in self
+                    .matcher
+                    .snapshot()
+                    .matched_items(0..self.matcher.snapshot().matched_item_count())
+                    .map(|item| item.data)
+                    .rev()
+                {
+                    (self.callback_fn)(ctx, matched, self.default_action);
+                }
+                // Open selected again so it is the active view
+                if let Some(option) = self.selection() {
+                    (self.callback_fn)(ctx, option, self.default_action);
+                }
+                return close_fn(self);
+            }
             key!(Enter) => {
                 // If the prompt has a history completion and is empty, use enter to accept
                 // that completion


### PR DESCRIPTION
Adding ctrl-enter to open all matched entries in the current picker, the selected entry will be visible, all other entries are in the background.

Useful e.g. for space-f and space-g to open a set of files at once.