### PR TITLE
bump `tree-sitter-ghostty` version to 1.3.1

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4776,7 +4776,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "ghostty"
-source = { git = "https://github.com/bezhermoso/tree-sitter-ghostty" , rev = "8438a93b44367e962b2ea3a3b6511885bebd196a" }
+source = { git = "https://github.com/bezhermoso/tree-sitter-ghostty" , rev = "753055073a26100e51bdf1a92f4234cd6789c1f9" }
 
 [[language]]
 name = "tera"

--- a/languages.toml
+++ b/languages.toml
@@ -4776,7 +4776,7 @@ indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]
 name = "ghostty"
-source = { git = "https://github.com/bezhermoso/tree-sitter-ghostty" , rev = "753055073a26100e51bdf1a92f4234cd6789c1f9" }
+source = { git = "https://github.com/bezhermoso/tree-sitter-ghostty" , rev = "4a0fd2ae492c6bbfd13a134067ee4258f0e0f189" }
 
 [[language]]
 name = "tera"

--- a/runtime/queries/ghostty/highlights.scm
+++ b/runtime/queries/ghostty/highlights.scm
@@ -17,6 +17,7 @@
  "+"
  "="
  (keybind_trigger ">")
+ (chain_operator)
 ] @operator
 
 (":") @punctuation.delimiter
@@ -59,9 +60,13 @@
 [
  (key_qualifier)
  (keybind_modifier)
+ (theme_variant)
+ (command_modifier)
 ] @attribute
 
 [
  (modifier_key)
  (key)
 ] @constant.builtin
+
+(keybind_table) @namespace


### PR DESCRIPTION
There's been updates the to the `ghostty` grammar, this PR is to catch Helix up with those & the queries.