### PR TITLE
fix: only consider named children in select_all_siblings

### DIFF
--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -58,7 +58,7 @@ pub fn select_all_siblings(syntax: &Syntax, text: RopeSlice, selection: Selectio
         let (from, to) = range.into_byte_range(text);
         cursor.reset_to_byte_range(from as u32, to as u32);
 
-        if !cursor.goto_parent_with(|parent| parent.child_count() > 1) {
+        if !cursor.goto_parent_with(|parent| parent.named_child_count() > 1) {
             return vec![range].into_iter();
         }
 

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -593,6 +593,16 @@ async fn select_all_siblings() -> anyhow::Result<()> {
                 ]|]#;
             "##},
         ),
+        // select siblings based on nearest parent with named children
+        (
+            indoc! {r##"
+                let foo = bar(*#[a|]#, b, c);
+            "##},
+            "<A-a>",
+            indoc! {r##"
+                let foo = bar(#[*a|]#, #(b|)#, #(c|)#);
+            "##},
+        ),
     ];
 
     for test in tests {


### PR DESCRIPTION
Since `select_all_children` only considers named children, it seems a bit odd that `select_all_siblings` finds the first parent with > 1 children, not named children: https://github.com/helix-editor/helix/blob/3beb268068d23294a26b47eab43b0a13a2a3a951/helix-core/src/object.rs#L78-L83

This means if you do `A-a` on the following:

```
foo(aaa, *b|bb);
```

Only `bbb` is selected when I think the intention is to select both `aaa` and `bbb`?