### PR TITLE
feat: make select_{prev,next}_sibling more strict

### DIFF
--- a/helix-core/src/object.rs
+++ b/helix-core/src/object.rs
@@ -42,8 +42,10 @@ pub fn select_next_sibling(syntax: &Syntax, text: RopeSlice, selection: Selectio
         text,
         selection,
         |cursor| {
+            let range = cursor.node().byte_range();
             while !cursor.goto_next_sibling() {
-                if !cursor.goto_parent() {
+                if !cursor.goto_parent_with(|n| n.byte_range() == range) {
+                    cursor.reset_to_byte_range(range.start, range.end);
                     break;
                 }
             }
@@ -95,8 +97,10 @@ pub fn select_prev_sibling(syntax: &Syntax, text: RopeSlice, selection: Selectio
         text,
         selection,
         |cursor| {
+            let range = cursor.node().byte_range();
             while !cursor.goto_previous_sibling() {
-                if !cursor.goto_parent() {
+                if !cursor.goto_parent_with(|n| n.byte_range() == range) {
+                    cursor.reset_to_byte_range(range.start, range.end);
                     break;
                 }
             }

--- a/helix-term/tests/test/commands/movement.rs
+++ b/helix-term/tests/test/commands/movement.rs
@@ -733,7 +733,7 @@ async fn test_select_next_sibling() -> anyhow::Result<()> {
         // basic test
         (
             indoc! {r##"
-                fn inc(x: usize) -> usize { x + 1 #[}|]#
+                #[fn inc(x: usize) -> usize { x + 1 }|]#
                 fn dec(x: usize) -> usize { x - 1 }
                 fn ident(x: usize) -> usize { x }
             "##},
@@ -747,7 +747,7 @@ async fn test_select_next_sibling() -> anyhow::Result<()> {
         // direction is not preserved and is always forward.
         (
             indoc! {r##"
-                fn inc(x: usize) -> usize { x + 1 #[}|]#
+                #[fn inc(x: usize) -> usize { x + 1 }|]#
                 fn dec(x: usize) -> usize { x - 1 }
                 fn ident(x: usize) -> usize { x }
             "##},
@@ -756,6 +756,30 @@ async fn test_select_next_sibling() -> anyhow::Result<()> {
                 fn inc(x: usize) -> usize { x + 1 }
                 fn dec(x: usize) -> usize { x - 1 }
                 #[fn ident(x: usize) -> usize { x }|]#
+            "##},
+        ),
+        // stops at last sibling
+        (
+            indoc! {r##"
+                fn inc(x: usize) -> usize { x + 1 #[}|]#
+                fn dec(x: usize) -> usize { x - 1 }
+                fn ident(x: usize) -> usize { x }
+            "##},
+            "<A-n>",
+            indoc! {r##"
+                fn inc(x: usize) -> usize { x + 1 #[}|]#
+                fn dec(x: usize) -> usize { x - 1 }
+                fn ident(x: usize) -> usize { x }
+            "##},
+        ),
+        // doesn't get stuck in node with one child
+        (
+            indoc! {r##"
+                fn inc(x: usize) -> usize { #[for _ in 0..1 {}|]# x + 1 }
+            "##},
+            "<A-n>",
+            indoc! {r##"
+                fn inc(x: usize) -> usize { for _ in 0..1 {} #[x + 1|]# }
             "##},
         ),
     ];
@@ -775,7 +799,7 @@ async fn test_select_prev_sibling() -> anyhow::Result<()> {
             indoc! {r##"
                 fn inc(x: usize) -> usize { x + 1 }
                 fn dec(x: usize) -> usize { x - 1 }
-                #[|f]#n ident(x: usize) -> usize { x }
+                #[|fn ident(x: usize) -> usize { x }]#
             "##},
             "<A-p>",
             indoc! {r##"
@@ -789,13 +813,37 @@ async fn test_select_prev_sibling() -> anyhow::Result<()> {
             indoc! {r##"
                 fn inc(x: usize) -> usize { x + 1 }
                 fn dec(x: usize) -> usize { x - 1 }
-                #[|f]#n ident(x: usize) -> usize { x }
+                #[|fn ident(x: usize) -> usize { x }]#
             "##},
             "<A-p><A-;><A-p>",
             indoc! {r##"
                 #[|fn inc(x: usize) -> usize { x + 1 }]#
                 fn dec(x: usize) -> usize { x - 1 }
                 fn ident(x: usize) -> usize { x }
+            "##},
+        ),
+        // stops at last sibling
+        (
+            indoc! {r##"
+                fn inc(x: usize) -> usize { x + 1 }
+                fn dec(x: usize) -> usize { x - 1 }
+                #[|f]#n ident(x: usize) -> usize { x }
+            "##},
+            "<A-p>",
+            indoc! {r##"
+                fn inc(x: usize) -> usize { x + 1 }
+                fn dec(x: usize) -> usize { x - 1 }
+                #[|fn]# ident(x: usize) -> usize { x }
+            "##},
+        ),
+        // doesn't get stuck in node with one child
+        (
+            indoc! {r##"
+                fn inc(x: usize) -> usize { println("{x}"); #[for _ in 0..1 {}|]# x + 1 }
+            "##},
+            "<A-p>",
+            indoc! {r##"
+                fn inc(x: usize) -> usize { #[|println("{x}");]# for _ in 0..1 {} x + 1 }
             "##},
         ),
     ];

--- a/helix-term/tests/test/movement.rs
+++ b/helix-term/tests/test/movement.rs
@@ -833,9 +833,9 @@ async fn tree_sitter_motions_work_across_injections() -> anyhow::Result<()> {
     test_with_config(
         AppBuilder::new().with_file("foo.html", None),
         (
-            "<script>let #[|x]# = 1;</script>",
+            "<script>let x #[|=]# 1;</script>",
             "<A-p>",
-            "<script>#[|let]# x = 1;</script>",
+            "<script>let #[|x]# = 1;</script>",
         ),
     )
     .await?;


### PR DESCRIPTION
Instead of always going to the parent when there is no sibling, this change makes it so that we do nothing when hitting the start/end of the siblings list. I like this behavior more since I find that I accidentally go past the end of the list and then have to backtrack but would be curious what others think.

Note that the implementation still includes the `goto_parent` loop since without it we can get stuck when trying to move between the statements in the following function (since the `for` is wrapped in `expression_statement`):

```rust
fn foo() {
    #[for i in 0..10 {
        println!("{i}")
    }|]#

    println!("done");
}
```

Closes #14304