### PR TITLE
feat(cli): support #section syntax when opening files at sections via cli or typed command

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -165,7 +165,7 @@ impl Application {
             // If there are any more files specified, open them
             if files_it.peek().is_some() {
                 let mut nr_of_files = 0;
-                for (file, pos) in files_it {
+                for (file, targets) in files_it {
                     nr_of_files += 1;
                     if file.is_dir() {
                         return Err(anyhow::anyhow!(
@@ -204,12 +204,33 @@ impl Application {
                         // opened last is focused on.
                         let view_id = editor.tree.focus;
                         let doc = doc_mut!(editor, &doc_id);
-                        let selection = pos
-                            .into_iter()
-                            .map(|coords| {
-                                Range::point(pos_at_coords(doc.text().slice(..), coords, true))
-                            })
-                            .collect();
+
+                        let section_pos = targets
+                            .first()
+                            .and_then(|t| t.section.as_ref())
+                            .and_then(|section| {
+                                let syntax = doc.syntax()?;
+                                let text = doc.text().slice(..);
+                                let loader = editor.syn_loader.load();
+                                crate::commands::syntax::find_section_position(
+                                    syntax, &loader, text, doc_id, section,
+                                )
+                            });
+
+                        let selection = if let Some(char_pos) = section_pos {
+                            Selection::point(char_pos)
+                        } else {
+                            targets
+                                .into_iter()
+                                .map(|target| {
+                                    Range::point(pos_at_coords(
+                                        doc.text().slice(..),
+                                        target.position,
+                                        true,
+                                    ))
+                                })
+                                .collect()
+                        };
                         doc.set_selection(view_id, selection);
                     }
                 }

--- a/helix-term/src/args.rs
+++ b/helix-term/src/args.rs
@@ -17,8 +17,14 @@ pub struct Args {
     pub verbosity: u64,
     pub log_file: Option<PathBuf>,
     pub config_file: Option<PathBuf>,
-    pub files: IndexMap<PathBuf, Vec<Position>>,
+    pub files: IndexMap<PathBuf, Vec<FileTarget>>,
     pub working_directory: Option<PathBuf>,
+}
+
+#[derive(Default, Clone)]
+pub struct FileTarget {
+    pub position: Position,
+    pub section: Option<String>,
 }
 
 impl Args {
@@ -27,16 +33,16 @@ impl Args {
         let mut argv = std::env::args().peekable();
         let mut line_number = 0;
 
-        let mut insert_file_with_position = |file_with_position: &str| {
-            let (filename, position) = parse_file(file_with_position);
+        let mut insert_file_with_position = |file_str: &str| {
+            let (filename, target) = parse_file(file_str);
 
             // Before setting the working directory, resolve all the paths in args.files
             let filename = helix_stdx::path::canonicalize(filename);
 
             args.files
                 .entry(filename)
-                .and_modify(|positions| positions.push(position))
-                .or_insert_with(|| vec![position]);
+                .and_modify(|targets| targets.push(target.clone()))
+                .or_insert_with(|| vec![target]);
         };
 
         argv.next(); // skip the program, we don't care about that
@@ -122,9 +128,9 @@ impl Args {
             if let Some(first_position) = args
                 .files
                 .first_mut()
-                .and_then(|(_, positions)| positions.first_mut())
+                .and_then(|(_, target)| target.first_mut())
             {
-                first_position.row = line_number;
+                first_position.position.row = line_number
             }
         }
 
@@ -132,15 +138,29 @@ impl Args {
     }
 }
 
-/// Parse arg into [`PathBuf`] and position.
-pub(crate) fn parse_file(s: &str) -> (PathBuf, Position) {
-    let def = || (PathBuf::from(s), Position::default());
+/// Parse arg into [`PathBuf`] and [`FileTarget`].
+///
+/// Supports `file#section`, `file:row`, `file:row:col`, and combinations
+/// like `file#section:row:col`. A file on disk always takes priority.
+pub(crate) fn parse_file(s: &str) -> (PathBuf, FileTarget) {
     if Path::new(s).exists() {
-        return def();
+        return (PathBuf::from(s), FileTarget::default());
     }
-    split_path_row_col(s)
-        .or_else(|| split_path_row(s))
-        .unwrap_or_else(def)
+
+    let (s, section) = match s.rsplit_once('#') {
+        Some((before, after)) if !after.is_empty() => (before, Some(after.to_string())),
+        _ => (s, None),
+    };
+
+    let (path, position) = if Path::new(s).exists() {
+        (PathBuf::from(s), Position::default())
+    } else {
+        split_path_row_col(s)
+            .or_else(|| split_path_row(s))
+            .unwrap_or_else(|| (PathBuf::from(s), Position::default()))
+    };
+
+    (path, FileTarget { position, section })
 }
 
 /// Split file.rs:10:2 into [`PathBuf`], row and col.

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -156,6 +156,18 @@ fn tags_iter<'a>(
     })
 }
 
+pub fn find_section_position(
+    syntax: &Syntax,
+    loader: &Loader,
+    text: RopeSlice<'_>,
+    doc_id: DocumentId,
+    section_name: &str,
+) -> Option<usize> {
+    tags_iter(syntax, loader, text, UriOrDocumentId::Id(doc_id), None)
+        .find(|tag| tag.kind == TagKind::Section && tag.name.contains(section_name))
+        .map(|tag| tag.start)
+}
+
 pub fn syntax_symbol_picker(cx: &mut Context) {
     let doc = doc!(cx.editor);
     let Some(syntax) = doc.syntax() else {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -145,7 +145,7 @@ fn open(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
 
 fn open_impl(cx: &mut compositor::Context, args: Args, action: Action) -> anyhow::Result<()> {
     for arg in args {
-        let (path, pos) = crate::args::parse_file(&arg);
+        let (path, target) = crate::args::parse_file(&arg);
         let path = helix_stdx::path::expand_tilde(path);
         // If the path is a directory, open a file picker on that directory and update the status
         // message
@@ -165,7 +165,24 @@ fn open_impl(cx: &mut compositor::Context, args: Args, action: Action) -> anyhow
             // Otherwise, just open the file
             let _ = cx.editor.open(&path, action)?;
             let (view, doc) = current!(cx.editor);
-            let pos = Selection::point(pos_at_coords(doc.text().slice(..), pos, true));
+            let pos = target
+                .section
+                .as_ref()
+                .and_then(|section| {
+                    let syntax = doc.syntax()?;
+                    let text = doc.text().slice(..);
+                    super::syntax::find_section_position(
+                        syntax,
+                        &cx.editor.syn_loader.load(),
+                        text,
+                        doc.id(),
+                        section,
+                    )
+                })
+                .map(Selection::point)
+                .unwrap_or_else(|| {
+                    Selection::point(pos_at_coords(doc.text().slice(..), target.position, true))
+                });
             doc.set_selection(view.id, pos);
             // does not affect opening a buffer without pos
             align_view(doc, view, Align::Center);

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -910,7 +910,10 @@ async fn test_open_file_with_section_fragment() -> anyhow::Result<()> {
         .primary()
         .cursor_line(doc.text().slice(..));
 
-    assert_eq!(cursor_line, 8, "cursor should be on the Installation heading");
+    assert_eq!(
+        cursor_line, 8,
+        "cursor should be on the Installation heading"
+    );
 
     Ok(())
 }

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -890,3 +890,27 @@ async fn align_selections_with_varying_columns() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_open_file_with_section_fragment() -> anyhow::Result<()> {
+    let file = helpers::temp_file_with_contents_and_ext(
+        "# Introduction\n\nSome text here.\n\n## Features\n\nFeature list.\n\n## Installation\n\nInstall steps.\n",
+        ".md",
+    )?;
+
+    let mut app = AppBuilder::new()
+        .with_file_section(file.path(), "Installation")
+        .build()?;
+
+    run_event_loop_until_idle(&mut app).await;
+
+    let (view, doc) = helix_view::current!(app.editor);
+    let cursor_line = doc
+        .selection(view.id)
+        .primary()
+        .cursor_line(doc.text().slice(..));
+
+    assert_eq!(cursor_line, 8, "cursor should be on the Installation heading");
+
+    Ok(())
+}

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -349,9 +349,13 @@ impl AppBuilder {
         path: P,
         pos: Option<helix_core::Position>,
     ) -> Self {
-        self.args
-            .files
-            .insert(path.into(), vec![pos.unwrap_or_default()]);
+        self.args.files.insert(
+            path.into(),
+            vec![helix_term::args::FileTarget {
+                position: pos.unwrap_or_default(),
+                section: None,
+            }],
+        );
 
         self
     }

--- a/helix-term/tests/test/helpers.rs
+++ b/helix-term/tests/test/helpers.rs
@@ -279,6 +279,21 @@ pub fn temp_file_with_contents<S: AsRef<str>>(
     Ok(temp_file)
 }
 
+pub fn temp_file_with_contents_and_ext<S: AsRef<str>>(
+    content: S,
+    ext: &str,
+) -> anyhow::Result<tempfile::NamedTempFile> {
+    let mut temp_file = tempfile::Builder::new().suffix(ext).tempfile()?;
+
+    temp_file
+        .as_file_mut()
+        .write_all(content.as_ref().as_bytes())?;
+
+    temp_file.flush()?;
+    temp_file.as_file_mut().sync_all()?;
+    Ok(temp_file)
+}
+
 /// Generates a config with defaults more suitable for integration tests
 pub fn test_config() -> Config {
     Config {
@@ -354,6 +369,18 @@ impl AppBuilder {
             vec![helix_term::args::FileTarget {
                 position: pos.unwrap_or_default(),
                 section: None,
+            }],
+        );
+
+        self
+    }
+
+    pub fn with_file_section<P: Into<PathBuf>>(mut self, path: P, section: &str) -> Self {
+        self.args.files.insert(
+            path.into(),
+            vec![helix_term::args::FileTarget {
+                position: helix_core::Position::default(),
+                section: Some(section.to_string()),
             }],
         );
 


### PR DESCRIPTION
Closes #15680

Instead of using just positions, updated the structure to use position as part of `FileTarget` struct. It adds support for opening files by section. For now, it opens at sections as the issue suggested. I have tested this with `README.md` and also with `Cargo.toml`. As long as the `TagKind::Section` is supported by the language of file, it should work on both the cli as well as commands from the editor. As of now, it takes `Section` precedence over the usual positioning. I am not sure if something like a mix of both is required.

## Examples                                                                                                                                                                                                      
  ```sh                                                                                                                                                                                                            
  # Open README.md with cursor at the "Features" heading
  hx README.md#Features                                                                                                                                                                                            
   
  # Open Cargo.toml with cursor at the [package] section                                                                                                                                                           
  hx Cargo.toml#package
                                                                                                                                                                                                                   
  # Combine with line number (section takes priority)
  hx README.md#Installation:10                                                                                                                                                                                     
                  
  # From within Helix:                                                                                                                                                                                               
  :open README.md#Features
```
 I am contributing for the very first time on this repository. happy to address any changes needed. Thanks!

