### PR TITLE
Make hx --v(h)split a.txt b.txt... focus on first file split instead of last

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -213,11 +213,10 @@ impl Application {
                         doc.set_selection(view_id, selection);
                     }
                 }
-                // im not sure if this may fail under some conditions 
-                let Some(first_view) = editor.tree.views().map(|(view, _)| view.id).next() else {
-                    unreachable!()
-                };
-                editor.focus(first_view);
+                let first_view = editor.tree.views().map(|(view, _)| view.id).next();
+                if let Some(first_view) = first_view {
+                    editor.focus(first_view);
+                }
 
                 // if all files were invalid, replace with empty buffer
                 if nr_of_files == 0 {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -213,6 +213,11 @@ impl Application {
                         doc.set_selection(view_id, selection);
                     }
                 }
+                // im not sure if this may fail under some conditions 
+                let Some(first_view) = editor.tree.views().map(|(view, _)| view.id).next() else {
+                    unreachable!()
+                };
+                editor.focus(first_view);
 
                 // if all files were invalid, replace with empty buffer
                 if nr_of_files == 0 {


### PR DESCRIPTION
Closes #15662

Makes the editor focus on the first file split when opened with many files in split mode: 
```sh
hx --v(h)split a.txt b.txt ... n.txt
```

This would match the behavior of launching helix with many files and no split: loads all files but keeps focus on the first file. 

ps: This is my first pr here, sorry for any trouble.