### PR TITLE
fix Csi::Mode::ReportTheme event triggering a theme reset to the conf…

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -470,6 +470,9 @@ impl Application {
         let true_color = terminal.backend().supports_true_color()
             || config.editor.true_color
             || crate::true_color();
+
+        log::warn!("config-theme: {:?}", config.theme);
+        log::warn!("editor-theme: {:?}", editor.theme.name());
         let theme = config
             .theme
             .as_ref()
@@ -494,8 +497,7 @@ impl Application {
                         }
                         colors_ok
                     })
-            })
-            .unwrap_or_else(|| editor.theme_loader.default_theme(true_color));
+            }).unwrap_or_else(|| editor.theme_loader.default_theme(true_color));
         let _ = editor.set_theme(theme);
     }
 
@@ -723,13 +725,14 @@ impl Application {
             }) => false,
             #[cfg(not(windows))]
             termina::Event::Csi(csi::Csi::Mode(csi::Mode::ReportTheme(mode))) => {
+                log::warn!("termina-event: report-theme: {:?}", mode);
                 self.theme_mode = Some(mode.into());
-                Self::load_configured_theme(
-                    &mut self.editor,
-                    &self.config.load(),
-                    &mut self.terminal,
-                    self.theme_mode,
-                );
+                // Self::load_configured_theme(
+                //     &mut self.editor,
+                //     &self.config.load(),
+                //     &mut self.terminal,
+                //     self.theme_mode,
+                // );
                 true
             }
             #[cfg(windows)]


### PR DESCRIPTION
Closes #15691.

Every time a Csi::Mode::ReportTheme termina event is triggered the current editor theme is discarded and the config theme is set in its place. This pr comments out the function call (Application::load_configured_theme(...)) responsible for this behavior.

Though, since I dont understand what that call is there to do, I cant be sure this change is agreeable, at least I know it doesnt break any tests.

