### PR TITLE
Do not change theme on OSC 997 when theme config is constant

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -723,14 +723,26 @@ impl Application {
             }) => false,
             #[cfg(not(windows))]
             termina::Event::Csi(csi::Csi::Mode(csi::Mode::ReportTheme(mode))) => {
-                self.theme_mode = Some(mode.into());
-                Self::load_configured_theme(
-                    &mut self.editor,
-                    &self.config.load(),
-                    &mut self.terminal,
-                    self.theme_mode,
-                );
-                true
+                let config = self.config.load();
+                let mode = mode.into();
+                if let (true, Some(theme::Config::Adaptive { .. })) = (
+                    self.theme_mode
+                        .as_ref()
+                        .map(|m| m != &mode)
+                        .unwrap_or_else(|| true),
+                    config.theme.as_ref(),
+                ) {
+                    self.theme_mode = Some(mode);
+                    Self::load_configured_theme(
+                        &mut self.editor,
+                        &config,
+                        &mut self.terminal,
+                        self.theme_mode,
+                    );
+                    true
+                } else {
+                    false
+                }
             }
             #[cfg(windows)]
             TerminalEvent::Resize(width, height) => {

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -725,13 +725,8 @@ impl Application {
             termina::Event::Csi(csi::Csi::Mode(csi::Mode::ReportTheme(mode))) => {
                 let config = self.config.load();
                 let mode = mode.into();
-                if let (true, Some(theme::Config::Adaptive { .. })) = (
-                    self.theme_mode
-                        .as_ref()
-                        .map(|m| m != &mode)
-                        .unwrap_or_else(|| true),
-                    config.theme.as_ref(),
-                ) {
+                let mode_changed = self.theme_mode.as_ref().is_none_or(|m| m != &mode);
+                if mode_changed && config.theme.as_ref().is_some_and(|t| t.is_adaptive()) {
                     self.theme_mode = Some(mode);
                     Self::load_configured_theme(
                         &mut self.editor,

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -79,6 +79,10 @@ impl Config {
             },
         }
     }
+
+    pub fn is_adaptive(&self) -> bool {
+        matches!(self, Self::Adaptive { .. })
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -51,59 +51,36 @@ impl From<termina::escape::csi::ThemeMode> for Mode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Config {
-    light: String,
-    dark: String,
-    /// A theme to choose when the terminal did not declare either light or dark mode.
-    /// When not specified the dark theme is preferred.
-    fallback: Option<String>,
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged, deny_unknown_fields, rename_all = "kebab-case")]
+pub enum Config {
+    Constant(String),
+    Adaptive {
+        light: String,
+        dark: String,
+        /// A theme to choose when the terminal did not declare either light or dark mode.
+        /// When not specified the dark theme is preferred.
+        fallback: Option<String>,
+    },
 }
 
 impl Config {
     pub fn choose(&self, preference: Option<Mode>) -> &str {
-        match preference {
-            Some(Mode::Light) => &self.light,
-            Some(Mode::Dark) => &self.dark,
-            None => self.fallback.as_ref().unwrap_or(&self.dark),
-        }
-    }
-}
-
-impl<'de> Deserialize<'de> for Config {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(untagged, deny_unknown_fields, rename_all = "kebab-case")]
-        enum InnerConfig {
-            Constant(String),
-            Adaptive {
-                dark: String,
-                light: String,
-                fallback: Option<String>,
-            },
-        }
-
-        let inner = InnerConfig::deserialize(deserializer)?;
-
-        let (light, dark, fallback) = match inner {
-            InnerConfig::Constant(theme) => (theme.clone(), theme.clone(), None),
-            InnerConfig::Adaptive {
+        match self {
+            Config::Constant(theme) => theme,
+            Config::Adaptive {
                 light,
                 dark,
                 fallback,
-            } => (light, dark, fallback),
-        };
-
-        Ok(Self {
-            light,
-            dark,
-            fallback,
-        })
+            } => match preference {
+                Some(Mode::Light) => light,
+                Some(Mode::Dark) => dark,
+                None => fallback.as_ref().unwrap_or(dark),
+            },
+        }
     }
 }
+
 #[derive(Clone, Debug)]
 pub struct Loader {
     /// Theme directories to search from highest to lowest priority


### PR DESCRIPTION
Closes #15691

~I _think_ this fixes the problem, but I can't test for sure (I don't have any way to toggle light/dark mode on runtime).~

Seems to be working, see linked issue.