### PR TITLE
Add Millet language server for SML

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -264,7 +264,7 @@
 | slisp | ✓ |  |  | ✓ |  |  |
 | smali | ✓ |  | ✓ |  |  | `smalisp` |
 | smithy | ✓ |  |  |  |  | `cs` |
-| sml | ✓ |  |  |  |  |  |
+| sml | ✓ |  |  |  |  | `millet-ls` |
 | snakemake | ✓ |  | ✓ |  |  | `pylsp` |
 | solidity | ✓ | ✓ |  |  |  | `solc` |
 | sourcepawn | ✓ | ✓ |  |  |  | `sourcepawn-studio` |

--- a/languages.toml
+++ b/languages.toml
@@ -318,6 +318,9 @@ args = ["server", "--stdio"]
 [language-server.drools-lsp]
 command = "drools-lsp"
 
+[language-server.millet]
+command = "millet-ls"
+
 [[language]]
 name = "rust"
 scope = "source.rust"
@@ -3085,8 +3088,10 @@ source = { git = "https://github.com/Isopod/tree-sitter-pascal", rev = "2fd40f47
 name = "sml"
 scope = "source.sml"
 injection-regex = "sml"
-file-types = ["sml"]
+file-types = ["sml", "sig", "fun"]
+roots = ["millet.toml"]
 block-comment-tokens = { start = "(*", end = "*)" }
+language-servers = ["millet"]
 
 [language.auto-pairs]
 '(' = ')'


### PR DESCRIPTION
Wires up [Millet](https://github.com/azdavis/millet) (`millet-ls`) as the default language server for the existing SML language entry.

Changes:
- Add a `[language-server.millet]` block invoking `millet-ls` over stdio (the binary's only mode).
- Attach `millet` to the `sml` language and add `millet.toml` as a project root marker (Millet's project config file).
- Extend SML `file-types` with `sig` and `fun`, the conventional Standard ML signature and functor file extensions, both of which Millet handles.
- Regenerate `book/src/generated/lang-support.md` via `cargo xtask docgen`.

Millet is the most actively maintained SML LSP server and the natural pairing for the existing tree-sitter-sml grammar already in Helix. With this change, users only need `millet-ls` on `$PATH` to get diagnostics, hover, and go-to-definition for SML in Helix.