### PR TITLE
ui: close picker and select overlays by id

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1128,6 +1128,7 @@ impl Application {
                     }
                     Ok(MethodCall::ShowMessageRequest(params)) => {
                         if let Some(actions) = params.actions.filter(|a| !a.is_empty()) {
+                            let select_id = "lsp-show-message-request";
                             let id = id.clone();
                             let select = ui::Select::new(
                                 params.message,
@@ -1152,9 +1153,9 @@ impl Application {
                                         }
                                     }
                                 },
-                            );
-                            self.compositor
-                                .replace_or_push("lsp-show-message-request", select);
+                            )
+                            .with_id(select_id);
+                            self.compositor.replace_or_push(select_id, select);
                             // Avoid sending a reply. The `Select` callback above sends the reply.
                             return;
                         } else {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -811,7 +811,8 @@ pub fn code_action(cx: &mut Context) {
                         }
                     }
                 }
-            });
+            })
+            .close_by_id("code-action");
             picker.move_down(); // pre-select the first item
 
             let popup = Popup::new("code-action", picker)

--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -40,7 +40,7 @@ pub fn prompt(path: PathBuf, compositor: &mut Compositor) {
     } else {
         workspaces.insert(path.clone());
     }
-    let select = select();
+    let select = select().with_id(ID);
     compositor.replace_or_push(ID, select);
 }
 

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -36,6 +36,7 @@ pub struct Menu<T: Item> {
     viewport: (u16, u16),
     recalculate: bool,
     auto_close: bool,
+    close_id: Option<&'static str>,
 }
 
 impl<T: Item> Menu<T> {
@@ -61,6 +62,7 @@ impl<T: Item> Menu<T> {
             viewport: (0, 0),
             recalculate: true,
             auto_close: false,
+            close_id: None,
         }
     }
 
@@ -131,6 +133,11 @@ impl<T: Item> Menu<T> {
 
     pub fn auto_close(mut self, auto_close: bool) -> Self {
         self.auto_close = auto_close;
+        self
+    }
+
+    pub fn close_by_id(mut self, id: &'static str) -> Self {
+        self.close_id = Some(id);
         self
     }
 
@@ -238,9 +245,14 @@ impl<T: Item + 'static> Component for Menu<T> {
             _ => return EventResult::Ignored(None),
         };
 
-        let close_fn: Option<Callback> = Some(Box::new(|compositor: &mut Compositor, _| {
+        let close_id = self.close_id;
+        let close_fn: Option<Callback> = Some(Box::new(move |compositor: &mut Compositor, _| {
             // remove the layer
-            compositor.pop();
+            if let Some(id) = close_id {
+                compositor.remove(id);
+            } else {
+                compositor.pop();
+            }
         }));
 
         // Ignore tab key when supertab is turned on in order not to interfere

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1068,7 +1068,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                 if picker.matcher.snapshot().item_count() > 1_000_000 {
                     Box::new(|compositor: &mut Compositor, _ctx| {
                         // remove the layer
-                        compositor.pop();
+                        compositor.remove(ID);
                     })
                 } else {
                     // stop streaming in new items in the background, really we should
@@ -1078,7 +1078,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                     picker.version.fetch_add(1, atomic::Ordering::Relaxed);
                     Box::new(|compositor: &mut Compositor, _ctx| {
                         // remove the layer
-                        compositor.last_picker = compositor.pop();
+                        compositor.last_picker = compositor.remove(ID);
                     })
                 };
             EventResult::Consumed(Some(callback))

--- a/helix-term/src/ui/select.rs
+++ b/helix-term/src/ui/select.rs
@@ -13,6 +13,7 @@ use super::{menu::Item, Menu, PromptEvent, Text};
 pub struct Select<T: Item> {
     message: Text,
     options: Menu<T>,
+    id: Option<&'static str>,
 }
 
 impl<T: Item> Select<T> {
@@ -38,6 +39,18 @@ impl<T: Item> Select<T> {
         Self {
             message,
             options: menu,
+            id: None,
+        }
+    }
+
+    pub fn with_id(self, id: &'static str) -> Self {
+        let Self {
+            message, options, ..
+        } = self;
+        Self {
+            message,
+            options: options.close_by_id(id),
+            id: Some(id),
         }
     }
 }
@@ -98,5 +111,9 @@ impl<T: Item> Component for Select<T> {
         // Options menu
         let menu_area = area.clip_top(message_height + 2);
         self.options.render(menu_area, surface, cx);
+    }
+
+    fn id(&self) -> Option<&'static str> {
+        self.id
     }
 }


### PR DESCRIPTION
Picker and select menu close callbacks currently use `compositor.pop()`. That closes the top compositor layer, not necessarily the picker or menu that produced the close callback.

This PR changes those close callbacks to target the overlay by its compositor id instead. That makes the code express the intended target directly and avoids relying on the overlay still being the top layer when the callback runs.

I am leaving this as draft because I have not found a reproducible trigger for this on current master.