### PR TITLE
fix(build): protect use of Termcode when term features is not set

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -147,8 +147,14 @@ mod external {
                 Self::Termux
             } else if env_var_is_set("TMUX") && binary_exists("tmux") {
                 Self::Tmux
-            } else if env_var_is_set("WEZTERM_UNIX_SOCKET") && binary_exists("wezterm") {
-                Self::Termcode
+            } else if cfg!(feature = "term")
+                && env_var_is_set("WEZTERM_UNIX_SOCKET")
+                && binary_exists("wezterm")
+            {
+                #[cfg(feature = "term")]
+                return Self::Termcode;
+                #[cfg(not(feature = "term"))]
+                return Self::None;
             } else if env_var_is_set("WAYLAND_DISPLAY")
                 && binary_exists("wl-copy")
                 && binary_exists("wl-paste")
@@ -164,10 +170,11 @@ mod external {
                 Self::XSel
             } else if binary_exists("win32yank.exe") {
                 Self::Win32Yank
-            } else if cfg!(feature = "term") {
-                Self::Termcode
             } else {
-                Self::None
+                #[cfg(feature = "term")]
+                return Self::Termcode;
+                #[cfg(not(feature = "term"))]
+                return Self::None;
             }
         }
     }


### PR DESCRIPTION
Fixes cargo check -p helix-view (no --features term).