### PR TITLE
feat(config): add HELIX_CONFIG_DIR as a loadable config path

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -27,6 +27,8 @@ hidden = false
 
 You can use a custom configuration file by specifying it with the `-c` or
 `--config` command line argument, for example `hx -c path/to/custom-config.toml`.
+You may also set the `HELIX_CONFIG_DIR` environment variable to provide a direct
+path to your Helix configuration.
 You can reload the config file by issuing the `:config-reload` command. Alternatively, on Unix operating systems, you can reload it by sending the USR1
 signal to the Helix process, such as by using the command `pkill -USR1 hx`.
 

--- a/helix-loader/src/lib.rs
+++ b/helix-loader/src/lib.rs
@@ -118,11 +118,13 @@ pub fn runtime_file(rel_path: impl AsRef<Path>) -> PathBuf {
 }
 
 pub fn config_dir() -> PathBuf {
-    // TODO: allow env var override
-    let strategy = choose_base_strategy().expect("Unable to find the config directory!");
-    let mut path = strategy.config_dir();
-    path.push("helix");
-    path
+    match std::env::var_os("HELIX_CONFIG_DIR") {
+        Some(path) => PathBuf::from(path),
+        None => choose_base_strategy()
+            .expect("Unable to find the config directory!")
+            .config_dir()
+            .join("helix"),
+    }
 }
 
 pub fn cache_dir() -> PathBuf {

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -451,7 +451,8 @@ pub mod completers {
     }
 
     pub fn theme(_editor: &Editor, input: &str) -> Vec<Completion> {
-        let mut names = theme::Loader::read_names(&helix_loader::config_dir().join("themes"));
+        let themes_dir = helix_loader::config_dir().join("themes");
+        let mut names = theme::Loader::read_names(&themes_dir);
         for rt_dir in helix_loader::runtime_dirs() {
             names.extend(theme::Loader::read_names(&rt_dir.join("themes")));
         }


### PR DESCRIPTION
## What is this PR supposed to do?

This PR should allow users to optionally provide a environment variable that Helix will attempt to use as the configuration directory.

## Why?

Firstly, there was already a TODO to add an environment variable override. Secondly, it would address a small use case regarding wrappers which I don't think `-c config.toml` alone can address, such as adding themes and languages to the configuration.

## Does this PR do anything else?

I have added a check to see if the users provided environment variable has any themes, and uses the XDG base directory in case it cannot find anything. I am really unsure if this behaviour should even exist, as it's whole point was to fix an issue which I probably just made up. I am happy to revert this change if it *is* unnecessary. It also introduced an extra function which you would assume I already don't like from the comment alone.

## Do I plan to add any more changes to this PR?

Outside of reviews, I do not plan to add any more changes to this PR.