### PR TITLE
add radian profile support for R

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2028,7 +2028,7 @@ source = { git = "https://github.com/Hubro/tree-sitter-robot", rev = "322e4cc657
 name = "r"
 scope = "source.r"
 injection-regex = "(r|R)"
-file-types = ["r", "R", { glob = ".Rprofile" }, { glob = "Rprofile.site" }, { glob = ".RHistory" }]
+file-types = ["r", "R", { glob = ".Rprofile" }, { glob = "Rprofile.site" }, { glob = ".RHistory" }, { glob = "radian/profile" }, { glob = ".radian_profile" }]
 shebangs = ["r", "R"]
 comment-tokens = ["#", "#'"]
 indent = { tab-width = 2, unit = "  " }


### PR DESCRIPTION
Radian is a REPL for R, the configuration of radian can be done using R code similar to R profiles at specific paths. This PR proposes to add support for these files by either matching `.radian_profile` or `radian/profile`, which should be specific to radian configuration.

use the following glob expressions:

- `radian/profile`
  - the global config is located at `$XDG_CONFIG_HOME/radian/profile` or `$HOME/.config/radian/profile` (Unix) or `%USERPROFILE%/radian/profile` (Windows)
- `.radian_profile`
  - the user config is located at `$HOME/.radian_profile` (Unix) or `%USERPROFILE%/.radian_profile` (Windows) or within project directory

according to [the official radian documentation](https://github.com/randy3k/radian#settings)