### PR TITLE
perf(commands/typed): mark typable commands as `#[cold]`

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -68,6 +68,7 @@ impl CommandCompleter {
     }
 }
 
+#[cold]
 fn exit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -87,6 +88,7 @@ fn exit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     quit(cx, Args::default(), event)
 }
 
+#[cold]
 fn force_exit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -106,6 +108,7 @@ fn force_exit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
     quit(cx, Args::default(), event)
 }
 
+#[cold]
 fn quit(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     log::debug!("quitting...");
 
@@ -124,6 +127,7 @@ fn quit(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow
     Ok(())
 }
 
+#[cold]
 fn force_quit(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -135,6 +139,7 @@ fn force_quit(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
     Ok(())
 }
 
+#[cold]
 fn open(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -245,6 +250,7 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: Args) -> Vec<DocumentId> 
     document_ids
 }
 
+#[cold]
 fn buffer_close(
     cx: &mut compositor::Context,
     args: Args,
@@ -258,6 +264,7 @@ fn buffer_close(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
+#[cold]
 fn force_buffer_close(
     cx: &mut compositor::Context,
     args: Args,
@@ -293,6 +300,7 @@ fn buffer_gather_others_impl(editor: &mut Editor, skip_visible: bool) -> Vec<Doc
     }
 }
 
+#[cold]
 fn buffer_close_others(
     cx: &mut compositor::Context,
     args: Args,
@@ -306,6 +314,7 @@ fn buffer_close_others(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
+#[cold]
 fn force_buffer_close_others(
     cx: &mut compositor::Context,
     args: Args,
@@ -323,6 +332,7 @@ fn buffer_gather_all_impl(editor: &mut Editor) -> Vec<DocumentId> {
     editor.documents().map(|doc| doc.id()).collect()
 }
 
+#[cold]
 fn buffer_close_all(
     cx: &mut compositor::Context,
     _args: Args,
@@ -336,6 +346,7 @@ fn buffer_close_all(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
+#[cold]
 fn force_buffer_close_all(
     cx: &mut compositor::Context,
     _args: Args,
@@ -349,6 +360,7 @@ fn force_buffer_close_all(
     buffer_close_by_ids_impl(cx, &document_ids, true)
 }
 
+#[cold]
 fn buffer_next(
     cx: &mut compositor::Context,
     _args: Args,
@@ -362,6 +374,7 @@ fn buffer_next(
     Ok(())
 }
 
+#[cold]
 fn buffer_previous(
     cx: &mut compositor::Context,
     _args: Args,
@@ -487,6 +500,7 @@ pub struct WriteOptions {
     pub auto_format: bool,
 }
 
+#[cold]
 fn write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -502,6 +516,7 @@ fn write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
     )
 }
 
+#[cold]
 fn force_write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -517,6 +532,7 @@ fn force_write(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
     )
 }
 
+#[cold]
 fn write_buffer_close(
     cx: &mut compositor::Context,
     args: Args,
@@ -539,6 +555,7 @@ fn write_buffer_close(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
+#[cold]
 fn force_write_buffer_close(
     cx: &mut compositor::Context,
     args: Args,
@@ -561,6 +578,7 @@ fn force_write_buffer_close(
     buffer_close_by_ids_impl(cx, &document_ids, false)
 }
 
+#[cold]
 fn new_file(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -571,6 +589,7 @@ fn new_file(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> an
     Ok(())
 }
 
+#[cold]
 fn format(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -586,6 +605,7 @@ fn format(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyh
     Ok(())
 }
 
+#[cold]
 fn set_indent_style(
     cx: &mut compositor::Context,
     args: Args,
@@ -628,6 +648,7 @@ fn set_indent_style(
 }
 
 /// Sets or reports the current document's line ending setting.
+#[cold]
 fn set_line_ending(
     cx: &mut compositor::Context,
     args: Args,
@@ -700,6 +721,8 @@ fn set_line_ending(
 
     Ok(())
 }
+
+#[cold]
 fn earlier(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -716,6 +739,7 @@ fn earlier(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyh
     Ok(())
 }
 
+#[cold]
 fn later(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -731,6 +755,7 @@ fn later(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
     Ok(())
 }
 
+#[cold]
 fn write_quit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -748,6 +773,7 @@ fn write_quit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
     quit(cx, Args::default(), event)
 }
 
+#[cold]
 fn force_write_quit(
     cx: &mut compositor::Context,
     args: Args,
@@ -886,6 +912,7 @@ pub fn write_all_impl(
     Ok(())
 }
 
+#[cold]
 fn write_all(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -901,6 +928,7 @@ fn write_all(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> an
     )
 }
 
+#[cold]
 fn force_write_all(
     cx: &mut compositor::Context,
     args: Args,
@@ -920,6 +948,7 @@ fn force_write_all(
     )
 }
 
+#[cold]
 fn write_all_quit(
     cx: &mut compositor::Context,
     args: Args,
@@ -939,6 +968,7 @@ fn write_all_quit(
     quit_all_impl(cx, false)
 }
 
+#[cold]
 fn force_write_all_quit(
     cx: &mut compositor::Context,
     args: Args,
@@ -973,6 +1003,7 @@ fn quit_all_impl(cx: &mut compositor::Context, force: bool) -> anyhow::Result<()
     Ok(())
 }
 
+#[cold]
 fn quit_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -981,6 +1012,7 @@ fn quit_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> an
     quit_all_impl(cx, false)
 }
 
+#[cold]
 fn force_quit_all(
     cx: &mut compositor::Context,
     _args: Args,
@@ -993,6 +1025,7 @@ fn force_quit_all(
     quit_all_impl(cx, true)
 }
 
+#[cold]
 fn cquit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1007,6 +1040,7 @@ fn cquit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
     quit_all_impl(cx, false)
 }
 
+#[cold]
 fn force_cquit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1021,6 +1055,7 @@ fn force_cquit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
     quit_all_impl(cx, true)
 }
 
+#[cold]
 fn theme(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     let true_color = cx.editor.config.load().true_color || crate::true_color();
     match event {
@@ -1062,6 +1097,7 @@ fn theme(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow
     Ok(())
 }
 
+#[cold]
 fn yank_main_selection_to_clipboard(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1075,6 +1111,7 @@ fn yank_main_selection_to_clipboard(
     Ok(())
 }
 
+#[cold]
 fn yank_joined(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1091,6 +1128,7 @@ fn yank_joined(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
     Ok(())
 }
 
+#[cold]
 fn yank_joined_to_clipboard(
     cx: &mut compositor::Context,
     args: Args,
@@ -1107,6 +1145,7 @@ fn yank_joined_to_clipboard(
     Ok(())
 }
 
+#[cold]
 fn yank_main_selection_to_primary_clipboard(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1120,6 +1159,7 @@ fn yank_main_selection_to_primary_clipboard(
     Ok(())
 }
 
+#[cold]
 fn yank_joined_to_primary_clipboard(
     cx: &mut compositor::Context,
     args: Args,
@@ -1136,6 +1176,7 @@ fn yank_joined_to_primary_clipboard(
     Ok(())
 }
 
+#[cold]
 fn paste_clipboard_after(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1149,6 +1190,7 @@ fn paste_clipboard_after(
     Ok(())
 }
 
+#[cold]
 fn paste_clipboard_before(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1162,6 +1204,7 @@ fn paste_clipboard_before(
     Ok(())
 }
 
+#[cold]
 fn paste_primary_clipboard_after(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1175,6 +1218,7 @@ fn paste_primary_clipboard_after(
     Ok(())
 }
 
+#[cold]
 fn paste_primary_clipboard_before(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1188,6 +1232,7 @@ fn paste_primary_clipboard_before(
     Ok(())
 }
 
+#[cold]
 fn replace_selections_with_clipboard(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1201,6 +1246,7 @@ fn replace_selections_with_clipboard(
     Ok(())
 }
 
+#[cold]
 fn replace_selections_with_primary_clipboard(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1214,6 +1260,7 @@ fn replace_selections_with_primary_clipboard(
     Ok(())
 }
 
+#[cold]
 fn show_clipboard_provider(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1256,6 +1303,7 @@ fn apply_directory_change(cx: &mut compositor::Context, dir: &Path) -> anyhow::R
     Ok(())
 }
 
+#[cold]
 fn change_current_directory(
     cx: &mut compositor::Context,
     args: Args,
@@ -1270,6 +1318,7 @@ fn change_current_directory(
     apply_directory_change(cx, &dir)
 }
 
+#[cold]
 fn show_directory_stack(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1296,6 +1345,7 @@ fn show_directory_stack(
     Ok(())
 }
 
+#[cold]
 fn push_directory(
     cx: &mut compositor::Context,
     args: Args,
@@ -1317,6 +1367,7 @@ fn push_directory(
     change_current_directory(cx, args, event)
 }
 
+#[cold]
 fn pop_directory(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1335,6 +1386,7 @@ fn pop_directory(
     Ok(())
 }
 
+#[cold]
 fn show_current_directory(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1356,6 +1408,7 @@ fn show_current_directory(
 }
 
 /// Sets the [`Document`]'s encoding..
+#[cold]
 fn set_encoding(
     cx: &mut compositor::Context,
     args: Args,
@@ -1376,6 +1429,7 @@ fn set_encoding(
 }
 
 /// Shows info about the character under the primary cursor.
+#[cold]
 fn get_character_info(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1501,6 +1555,7 @@ fn get_character_info(
 }
 
 /// Reload the [`Document`] from its source file.
+#[cold]
 fn reload(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1522,6 +1577,7 @@ fn reload(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyh
     Ok(())
 }
 
+#[cold]
 fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1594,6 +1650,7 @@ fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
 }
 
 /// Update the [`Document`] if it has been modified.
+#[cold]
 fn update(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1614,6 +1671,7 @@ fn update(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyho
     }
 }
 
+#[cold]
 fn lsp_workspace_command(
     cx: &mut compositor::Context,
     args: Args,
@@ -1714,6 +1772,7 @@ fn lsp_workspace_command(
     Ok(())
 }
 
+#[cold]
 fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1799,6 +1858,7 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
     }
 }
 
+#[cold]
 fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -1838,6 +1898,7 @@ fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
     Ok(())
 }
 
+#[cold]
 fn tree_sitter_scopes(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1871,6 +1932,7 @@ fn tree_sitter_scopes(
     Ok(())
 }
 
+#[cold]
 fn tree_sitter_highlight_name(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1939,6 +2001,7 @@ fn tree_sitter_highlight_name(
     Ok(())
 }
 
+#[cold]
 fn tree_sitter_layers(
     cx: &mut compositor::Context,
     _args: Args,
@@ -1989,6 +2052,7 @@ fn tree_sitter_layers(
     Ok(())
 }
 
+#[cold]
 fn vsplit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2003,6 +2067,7 @@ fn vsplit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyho
     Ok(())
 }
 
+#[cold]
 fn hsplit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2017,6 +2082,7 @@ fn hsplit(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyho
     Ok(())
 }
 
+#[cold]
 fn vsplit_new(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2027,6 +2093,7 @@ fn vsplit_new(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
     Ok(())
 }
 
+#[cold]
 fn hsplit_new(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2037,6 +2104,7 @@ fn hsplit_new(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
     Ok(())
 }
 
+#[cold]
 fn debug_eval(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2059,6 +2127,7 @@ fn debug_eval(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
     Ok(())
 }
 
+#[cold]
 fn debug_start(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2072,6 +2141,7 @@ fn debug_start(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
     dap_start_impl(cx, name.as_deref(), None, Some(args))
 }
 
+#[cold]
 fn debug_remote(
     cx: &mut compositor::Context,
     args: Args,
@@ -2093,6 +2163,7 @@ fn debug_remote(
     dap_start_impl(cx, name.as_deref(), address, Some(args))
 }
 
+#[cold]
 fn tutor(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2139,6 +2210,7 @@ fn update_goto_line_number_preview(cx: &mut compositor::Context, args: Args) -> 
     Ok(())
 }
 
+#[cold]
 pub(super) fn goto_line_number(
     cx: &mut compositor::Context,
     args: Args,
@@ -2173,6 +2245,7 @@ pub(super) fn goto_line_number(
 }
 
 // Fetch the current value of a config option and output as status.
+#[cold]
 fn get_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2191,6 +2264,7 @@ fn get_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
 
 /// Change config at runtime. Access nested values by dot syntax, for
 /// example to disable smart case search, use `:set search.smart-case false`.
+#[cold]
 fn set_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2223,6 +2297,7 @@ fn set_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
 /// Toggle boolean config option at runtime. Access nested values by dot
 /// syntax, for example to toggle smart case search, use `:toggle search.smart-
 /// case`.
+#[cold]
 fn toggle_option(
     cx: &mut compositor::Context,
     args: Args,
@@ -2317,6 +2392,7 @@ fn toggle_option(
 }
 
 /// Change the language of the current buffer at runtime.
+#[cold]
 fn language(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2348,6 +2424,7 @@ fn language(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
     Ok(())
 }
 
+#[cold]
 fn sort(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2392,6 +2469,7 @@ fn sort(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     Ok(())
 }
 
+#[cold]
 fn reflow(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2427,6 +2505,7 @@ fn reflow(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyho
     Ok(())
 }
 
+#[cold]
 fn tree_sitter_subtree(
     cx: &mut compositor::Context,
     _args: Args,
@@ -2466,6 +2545,7 @@ fn tree_sitter_subtree(
     Ok(())
 }
 
+#[cold]
 fn open_config(
     cx: &mut compositor::Context,
     _args: Args,
@@ -2480,6 +2560,7 @@ fn open_config(
     Ok(())
 }
 
+#[cold]
 fn open_workspace_config(
     cx: &mut compositor::Context,
     _args: Args,
@@ -2494,6 +2575,7 @@ fn open_workspace_config(
     Ok(())
 }
 
+#[cold]
 fn open_log(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2503,6 +2585,7 @@ fn open_log(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> an
     Ok(())
 }
 
+#[cold]
 fn refresh_config(
     cx: &mut compositor::Context,
     _args: Args,
@@ -2516,6 +2599,7 @@ fn refresh_config(
     Ok(())
 }
 
+#[cold]
 fn append_output(
     cx: &mut compositor::Context,
     args: Args,
@@ -2529,6 +2613,7 @@ fn append_output(
     Ok(())
 }
 
+#[cold]
 fn insert_output(
     cx: &mut compositor::Context,
     args: Args,
@@ -2550,6 +2635,7 @@ fn pipe(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     pipe_impl(cx, args, event, &ShellBehavior::Replace)
 }
 
+#[cold]
 fn pipe_impl(
     cx: &mut compositor::Context,
     args: Args,
@@ -2564,6 +2650,7 @@ fn pipe_impl(
     Ok(())
 }
 
+#[cold]
 fn run_shell_command(
     cx: &mut compositor::Context,
     args: Args,
@@ -2600,6 +2687,7 @@ fn run_shell_command(
     Ok(())
 }
 
+#[cold]
 fn reset_diff_change(
     cx: &mut compositor::Context,
     _args: Args,
@@ -2652,6 +2740,7 @@ fn reset_diff_change(
     Ok(())
 }
 
+#[cold]
 fn clear_register(
     cx: &mut compositor::Context,
     args: Args,
@@ -2682,6 +2771,7 @@ fn clear_register(
     Ok(())
 }
 
+#[cold]
 fn set_register(
     cx: &mut compositor::Context,
     args: Args,
@@ -2700,6 +2790,7 @@ fn set_register(
     cx.editor.registers.write(register, vec![args[1].into()])
 }
 
+#[cold]
 fn redraw(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2724,6 +2815,7 @@ pub struct MoveBufferOptions {
     pub force: bool,
 }
 
+#[cold]
 fn move_buffer(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2733,6 +2825,7 @@ fn move_buffer(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
     move_buffer_impl(cx, new_path, MoveBufferOptions { force: false })
 }
 
+#[cold]
 fn force_move_buffer(
     cx: &mut compositor::Context,
     args: Args,
@@ -2785,6 +2878,7 @@ fn move_buffer_impl(
     Ok(())
 }
 
+#[cold]
 fn yank_diagnostic(
     cx: &mut compositor::Context,
     args: Args,
@@ -2825,6 +2919,7 @@ fn yank_diagnostic(
     Ok(())
 }
 
+#[cold]
 fn read(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2856,6 +2951,7 @@ fn read(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     Ok(())
 }
 
+#[cold]
 fn echo(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2873,6 +2969,7 @@ fn echo(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
     Ok(())
 }
 
+#[cold]
 fn noop(_cx: &mut compositor::Context, _args: Args, _event: PromptEvent) -> anyhow::Result<()> {
     Ok(())
 }
@@ -4466,6 +4563,7 @@ fn doc_trust_full(editor: &helix_view::Editor) -> bool {
         .is_trusted()
 }
 
+#[cold]
 fn trust_workspace(
     cx: &mut compositor::Context,
     args: Args<'_>,
@@ -4483,6 +4581,7 @@ fn trust_workspace(
     lsp_restart(cx, args, event)
 }
 
+#[cold]
 fn untrust_workspace(
     cx: &mut compositor::Context,
     _args: Args<'_>,
@@ -4501,6 +4600,7 @@ fn untrust_workspace(
     Ok(())
 }
 
+#[cold]
 fn exclude_workspace(
     cx: &mut compositor::Context,
     _args: Args<'_>,


### PR DESCRIPTION
This was mentioned briefly in #15626, but the idea is that as these are manually called, and thus rarely called, it should be fine to mark these as `#[cold]`, which allows the compiler to hint that these can be stored in a separate part of the binary, among other optimizations possible. This can have the benefit of leaving code that is actually called frequently to live closer together.

There are no measurements here, this is coming purely from assumptions. Ideally, we could setup a PGO build which would do most of what this can offer, but for the whole binary, and there is no need to add hints everywhere, and it wouldn't be guessing, but using real data.

I have some ideas about how this could be done, but it mostly involves something like zellij, which now has windows support, to "script" use in CI, but as this is a lot more involved, this PR is at least getting low hanging fruit. Given that this code lives in `helix-term`, and that LLVM loves to inline, this could be the most low hanging of fruits.