### PR TITLE
fix: Suppress external URL opener terminal output

### DIFF
--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -16,6 +16,7 @@ pub mod ui;
 use std::env::var_os;
 
 use std::path::Path;
+use std::process::Stdio;
 
 use futures_util::Future;
 mod handlers;
@@ -79,9 +80,25 @@ fn open_external_url_callback(
     async {
         for cmd in commands {
             let mut command: tokio::process::Command = cmd.into();
-            if command.status().await.is_ok() {
+            command.stdin(Stdio::null());
+            let output = match command.output().await {
+                Ok(output) => output,
+                Err(err) => {
+                    log::debug!("Failed to launch external URL opener: {err}");
+                    continue;
+                }
+            };
+            if output.status.success() {
                 return Ok(job::Callback::Editor(Box::new(|_| {})));
             }
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            log::warn!(
+                "External URL opener exited with status {}. stdout: {:?}, stderr: {:?}",
+                output.status,
+                stdout.trim(),
+                stderr.trim()
+            );
         }
         Ok(job::Callback::Editor(Box::new(move |editor| {
             editor.set_error("Opening URL in external program failed")


### PR DESCRIPTION
### Summary

Capture stdout/stderr from external URL opener commands instead of letting them write directly to Helix's terminal UI.

### Motivation

`goto_file` can open URLs through the platform opener. Some opener backends, such as portal-based `xdg-open` flows, may print status or diagnostic text while opening a URL. Since Helix runs in the terminal alternate screen, that output can appear inside the editor and leave stale rendered text behind.

I hit this with `gf` on a Markdown URL where the opener printed portal request information into the Helix UI.

Before:

<img width="720" height="445" alt="opener output rendered inside Helix" src="https://github.com/user-attachments/assets/19db8129-a875-49ce-ac55-f3b823153316" />


After:

<img width="720" height="445" alt="Helix UI remains clean after opening the URL" src="https://github.com/user-attachments/assets/3622a983-e81d-4a0f-a8a3-a737ece22209" />


### Changes

- Capture external opener output instead of inheriting the terminal.
- Treat non-zero opener exit statuses as failures and try the next opener command.
- Log opener launch failures and non-zero exits with captured stdout/stderr.
- Keep the existing statusline error when all opener commands fail.

### Testing

- `cargo fmt --check`
- `nix develop -c cargo check -p helix-term`
- Manually verified `gf` on a Markdown URL no longer leaves opener output in the Helix UI.
