### PR TITLE
Feature: Improved Ink syntax support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -4836,7 +4836,7 @@ file-types = ["ink"]
 injection-regex = "ink"
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/"}
-indent = { tab-width = 4, unit = "\t" }
+indent = { tab-width = 2, unit = "  " }
 soft-wrap = { enable = true }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -4841,7 +4841,7 @@ soft-wrap = { enable = true }
 
 [[grammar]]
 name = "ink"
-source = { git = "https://github.com/rhizoome/tree-sitter-ink", rev = "8486e9b1627b0bc6b2deb9ee8102277a7c1281ac" }
+source = { git = "https://github.com/wldmr/tree-sitter-ink.git", rev = "632072bab485ab4c705c39cb9aae9eaeac6893ba"}
 
 [[language]]
 name = "sourcepawn"

--- a/runtime/queries/ink/highlights.scm
+++ b/runtime/queries/ink/highlights.scm
@@ -1,53 +1,128 @@
-; tags and labels
-(label) @label
-(tag (identifier) @comment)
-(tag) @comment
+(identifier) @variable
+(return "return" @keyword.control.return)
+(global ["VAR" "CONST"] @keyword.storage.type
+        "=" @operator)
+(temp_def "temp" @keyword
+      name: (identifier) @variable.member) ; not really, but temp vars are the closest thing to members that ink has
+(include "INCLUDE" @keyword.control.import
+         (path) @string.special.path)
+(external "EXTERNAL" @keyword
+          (identifier) @function)
+(todo_comment "TODO" @keyword ":" @comment) @comment
+(code "~" @keyword.directive)
 
-; values
-(identifier) @function
+(binary "+" @operator)
+(binary "-" @operator)
+(binary "*" @operator)
+(binary "/" @operator)
+(binary "?" @operator)
+(binary "!?" @operator)
+(binary "^" @operator)
+(binary "==" @operator)
+(binary "!=" @operator)
+(binary "||" @operator)
+(binary "&&" @operator)
+(binary "<=" @operator)
+(binary ">=" @operator)
+(binary "<" @operator)
+(binary ">" @operator)
+(binary "%" @operator)
+(binary "and" @keyword.operator)
+(binary "or" @keyword.operator)
+(binary "has" @keyword.operator)
+(binary "hasnt" @keyword.operator)
+(binary "mod" @keyword.operator)
+
+(postfix "++" @operator)
+(postfix "--" @operator)
+
+(unary "!" @operator)
+(unary "-" @operator)
+(unary "not" @keyword.operator)
+
+(assignment ["=" "+=" "-="]) @operator
+
+(choice_only ["[" "]"] @punctuation.bracket)  ; Need to specifiy choice here, because the grammar does always tokenize these brackets (for all text), but we don't want to highlight them outside of choices.
+(label ["(" ")"] @punctuation.bracket name: (_) @label)
+
+["{" "}"] @punctuation.bracket ; Curlies are never just text, no need to qualify
+
+["," "|" ":"] @punctuation.delimiter
+
+(call (identifier) @function.builtin
+      (#any-of? @function.builtin
+       ; List Functions
+       "LIST_VALUE"
+       "LIST_COUNT"
+       "LIST_MIN"
+       "LIST_MAX"
+       "LIST_RANDOM"
+       "LIST_RANGE"
+       "LIST_INVERT"
+       ; Game Queries
+       "CHOICE_COUNT"
+       "TURNS"
+       "TURNS_SINCE"
+       "LIST_FOO"
+       "SEED_RANDOM"))
+(call (identifier) @function)
+(call ["(" ")"] @punctuation.bracket)
+
+(knot "==" @markup.heading.1 (identifier) @label)
+(knot "function" @keyword.function
+      (identifier) @function)
+
+(stitch "=" @markup.heading.2 (identifier) @label)
+
+(choice_mark) @markup.list.numbered
+(gather_mark) @markup.list.unnumbered
+
+(cond_arm "-" @keyword.control.conditional)
+(alt_arm "-" @keyword.control.repeat)
+(else) @constant.builtin
+
+(list "LIST" @keyword.storage.type
+      (identifier) @type.enum
+      "=" @operator)
+
+(list_value_def (identifier) @type.enum.variant)
+
+(list_values (identifier) @type.enum.variant)
+(list_values
+      (qualified_name
+            . (identifier) @type.enum
+            (identifier) @type.enum.variant))
+
+(glue) @keyword
+
+["->" "->->" "<-"] @keyword.control
+
+(divert (identifier) @label)
+(divert (identifier) @constant.builtin
+        (#any-of? @constant.builtin "END" "DONE"))
+
+(divert (call (identifier) @label))
+(divert (call (qualified_name (identifier) @label)))
+
+(thread [(identifier) (call)] @label)
+
+; Deal with parames *after* the general divert highlighting, so that divert parames still look like params
+(params ["(" ")"] @punctuation.bracket)
+(param
+      "ref"? @keyword.storage.modifier
+      value: [ (identifier) @variable.parameter
+               (divert (identifier) @variable.parameter) ]?)
+
+(multiline_alternatives ["shuffle" "stopping" "cycle" "once"] @keyword.control.repeat)
+(alternatives ["&" "$" "~" "!"] @keyword.control.repeat)
+
+(line_comment) @comment.line
+(block_comment) @comment.block
+
+(qualified_name "." @punctuation.delimiter)
 (string) @string
-(boolean) @constant.builtin.boolean
+
 (number) @constant.numeric
+(boolean) @keyword.builtin.boolean
 
-; headers
-(knot_header) @keyword
-(stitch_header) @keyword
-(function_header) @keyword
-
-; marks (ink)
-(option_mark) @keyword.directive
-(gather_mark) @type.builtin
-(glue) @type.builtin
-
-; calls
-(divert_or_thread) @function
-
-; operators
-(assignment) @operator
-
-; special marks/operators (ink)
-(arrow) @special
-(double_arrow) @special
-(back_arrow) @constant
-(dot) @special
-(mark_start) @special
-(mark_end) @special
-(hide_start) @special
-(hide_end) @special
-
-; declarations
-(var_line) @attribute
-(const_line) @constant
-(list_line) @type
-
-; comments
-(line_comment) @comment
-(block_comment) @comment
-
-; unparsed code
-(inline_block) @keyword
-(condition_block) @keyword
-(code_text) @keyword
-
-; support injection
-(program) @ui.text
+(tag "#" @punctuation.special) @tag

--- a/runtime/queries/ink/indents.scm
+++ b/runtime/queries/ink/indents.scm
@@ -1,0 +1,6 @@
+(choice_block
+  (choice (choice_marks) . _ @anchor)
+  (#set! "scope" "tail")) @align
+(gather_block
+  (gather (gather_marks) . _ @anchor)
+  (#set! "scope" "tail")) @align

--- a/runtime/queries/ink/locals.scm
+++ b/runtime/queries/ink/locals.scm
@@ -1,0 +1,9 @@
+(knot_block) @local.scope
+(stitch_block) @local.scope
+
+(param (identifier) @local.definition.variable.parameter)
+(param (divert (identifier) @local.definition.variable.parameter))
+(temp_def name: (identifier) @local.definition.variable)
+
+(identifier) @local.reference
+(divert (identifier) @local.reference)

--- a/runtime/queries/ink/textobjects.scm
+++ b/runtime/queries/ink/textobjects.scm
@@ -1,0 +1,15 @@
+(knot_block (knot function: _) . _+ @function.inside) @function.around
+(knot_block (knot !function) . _+ @class.inside) @class.around
+(stitch_block (stitch) . _+ @class.inside) @class.around
+
+
+(params ((param) @parameter.inside . ","? @parameter.around) @parameter.around)
+(args ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(line_comment) @comment.inside
+(line_comment)+ @comment.around
+
+(block_comment) @comment.inside @comment.around
+
+(((list_value_def) @entry.inside ) . ","? @entry.around) @entry.around
+


### PR DESCRIPTION
Updates the existing Ink interactive fiction language syntax (#12773) with an updated version. The original PR was by @rhizoome, and we collaborated on this one.

**Improvements**

* Nesting syntax (sections and nesting branches can now be selected/navigated, similar to, say, Markdown syntax)
* Parses *all* of the language and highlights accordingly (conditional text vs sequences, dynamic tags, string interpolation, …).

  <details>
  <summary>Expand to see comparison screenshots</summary>
  
  This syntax (Helix)
  ![tree-sitter-ink example in Helix](https://github.com/wldmr/tree-sitter-ink/raw/main/doc/img/dynamic_evaluation.png)
  
  vs the official one (Textmate, VSCode)
  ![official text mate example in VSCode](https://github.com/wldmr/tree-sitter-ink/raw/main/doc/img/dynamic_evaluation_before.png)
  
  </details>
* textobject, locals, and indentation queries

The readme (https://github.com/wldmr/tree-sitter-ink) goes into more detail.