### PR TITLE
Fix formatting length calculation in integer.rs (leading zeros & thousand separators)

### DIFF
--- a/helix-core/src/increment/integer.rs
+++ b/helix-core/src/increment/integer.rs
@@ -48,7 +48,7 @@ pub fn increment(selected_text: &str, amount: i64) -> Option<String> {
             (true, false) => number.len() - 1,
             (false, true) => number.len() + 1,
             _ => number.len(),
-        } - separator_rtl_indexes.len();
+        };
 
         if number.starts_with('0') || number.starts_with("-0") {
             format!("{:01$}", new_value, format_length)


### PR DESCRIPTION
## Bug

I noticed a weird behavior when incrementing or decrementing numbers with _leading zeros and thousand separators_ in Helix Editor. Prefilled zeros are often removed incorrectly.

Select a number like ```000_000_001``` and press C-a (increment) multiple times.

__Result:__

1. 000_000_001 -> 0_000_002
1. 0_000_002 -> 00_003
1. 00_003 -> 0_004
1. 0_004 -> 005

__Expected:__

1. 000_000_001 -> 000_000_002
1. 000_000_002 -> 000_000_003
1. 000_000_003 -> 000_000_004
1. 000_000_004 -> 000_000_005

Normally, I would consider this a minor issue, but I found that the bug is caused by an entirely unnecessary line in [helix-core/increment/integer.rs](https://github.com/helix-editor/helix/blob/master/helix-core/src/increment/integer.rs):

```rust
let format_length = match (value.is_negative(), new_value.is_negative()) {
    (true, false) => number.len() - 1,
    (false, true) => number.len() + 1,
    _ => number.len(),
}; // - separator_rtl_indexes.len(); <---- This command is the problem.
```

You can add the following test case to test_increment_with_separators():

```rust
("000_001", 1, "000_002"),
```

The existing tests are unaffected by this change.

## Why not permanently add 000_001 to test_increment_with_separators()?

1. The bug cannot reappear once the problematic line is removed. You wouldn't add a test case for 333 + 1 = 334 just because an old bug only affected the number 333 e.g.
1. Commits that reduce the codebase instead of bloating it are rare. ;)
