### PR TITLE
docs(keymap): add smart tab info for insert mode

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -404,6 +404,9 @@ escaping from insert mode to normal mode.
 | `Ctrl-h`, `Backspace`, `Shift-Backspace`    | Delete previous char        | `delete_char_backward`   |
 | `Ctrl-d`, `Delete`                          | Delete next char            | `delete_char_forward`    |
 | `Ctrl-j`, `Enter`                           | Insert new line             | `insert_newline`         |
+| `Tab`                                       | [Smart tab] (configurable)  | `smart_tab`              | 
+
+[Smart tab]: ./editor.md#editorsmart-tab-section
 
 These keys are not recommended, but are included for new users less familiar
 with modal editors.


### PR DESCRIPTION
I wasnt aware of smart tab, as its description is buried in the editor configuration section, but it's not mentioned the keymap docs. I discovered its intriguing behaviour just by hitting tab when not at the start of a line and seeing what tab was doing, but i wasnt aware of what it actually was supposed to be doing, so i went to the keymap, but it isnt mentioned, so here's the docs update to mention it. 