### PR TITLE
Change page up/down keybinds from Ctrl-U/D to Ctrl-B/F in popup and picker

### DIFF
--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -276,13 +276,13 @@ impl<T: Item + 'static> Component for Menu<T> {
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(PageUp) | ctrl!('u') => {
+            key!(PageUp) | ctrl!('b') => {
                 // page up moves back in the completion choice (including updating the doc)
                 self.move_half_page_up();
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(PageDown) | ctrl!('d') => {
+            key!(PageDown) | ctrl!('f') => {
                 // page down advances completion choice (including updating the doc)
                 self.move_half_page_down();
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1091,10 +1091,10 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(Tab) | key!(Down) | ctrl!('n') => {
                 self.move_by(1, Direction::Forward);
             }
-            key!(PageDown) | ctrl!('d') => {
+            key!(PageDown) | ctrl!('f') => {
                 self.page_down();
             }
-            key!(PageUp) | ctrl!('u') => {
+            key!(PageUp) | ctrl!('b') => {
                 self.page_up();
             }
             key!(Home) => {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -290,11 +290,11 @@ impl<T: Component> Component for Popup<T> {
                         let _ = self.contents.handle_event(event, cx);
                         EventResult::Consumed(Some(close_fn))
                     }
-                    key!(PageDown) | ctrl!('d') => {
+                    key!(PageDown) | ctrl!('f') => {
                         self.scroll_half_page_down();
                         EventResult::Consumed(None)
                     }
-                    key!(PageUp) | ctrl!('u') => {
+                    key!(PageUp) | ctrl!('b') => {
                         self.scroll_half_page_up();
                         EventResult::Consumed(None)
                     }


### PR DESCRIPTION
As discussed in https://github.com/helix-editor/helix/issues/13984, Helix shouldn't have multiple actions bound to the same keybinding. This is quite confusing especially when considering that Ctrl+U will execute the normal action in the insert mode unless a popup dialog is shown, in which case a scroll-up movement is performed instead. As for the Ctrl+K keybinding, it's not affected in any way by the popup being shown. This happens because we have bound Ctrl+U and Ctrl+D to scroll up/down movements in the picker, which will only conflict with the aforementioned keybindings when the popup is shown.

Ctrl+U and Ctrl+K are standard shortcuts that are, on top of Helix, used at the very least in Bash and Nushell.

Moreover, in Helix in most contexts it is Ctrl+B and Ctrl+F that are used for scrolling one page up or down, not Ctrl+U and Ctrl+D. According to the documentation, it is infact Ctrl+U and Ctrl+D which are mainly used for scrolling half a page up/down. As such these shortcuts don't make sense as it currently stands when compared to the rest of the keybindings.

Since Ctrl+F/B are used elsewhere to scroll one full page up/down, I propose we switch to using them in place of Ctrl+U/D in the picker and popup menus to solve this conflict between the shortcuts.