### PR TITLE
Add root file for quarto

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2469,6 +2469,7 @@ scope = "source.qmd"
 language-id = "qmd"
 injection-regex = "qmd"
 file-types = ["qmd"]
+roots = ["_quarto.yml"]
 indent = { tab-width = 2, unit = "  " }
 grammar = "markdown"
 block-comment-tokens = { start = "<!--", end = "-->" }


### PR DESCRIPTION
Adds `_quarto.yml` as the workspace root marker for the `quarto` language. That file is the project metadata file Quarto itself uses to mark the top of a project (https://quarto.org/docs/projects/quarto-projects.html#project-metadata), so it's the natural anchor when opening a `.qmd` buffer somewhere inside a Quarto project.

Closes #15704