### PR TITLE
Print an error instead of panicking when the cwd is missing at startup

### DIFF
--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -123,6 +123,10 @@ FLAGS:
     } else if let Some((path, _)) = args.files.first().filter(|p| p.0.is_dir()) {
         // If the first file is a directory, it will be the working directory unless -w was specified
         helix_stdx::env::set_current_working_dir(path)?;
+    } else if let Err(err) = std::env::current_dir() {
+        eprintln!("Couldn't determine the current working directory: {err}");
+        eprintln!("Check that it still exists, or pass an initial directory with `--working-dir`");
+        return Ok(1);
     }
 
     let config = match Config::load_default() {


### PR DESCRIPTION
When Helix is launched from a directory that no longer exists (and no `--working-dir` is given), it panicked in `current_working_dir()` instead of failing gracefully. This adds an early check in `main_impl` that prints a clear message and exits with code 1, as discussed in #8068. Closes #8068.