### PR TITLE
Nix devshell: set LD_LIBRARY_PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -80,6 +80,7 @@
               export RUST_BACKTRACE="1"
               export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv} ${platformRustFlagsEnv}"
             '';
+            LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";
           };
       })
       pkgsFor;


### PR DESCRIPTION
Without this, a bunch of integration tests fail, since there is no c++ library to link against grammar files:

````
 ❯ ldd runtime/grammars/c.so
        linux-vdso.so.1 (0x000071a6d3676000)
        libstdc++.so.6 => not found
        libm.so.6 => /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libm.so.6 (0x000071a6d34dc000)
        libgcc_s.so.1 => /nix/store/vpxblivamvic1p5r5zny934jvg33m50r-xgcc-15.2.0-libgcc/lib/libgcc_s.so.1 (0x000071a6d34af000)
        libc.so.6 => /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6 (0x000071a6d3200000)
        /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib64/ld-linux-x86-64.so.2 (0x000071a6d3678000)
````

With this change:
````
 ❯ ldd runtime/grammars/c.so
        linux-vdso.so.1 (0x000073ef40e0a000)
        libstdc++.so.6 => /nix/store/ab3753m6i7isgvzphlar0a8xb84gl96i-gcc-15.2.0-lib/lib/libstdc++.so.6 (0x000073ef40a00000)
        libm.so.6 => /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libm.so.6 (0x000073ef40908000)
        libgcc_s.so.1 => /nix/store/ab3753m6i7isgvzphlar0a8xb84gl96i-gcc-15.2.0-lib/lib/libgcc_s.so.1 (0x000073ef40d3b000)
        libc.so.6 => /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6 (0x000073ef40600000)
        /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib64/ld-linux-x86-64.so.2 (0x000073ef40e0c000)
````

I'm pretty sure integration tests worked for me before, and I'm not sure why.