### PR TITLE
fix: duplicated words in helix-core and helix-lsp-types comments

### DIFF
--- a/helix-core/src/position.rs
+++ b/helix-core/src/position.rs
@@ -256,7 +256,7 @@ pub fn visual_offset_from_anchor(
 /// character--on the border between the current line and the next.
 ///
 /// Usually you only want `limit_before_line_ending` to be `true` if you're working
-/// with left-side block-cursor positions, as this prevents the the block cursor
+/// with left-side block-cursor positions, as this prevents the block cursor
 /// from jumping to the next line.  Otherwise you typically want it to be `false`,
 /// such as when dealing with raw anchor/head positions.
 pub fn pos_at_coords(text: RopeSlice, coords: Position, limit_before_line_ending: bool) -> usize {

--- a/helix-lsp-types/src/document_symbols.rs
+++ b/helix-lsp-types/src/document_symbols.rs
@@ -92,11 +92,11 @@ pub struct DocumentSymbol {
     #[deprecated(note = "Use tags instead")]
     pub deprecated: Option<bool>,
     /// The range enclosing this symbol not including leading/trailing whitespace but everything else
-    /// like comments. This information is typically used to determine if the the clients cursor is
+    /// like comments. This information is typically used to determine if the clients cursor is
     /// inside the symbol to reveal in the symbol in the UI.
     pub range: Range,
     /// The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-    /// Must be contained by the the `range`.
+    /// Must be contained by the `range`.
     pub selection_range: Range,
     /// Children of this symbol, e.g. properties of a class.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/helix-lsp-types/src/lib.rs
+++ b/helix-lsp-types/src/lib.rs
@@ -2085,7 +2085,7 @@ pub struct WorkspaceServerCapabilities {
     pub file_operations: Option<WorkspaceFileOperationsServerCapabilities>,
 }
 
-/// General parameters to to register for a capability.
+/// General parameters to register for a capability.
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Registration {


### PR DESCRIPTION
Four one-line typo fixes for duplicated words in doc-comments:
- `helix-core/src/position.rs` — "the the block cursor" → "the block cursor"
- `helix-lsp-types/src/document_symbols.rs` — "the the clients cursor" → "the clients cursor"
- `helix-lsp-types/src/document_symbols.rs` — "by the the `range`" → "by the `range`"
- `helix-lsp-types/src/lib.rs` — "parameters to to register" → "parameters to register"

No code/behavior change.