### PR TITLE
fix: update F# comment tokens to also support Doc comments

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3868,7 +3868,7 @@ scope = "source.fs"
 roots = ["*.slnx", "*.sln", "*.fsproj"]
 injection-regex = "fsharp"
 file-types = ["fs", "fsx", "fsi", "fsscript"]
-comment-token = "//"
+comment-tokens = ["//", "///"]
 block-comment-tokens = { start = "(*", end = "*)" }
 indent = { tab-width = 4, unit = "    " }
 auto-format = true


### PR DESCRIPTION
Hello,

F# supports 2 types of line comments:

1. `//` is the general comment
2. `///` is used Doc comment. These are used to write documentation about functions, members, etc.