### PR TITLE
themes: sync catppuccin with upstream

### DIFF
--- a/runtime/themes/catppuccin_frappe.toml
+++ b/runtime/themes/catppuccin_frappe.toml
@@ -30,5 +30,6 @@ crust = "#232634"
 
 cursorline = "#3b3f52"
 secondary_cursor = "#b8a5a6"
-secondary_cursor_normal = "#9192be"
+secondary_cursor_select = "#9192be"
+secondary_cursor_normal = "#b8a5a6"
 secondary_cursor_insert = "#83a275"

--- a/runtime/themes/catppuccin_latte.toml
+++ b/runtime/themes/catppuccin_latte.toml
@@ -30,5 +30,6 @@ crust = "#dce0e8"
 
 cursorline = "#e8ecf1"
 secondary_cursor = "#e1a99d"
-secondary_cursor_normal = "#97a7fb"
+secondary_cursor_select = "#97a7fb"
+secondary_cursor_normal = "#e1a99d"
 secondary_cursor_insert = "#74b867"

--- a/runtime/themes/catppuccin_macchiato.toml
+++ b/runtime/themes/catppuccin_macchiato.toml
@@ -30,5 +30,6 @@ crust = "#181926"
 
 cursorline = "#303347"
 secondary_cursor = "#b6a6a7"
-secondary_cursor_normal = "#8b91bf"
+secondary_cursor_select = "#8b91bf"
+secondary_cursor_normal = "#b6a6a7"
 secondary_cursor_insert = "#80a57a"

--- a/runtime/themes/catppuccin_mocha.toml
+++ b/runtime/themes/catppuccin_mocha.toml
@@ -4,6 +4,7 @@
 "attribute" = "yellow"
 
 "type" = "yellow"
+"type.builtin" = "mauve"
 "type.enum.variant" = "teal"
 
 "constructor" = "sapphire"
@@ -35,7 +36,7 @@
 "operator" = "sky"
 
 "function" = "blue"
-"function.macro" = "mauve"
+"function.macro" = "rosewater"
 
 "tag" = "blue"
 
@@ -54,6 +55,7 @@
 "markup.list.checked" = "green"
 "markup.bold" = { fg = "red", modifiers = ["bold"] }
 "markup.italic" = { fg = "red", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
 "markup.link.url" = { fg = "blue", modifiers = ["italic", "underlined"] }
 "markup.link.text" = "lavender"
 "markup.link.label" = "sapphire"
@@ -122,6 +124,7 @@
 "diagnostic.info" = { underline = { color = "sky", style = "curl" } }
 "diagnostic.hint" = { underline = { color = "teal", style = "curl" } }
 "diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 error = "red"
 warning = "yellow"


### PR DESCRIPTION
Updates the vendored Catppuccin themes with changes from https://github.com/catppuccin/helix