### PR TITLE
Add unit tests for to_camel_case_with and proposed solution to the function

### DIFF
--- a/helix-core/src/case_conversion.rs
+++ b/helix-core/src/case_conversion.rs
@@ -46,24 +46,90 @@ pub fn to_camel_case(text: impl Iterator<Item = char>) -> Tendril {
     to_camel_case_with(text, &mut res);
     res
 }
-pub fn to_camel_case_with(mut text: impl Iterator<Item = char>, buf: &mut Tendril) {
-    for c in &mut text {
-        if c.is_alphanumeric() {
-            buf.extend(c.to_lowercase())
-        }
-    }
+pub fn to_camel_case_with(text: impl Iterator<Item = char>, buf: &mut Tendril) {
+    let mut first = true;
     let mut at_word_start = false;
+
     for c in text {
-        // we don't count _ as a word char here so case conversions work well
         if !c.is_alphanumeric() {
             at_word_start = true;
             continue;
         }
-        if at_word_start {
+
+        if first {
+            buf.extend(c.to_lowercase());
+            first = false;
+        } else if at_word_start {
             at_word_start = false;
             buf.extend(c.to_uppercase());
         } else {
-            buf.push(c)
+            buf.extend(c.to_lowercase());
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_camel_case_underscore() {
+        let result = to_camel_case("otto_botto".chars());
+        assert_eq!(result.as_ref() as &str, "ottoBotto");
+    }
+
+    #[test]
+    fn test_camel_case_uppercase() {
+        let result = to_camel_case("OTTO_BOTTO".chars());
+        assert_eq!(result.as_ref() as &str, "ottoBotto");
+    }
+
+    #[test]
+    fn test_camel_case_mixed_case(){
+        let result = to_camel_case("OttO_boTTO".chars());
+        assert_eq!(result.as_ref() as &str, "ottoBotto");
+    }
+    
+    #[test]
+    fn test_camel_case_includes_nums(){
+        let result = to_camel_case("Ott0_b0TT0".chars());
+        assert_eq!(result.as_ref() as &str, "ott0B0tt0");
+    }
+
+    #[test]
+    fn test_camel_case_one_word_lower(){
+        let result = to_camel_case("otto".chars());
+        assert_eq!(result.as_ref() as &str, "otto");
+    }
+
+    #[test]
+    fn test_camel_case_one_word_upper(){
+        let result = to_camel_case("OTTO".chars());
+        assert_eq!(result.as_ref() as &str, "otto");
+    }
+
+    #[test]
+    fn test_camel_case_one_char_lower(){
+        let result = to_camel_case("o".chars());
+        assert_eq!(result.as_ref() as &str, "o");
+    }
+
+    #[test]
+    fn test_camel_case_one_char_upper(){
+        let result = to_camel_case("O".chars());
+        assert_eq!(result.as_ref() as &str, "o");
+    }
+
+    #[test]
+    fn test_camel_case_many_words_separators(){
+        let result = to_camel_case("otto_botto_the_dog".chars());
+        assert_eq!(result.as_ref() as &str, "ottoBottoTheDog");
+    }
+
+    #[test]
+    fn test_camel_case_empty_string(){
+        let result = to_camel_case("".chars());
+        assert_eq!(result.as_ref() as &str, "");
+    }
+
 }

--- a/helix-core/src/case_conversion.rs
+++ b/helix-core/src/case_conversion.rs
@@ -85,51 +85,50 @@ mod tests {
     }
 
     #[test]
-    fn test_camel_case_mixed_case(){
+    fn test_camel_case_mixed_case() {
         let result = to_camel_case("OttO_boTTO".chars());
         assert_eq!(result.as_ref() as &str, "ottoBotto");
     }
-    
+
     #[test]
-    fn test_camel_case_includes_nums(){
+    fn test_camel_case_includes_nums() {
         let result = to_camel_case("Ott0_b0TT0".chars());
         assert_eq!(result.as_ref() as &str, "ott0B0tt0");
     }
 
     #[test]
-    fn test_camel_case_one_word_lower(){
+    fn test_camel_case_one_word_lower() {
         let result = to_camel_case("otto".chars());
         assert_eq!(result.as_ref() as &str, "otto");
     }
 
     #[test]
-    fn test_camel_case_one_word_upper(){
+    fn test_camel_case_one_word_upper() {
         let result = to_camel_case("OTTO".chars());
         assert_eq!(result.as_ref() as &str, "otto");
     }
 
     #[test]
-    fn test_camel_case_one_char_lower(){
+    fn test_camel_case_one_char_lower() {
         let result = to_camel_case("o".chars());
         assert_eq!(result.as_ref() as &str, "o");
     }
 
     #[test]
-    fn test_camel_case_one_char_upper(){
+    fn test_camel_case_one_char_upper() {
         let result = to_camel_case("O".chars());
         assert_eq!(result.as_ref() as &str, "o");
     }
 
     #[test]
-    fn test_camel_case_many_words_separators(){
+    fn test_camel_case_many_words_separators() {
         let result = to_camel_case("otto_botto_the_dog".chars());
         assert_eq!(result.as_ref() as &str, "ottoBottoTheDog");
     }
 
     #[test]
-    fn test_camel_case_empty_string(){
+    fn test_camel_case_empty_string() {
         let result = to_camel_case("".chars());
         assert_eq!(result.as_ref() as &str, "");
     }
-
 }


### PR DESCRIPTION
Addresses issue #15751 
The to_camel_case_with returns everything in lower case. For example, "otto_botto" and "OTTO_BOTTO" both return as "ottobotto" rather than "ottoBotto". The case in which the original function passes the test was for one word only. For example, "otto" and "OTTO" both returned "otto". 

What was changed:
Replaced the nested loops with series if of statements:
 -- if you run into non-alphanumeric, you've hit the word separator, set the flag for at the beginning of a new word to true. 
 -- otherwise
    -- if this is the first char, extend it to buffer and set the first (char) to false
    -- if this is not the first char, but you're at the start of a word either, capitalize this char and set word_start to false
    -- otherwise, keep adding characters in lower case  

