### PR TITLE
Preserve jumplist across `:reflow`

### DIFF
--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -524,6 +524,10 @@ impl ChangeSet {
         ChangeIterator::new(self)
     }
 
+    pub fn into_changes_iter(self) -> OwningChangeIterator {
+        OwningChangeIterator::new(self)
+    }
+
     pub fn from_change(doc: &Rope, change: Change) -> Self {
         Self::from_changes(doc, std::iter::once(change))
     }
@@ -872,6 +876,10 @@ impl Transaction {
     pub fn changes_iter(&self) -> ChangeIterator<'_> {
         self.changes.changes_iter()
     }
+
+    pub fn into_changes_iter(self) -> OwningChangeIterator {
+        self.changes.into_changes_iter()
+    }
 }
 
 impl From<ChangeSet> for Transaction {
@@ -921,6 +929,52 @@ impl Iterator for ChangeIterator<'_> {
                         return Some((start, self.pos, Some(s.clone())));
                     } else {
                         return Some((start, start, Some(s.clone())));
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub struct OwningChangeIterator {
+    iter: std::iter::Peekable<std::vec::IntoIter<Operation>>,
+    pos: usize,
+}
+
+impl OwningChangeIterator {
+    fn new(changeset: ChangeSet) -> Self {
+        let iter = changeset.changes.into_iter().peekable();
+        Self { iter, pos: 0 }
+    }
+}
+
+impl Iterator for OwningChangeIterator {
+    type Item = Change;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        use Operation::*;
+
+        loop {
+            match self.iter.next()? {
+                Retain(len) => {
+                    self.pos += len;
+                }
+                Delete(len) => {
+                    let start = self.pos;
+                    self.pos += len;
+                    return Some((start, self.pos, None));
+                }
+                Insert(s) => {
+                    let start = self.pos;
+                    // a subsequent delete means a replace, consume it
+                    if let Some(Delete(len)) = self.iter.peek() {
+                        let len = *len;
+                        self.iter.next();
+
+                        self.pos += len;
+                        return Some((start, self.pos, Some(s)));
+                    } else {
+                        return Some((start, start, Some(s)));
                     }
                 }
             }
@@ -1110,6 +1164,14 @@ mod test {
         let changes = vec![(6, 11, Some("void".into())), (12, 17, None)];
         let transaction = Transaction::change(&doc, changes.clone().into_iter());
         assert_eq!(transaction.changes_iter().collect::<Vec<_>>(), changes);
+    }
+
+    #[test]
+    fn into_changes_iter() {
+        let doc = Rope::from("hello world!\ntest 123");
+        let changes = vec![(6, 11, Some("void".into())), (12, 17, None)];
+        let transaction = Transaction::change(&doc, changes.clone().into_iter());
+        assert_eq!(transaction.into_changes_iter().collect::<Vec<_>>(), changes);
     }
 
     #[test]

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2395,12 +2395,20 @@ fn reflow(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyho
     let rope = doc.text();
 
     let selection = doc.selection(view.id);
-    let transaction = Transaction::change_by_selection(rope, selection, |range| {
+    let changes = selection.iter().flat_map(|range| {
         let fragment = range.fragment(rope.slice(..));
         let reflowed_text = helix_core::wrap::reflow_hard_wrap(&fragment, text_width);
+        let diff = helix_core::diff::compare_ropes(
+            &Rope::from(fragment.as_ref()),
+            &Rope::from(reflowed_text.as_str()),
+        );
 
-        (range.from(), range.to(), Some(reflowed_text))
+        diff.into_changes_iter()
+            .map(move |(from, to, replacement)| {
+                (range.from() + from, range.from() + to, replacement)
+            })
     });
+    let transaction = Transaction::change(rope, changes);
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view);

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -321,6 +321,26 @@ async fn test_undo_redo() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_reflow_preserves_saved_jump_selection() -> anyhow::Result<()> {
+    // Reflow should preserve saved jumplist cursor positions instead of remapping them through
+    // a single whole-paragraph replacement.
+    test((
+        indoc! {"\
+            aaaa bbbb #[c|]#ccc dddd
+            "},
+        "<C-s>mip:reflow 9<ret><C-o>",
+        indoc! {"\
+            aaaa bbbb
+            #[c|]#ccc dddd
+            "},
+        LineFeedHandling::AsIs,
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_extend_line() -> anyhow::Result<()> {
     // extend with line selected then count
     test((


### PR DESCRIPTION
The motivation for this is this macro I came up to reflow the current paragraph:

```
[keys.normal]
ret.r = "@<C-s>mip_:reflow<ret><C-o>"
```

The idea is that it first saves where you are in the jumplist, selects the paragraph, reflows, then restore the last saved jump.

Though it didn't actually work :( the `:reflow` logic completely messed up the jumplist.

This PR fixes it! So now it works! Yay!
