### PR TITLE
docs(building-from-source): add shell completions install section

### DIFF
--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -180,14 +180,17 @@ Shell completion scripts for Helix are included in the source tree under
 `contrib/completion/`. Distribution packages install them automatically; when
 you build from source you can install them by hand for your shell of choice.
 
-The commands below assume you cloned the repository into `~/src/helix`; adjust
-the paths if you cloned elsewhere.
+> 💡 No PowerShell completion is shipped yet, so the instructions below cover
+> Bash, Zsh, Fish, Elvish, and Nushell only.
+
+The commands below assume you are running them from the root of the Helix
+source tree (the directory you cloned into).
 
 #### Bash
 
 ```sh
 mkdir -p ~/.local/share/bash-completion/completions
-cp ~/src/helix/contrib/completion/hx.bash \
+cp contrib/completion/hx.bash \
    ~/.local/share/bash-completion/completions/hx
 ```
 
@@ -198,7 +201,7 @@ current session.
 
 ```sh
 mkdir -p ~/.zfunc
-cp ~/src/helix/contrib/completion/hx.zsh ~/.zfunc/_hx
+cp contrib/completion/hx.zsh ~/.zfunc/_hx
 ```
 
 Then make sure `~/.zfunc` is on `$fpath` and that completions are initialised
@@ -209,35 +212,48 @@ fpath=(~/.zfunc $fpath)
 autoload -Uz compinit && compinit
 ```
 
+> 💡 If your `~/.zshrc` already runs `compinit` (oh-my-zsh, prezto, zinit,
+> and similar frameworks all do), add only the `fpath=…` line and place it
+> **before** the framework's init line. Calling `compinit` a second time is
+> slow and can cause `_hx: function definition file not found` if ordered
+> incorrectly.
+
 #### Fish
 
 ```sh
 mkdir -p ~/.config/fish/completions
-cp ~/src/helix/contrib/completion/hx.fish \
+cp contrib/completion/hx.fish \
    ~/.config/fish/completions/hx.fish
 ```
 
-Fish picks the completions up automatically — no shell restart required.
+Fish loads completions for new shells automatically. To use them in the
+current session without restarting, run `exec fish`.
 
 #### Elvish
 
 ```sh
 mkdir -p ~/.config/elvish/lib
-cp ~/src/helix/contrib/completion/hx.elv ~/.config/elvish/lib/hx.elv
+cp contrib/completion/hx.elv ~/.config/elvish/lib/hx.elv
 ```
 
-Then load the module from your `~/.config/elvish/rc.elv`:
+Then load the script from your `~/.config/elvish/rc.elv`:
 
 ```elvish
-use hx
+eval (slurp < ~/.config/elvish/lib/hx.elv)
 ```
 
 #### Nushell
 
-Source the completion script from your Nushell config (find it with `$nu.config-path`):
+```sh
+mkdir -p "$(dirname "$(nu -c '$nu.config-path')")/completions"
+cp contrib/completion/hx.nu \
+   "$(dirname "$(nu -c '$nu.config-path')")/completions/hx.nu"
+```
+
+Then source it from your Nushell config (find it with `$nu.config-path`):
 
 ```nu
-source ~/src/helix/contrib/completion/hx.nu
+source ($nu.default-config-dir | path join "completions" "hx.nu")
 ```
 
 > 💡 The `+N` line-number syntax is not currently supported in Nushell, so it

--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -7,6 +7,7 @@
   - [Note to packagers](#note-to-packagers)
 - [Validating the installation](#validating-the-installation)
 - [Configure the desktop shortcut](#configure-the-desktop-shortcut)
+- [Install shell completions](#install-shell-completions)
 - [Building the Debian package](#building-the-debian-package)
 
 Requirements:
@@ -172,6 +173,75 @@ file. For example, to use `kitty`:
 sed -i "s|Exec=hx %F|Exec=kitty hx %F|g" ~/.local/share/applications/Helix.desktop
 sed -i "s|Terminal=true|Terminal=false|g" ~/.local/share/applications/Helix.desktop
 ```
+
+### Install shell completions
+
+Shell completion scripts for Helix are included in the source tree under
+`contrib/completion/`. Distribution packages install them automatically; when
+you build from source you can install them by hand for your shell of choice.
+
+The commands below assume you cloned the repository into `~/src/helix`; adjust
+the paths if you cloned elsewhere.
+
+#### Bash
+
+```sh
+mkdir -p ~/.local/share/bash-completion/completions
+cp ~/src/helix/contrib/completion/hx.bash \
+   ~/.local/share/bash-completion/completions/hx
+```
+
+Restart your shell, or `source` the file from `~/.bashrc` to load it in the
+current session.
+
+#### Zsh
+
+```sh
+mkdir -p ~/.zfunc
+cp ~/src/helix/contrib/completion/hx.zsh ~/.zfunc/_hx
+```
+
+Then make sure `~/.zfunc` is on `$fpath` and that completions are initialised
+in your `~/.zshrc`:
+
+```sh
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit && compinit
+```
+
+#### Fish
+
+```sh
+mkdir -p ~/.config/fish/completions
+cp ~/src/helix/contrib/completion/hx.fish \
+   ~/.config/fish/completions/hx.fish
+```
+
+Fish picks the completions up automatically — no shell restart required.
+
+#### Elvish
+
+```sh
+mkdir -p ~/.config/elvish/lib
+cp ~/src/helix/contrib/completion/hx.elv ~/.config/elvish/lib/hx.elv
+```
+
+Then load the module from your `~/.config/elvish/rc.elv`:
+
+```elvish
+use hx
+```
+
+#### Nushell
+
+Source the completion script from your Nushell config (find it with `$nu.config-path`):
+
+```nu
+source ~/src/helix/contrib/completion/hx.nu
+```
+
+> 💡 The `+N` line-number syntax is not currently supported in Nushell, so it
+> is not proposed by autocomplete. See [nushell/nushell#13418](https://github.com/nushell/nushell/issues/13418).
 
 ### Building the Debian package
 

--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -236,24 +236,30 @@ mkdir -p ~/.config/elvish/lib
 cp contrib/completion/hx.elv ~/.config/elvish/lib/hx.elv
 ```
 
-Then load the script from your `~/.config/elvish/rc.elv`:
+Then import the module from your `~/.config/elvish/rc.elv`:
 
 ```elvish
-eval (slurp < ~/.config/elvish/lib/hx.elv)
+use hx
 ```
+
+The script sets `edit:completion:arg-completer[hx]` as a top-level
+side-effect, so the completer is registered as soon as the module is
+imported — no further calls are needed.
 
 #### Nushell
 
-```sh
-mkdir -p "$(dirname "$(nu -c '$nu.config-path')")/completions"
-cp contrib/completion/hx.nu \
-   "$(dirname "$(nu -c '$nu.config-path')")/completions/hx.nu"
-```
-
-Then source it from your Nushell config (find it with `$nu.config-path`):
+Run the install inside `nu` so the source and the later `source` line
+agree on the same config-dir path:
 
 ```nu
-source ($nu.default-config-dir | path join "completions" "hx.nu")
+mkdir ($nu.default-config-dir | path join completions)
+cp contrib/completion/hx.nu ($nu.default-config-dir | path join completions hx.nu)
+```
+
+Then add this to your Nushell config (find it with `$nu.config-path`):
+
+```nu
+source ($nu.default-config-dir | path join completions hx.nu)
 ```
 
 > 💡 The `+N` line-number syntax is not currently supported in Nushell, so it

--- a/book/src/building-from-source.md
+++ b/book/src/building-from-source.md
@@ -248,6 +248,11 @@ imported — no further calls are needed.
 
 #### Nushell
 
+> 💡 The commands below use `$nu.default-config-dir`, which requires
+> Nushell **≥ 0.87** (October 2024). On older versions, replace
+> `$nu.default-config-dir` with `$nu.config-path | path dirname` in the
+> snippets below.
+
 Run the install inside `nu` so the source and the later `source` line
 agree on the same config-dir path:
 


### PR DESCRIPTION
## Summary

Closes #3605.

Helix ships completion scripts for Bash, Zsh, Fish, Elvish, and Nushell under [`contrib/completion/`](../tree/master/contrib/completion), but the build-from-source guide only explained how to install the `.desktop` file. Users building with `cargo install` had no in-tree documentation telling them how to enable completions for their shell.

This PR adds a new **"Install shell completions"** section to `book/src/building-from-source.md`, placed between the existing *Configure the desktop shortcut* and *Building the Debian package* sections (and added to the page TOC).

### Per-shell coverage

- **Bash** — copy to `~/.local/share/bash-completion/completions/hx`.
- **Zsh** — copy to `~/.zfunc/_hx`, add `fpath=...` + `compinit`, with a callout warning users on oh-my-zsh / prezto / zinit to not double-init.
- **Fish** — copy to `~/.config/fish/completions/hx.fish`; note that `exec fish` is the way to pick it up in the current session.
- **Elvish** — copy to `~/.config/elvish/lib/hx.elv` + `use hx` in `rc.elv`. The script sets `edit:completion:arg-completer[hx]` as a top-level side-effect of `use`, so no further wiring is required.
- **Nushell** — install runs inside `nu` so `\$nu.default-config-dir` is the single source of truth for both the copy target and the later `source` line; a callout links to nushell/nushell#13418 explaining why the `+N` line-number syntax is not proposed by autocomplete.

A small upfront callout notes that no PowerShell completion ships in `contrib/completion/` yet.

### Notes for reviewers

- All `cp` commands are repository-relative (run from the source tree root), matching the style of the existing *Configure the desktop shortcut* section.
- I ran an adversarial self-review across three rounds before pushing; the diff went through three commits and is intentionally not squashed so the review trail is visible. Happy to squash on request before merge.

## Test plan

- [ ] mdBook builds cleanly (`mdbook build book/`).
- [ ] Spot-check that the new section renders with correct anchors and that the TOC link `#install-shell-completions` resolves.
- [ ] (Optional) A maintainer running one or more of the listed shells confirms the install commands work end-to-end.