### PR TITLE
feat(file-picker): add `sort` option to disable alphabetical sorting

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -214,6 +214,7 @@ All git related options are only enabled in a git repository.
 |`git-global` | Enables reading global `.gitignore`, whose path is specified in git's config: `core.excludesfile` option | `true`
 |`git-exclude` | Enables reading `.git/info/exclude` files | `true`
 |`max-depth` | Set with an integer value for maximum depth to recurse | Unset by default
+|`sort` | Sort file picker entries alphabetically by file name. Disabling this lets the walker traverse the directory tree in parallel, which can speed up the initial listing on slow filesystems (e.g. Windows / WSL on a large repository). Sort order is only a secondary tie-breaker before any query is entered. | `true`
 
 Ignore files can be placed locally as `.ignore` or put in your home directory as `~/.ignore`. They support the usual ignore and negative ignore (unignore) rules used in `.gitignore` files.
 

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -230,7 +230,7 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
 
     let mut walk_builder = WalkBuilder::new(&root);
 
-    let mut files = walk_builder
+    walk_builder
         .hidden(config.file_picker.hidden)
         .parents(config.file_picker.parents)
         .ignore(config.file_picker.ignore)
@@ -238,20 +238,28 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         .git_ignore(config.file_picker.git_ignore)
         .git_global(config.file_picker.git_global)
         .git_exclude(config.file_picker.git_exclude)
-        .sort_by_file_name(|name1, name2| name1.cmp(name2))
         .max_depth(config.file_picker.max_depth)
         .filter_entry(move |entry| filter_picker_entry(entry, &absolute_root, dedup_symlinks))
         .add_custom_ignore_filename(helix_loader::config_dir().join("ignore"))
         .add_custom_ignore_filename(".helix/ignore")
-        .types(get_excluded_types())
-        .build()
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            if !entry.path().is_file() {
-                return None;
-            }
-            Some(entry.into_path())
-        });
+        .types(get_excluded_types());
+
+    // Sorting forces a single-threaded walk; only request it when the user
+    // has not disabled sorting. With sorting off, the `ignore` walker can
+    // traverse the directory tree in parallel, which is meaningful on slow
+    // filesystems (e.g. Windows / WSL on large repos). Sort order is only a
+    // secondary tie-breaker before any query is entered.
+    if config.file_picker.sort {
+        walk_builder.sort_by_file_name(|name1, name2| name1.cmp(name2));
+    }
+
+    let mut files = walk_builder.build().filter_map(|entry| {
+        let entry = entry.ok()?;
+        if !entry.path().is_file() {
+            return None;
+        }
+        Some(entry.into_path())
+    });
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
     let columns = [PickerColumn::new(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -205,6 +205,14 @@ pub struct FilePickerConfig {
     /// WalkBuilder options
     /// Maximum Depth to recurse directories in file picker and global search. Defaults to `None`.
     pub max_depth: Option<usize>,
+    /// Whether to sort file picker entries alphabetically by file name. Defaults to true.
+    ///
+    /// Disabling this allows the `ignore` crate's walker to traverse the
+    /// directory tree in parallel, which can noticeably speed up the initial
+    /// listing on slow filesystems (e.g. Windows / WSL on a large repository).
+    /// Sort order only matters as a secondary tie-breaker before any query is
+    /// entered; once you start typing, matches are ranked by score.
+    pub sort: bool,
 }
 
 impl Default for FilePickerConfig {
@@ -219,6 +227,7 @@ impl Default for FilePickerConfig {
             git_global: true,
             git_exclude: true,
             max_depth: None,
+            sort: true,
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #11021. Cross-references the rationale from @pascalkuthe in [helix#10995's discussion](https://github.com/helix-editor/helix/discussions/10995#discussioncomment-9822792).

Adds an `editor.file-picker.sort` config option (defaults to `true`, preserving current behavior). When set to `false`, the `WalkBuilder` is built without `.sort_by_file_name(...)`, so the `ignore` crate's walker is no longer pinned to a single-threaded ordered traversal. Sort order only acts as a secondary tie-breaker before any query is entered, so disabling it has no observable effect once the user starts typing — and on slow filesystems (notably Windows / WSL on a large repo) skipping the sort lets the initial listing populate noticeably faster.

### What changes

| File | Change |
| --- | --- |
| `helix-view/src/editor.rs` | New `pub sort: bool` field on `FilePickerConfig`; default `true`; doc comment |
| `helix-term/src/ui/mod.rs` | Hoist the `WalkBuilder` setup; conditionally call `.sort_by_file_name(...)` only when `config.file_picker.sort` is `true`; inline comment explaining the rationale |
| `book/src/editor.md` | New row in the `[editor.file-picker]` table |

### Scope note for reviewers

This PR removes the *blocker* to parallel traversal (the `sort_by_file_name` call) but stops short of switching the picker injector to `.build_parallel()` with a channel sink. Doing so would change the concurrency semantics of the timeout-batching loop at lines 290-308 and seemed worth landing as a separate follow-up so this change can ship as a small, reviewable opt-in. Happy to extend the PR if you'd rather have both in one.

## Test plan

- [ ] `cargo fmt --all --check` passes (verified locally).
- [ ] `cargo check` passes (verified locally).
- [ ] Build with `cargo run` and confirm:
  - [ ] Default behavior is unchanged (picker entries appear alphabetically sorted).
  - [ ] Setting `[editor.file-picker]\nsort = false` in `config.toml` produces a picker whose entries appear in walker-discovery order rather than alphabetical.
- [ ] (Optional) Maintainer indicates whether to also wire up `.build_parallel()` here or as a follow-up.