### PR TITLE
fix: clear stale LSP data on language server stop/refresh

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1813,6 +1813,9 @@ fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
                 doc.clear_diagnostics_for_language_server(client.id());
                 doc.reset_all_inlay_hints();
                 doc.inlay_hints_oudated = true;
+                doc.document_links.clear();
+                doc.color_swatches = None;
+                doc.clear_all_document_highlights();
             }
         }
     }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1634,6 +1634,9 @@ impl Editor {
         let diagnostics = Editor::doc_diagnostics(&self.language_servers, &self.diagnostics, doc);
         doc.replace_diagnostics(diagnostics, &[], None);
         doc.reset_all_inlay_hints();
+        doc.document_links.clear();
+        doc.color_swatches = None;
+        doc.clear_all_document_highlights();
     }
 
     /// Launch a language server for a given document


### PR DESCRIPTION
Fixes #15776 

When a language server is stopped or a document language is refreshed, cached LSP responses (document links, color swatches, document highlights) were not cleared. This left stale visual artifacts in the editor even after the language server was gone.