### PR TITLE
Include Rust attributes in function textobjects

### DIFF
--- a/runtime/queries/rust/textobjects.scm
+++ b/runtime/queries/rust/textobjects.scm
@@ -1,5 +1,9 @@
-(function_item
-  body: (_) @function.inside) @function.around
+(
+  (attribute_item)* @function.around
+  .
+  (function_item
+    body: (_) @function.inside) @function.around
+)
 
 (closure_expression
   body: (_) @function.inside) @function.around
@@ -49,12 +53,13 @@
 (; #[test]
  (attribute_item
    (attribute
-     (identifier) @_test_attribute))
+     (identifier) @_test_attribute)) @test.around
  ; allow other attributes like #[should_panic] and comments
  [
-   (attribute_item)
-   (line_comment)
+   (attribute_item) @test.around
+   (line_comment) @test.around
  ]*
+ .
  ; the test function
  (function_item
    body: (_) @test.inside) @test.around


### PR DESCRIPTION
Closes #7501

Updates Rust textobject queries so `function.around` includes preceding attributes such as `#[test]`.

This keeps regular functions without attributes working while allowing attributed functions to be selected together with their attributes.

Tested with:

- `HELIX_RUNTIME="$PWD/runtime" ./target/debug/hx --health rust`
- `cargo check`
- Manual `m a f` selection on Rust functions with and without attributes