### PR TITLE
fix: refech diagnostics on end progress

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -875,6 +875,10 @@ impl Application {
                                     self.lsp_progress.end_progress(server_id, &token);
                                     if !self.lsp_progress.is_progressing(server_id) {
                                         editor_view.spinners_mut().get_or_create(server_id).stop();
+                                        handlers::diagnostics::request_all_document_diagnostics_for_language_server(
+                                            &mut self.editor,
+                                            server_id,
+                                        );
                                     }
                                     self.editor.clear_status();
 
@@ -919,6 +923,10 @@ impl Application {
                                 self.lsp_progress.end_progress(server_id, &token);
                                 if !self.lsp_progress.is_progressing(server_id) {
                                     editor_view.spinners_mut().get_or_create(server_id).stop();
+                                    handlers::diagnostics::request_all_document_diagnostics_for_language_server(
+                                        &mut self.editor,
+                                        server_id,
+                                    );
                                 };
                             }
                         }
@@ -1107,22 +1115,11 @@ impl Application {
                         Ok(json!(result))
                     }
                     Ok(MethodCall::WorkspaceDiagnosticRefresh) => {
-                        let language_server = language_server!().id();
-
-                        let documents: Vec<_> = self
-                            .editor
-                            .documents
-                            .values()
-                            .filter(|x| x.supports_language_server(language_server))
-                            .map(|x| x.id())
-                            .collect();
-
-                        for document in documents {
-                            handlers::diagnostics::request_document_diagnostics(
-                                &mut self.editor,
-                                document,
-                            );
-                        }
+                        let server_id = language_server!().id();
+                        handlers::diagnostics::request_all_document_diagnostics_for_language_server(
+                            &mut self.editor,
+                            server_id,
+                        );
 
                         Ok(serde_json::Value::Null)
                     }

--- a/helix-term/src/handlers/diagnostics.rs
+++ b/helix-term/src/handlers/diagnostics.rs
@@ -258,6 +258,21 @@ fn request_document_diagnostics_for_language_severs(
     });
 }
 
+pub fn request_all_document_diagnostics_for_language_server(
+    editor: &mut Editor,
+    server_id: LanguageServerId,
+) {
+    let doc_ids: Vec<_> = editor
+        .documents
+        .values()
+        .filter(|doc| doc.supports_language_server(server_id))
+        .map(|doc| doc.id())
+        .collect();
+    for doc_id in doc_ids {
+        request_document_diagnostics(editor, doc_id);
+    }
+}
+
 pub fn request_document_diagnostics(editor: &mut Editor, doc_id: DocumentId) {
     let Some(doc) = editor.document(doc_id) else {
         return;


### PR DESCRIPTION
roslyn-language-server in not ready until it signals that its progress has been finished. The diagnostics are only fetched when `Notification::Initialized` arrives (server not fully ready yet) and not when `Notification::ProgressMessage` signals the end of the progress. As a result, the diagnostics are never shown until an edit.

closes #15779.