### PR TITLE
ci(release): clean up old cross steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,20 +45,13 @@ jobs:
     name: Dist
     needs: [fetch-grammars]
     env:
-      # For some builds, we use cross to test on 32-bit and big-endian
-      # systems.
-      CARGO: cargo
-      # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS:
-      # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
-      TARGET_DIR: ./target
       # Emit backtraces on panics.
       RUST_BACKTRACE: 1
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos, aarch64-windows] #, x86_64-win-gnu, win32-msvc
+        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos, aarch64-windows]
         include:
         - build: x86_64-linux
           # WARN: When changing this to a newer version, make sure that the GLIBC isnt too new, as this can cause issues
@@ -66,46 +59,27 @@ jobs:
           os: ubuntu-22.04
           rust: stable
           target: x86_64-unknown-linux-gnu
-          cross: false
         - build: aarch64-linux
           # Version should be kept in lockstep with the x86_64 version
           os: ubuntu-22.04-arm
           rust: stable
           target: aarch64-unknown-linux-gnu
-          cross: false
         - build: x86_64-macos
           os: macos-latest
           rust: stable
           target: x86_64-apple-darwin
-          cross: false
         - build: x86_64-windows
           os: windows-latest
           rust: stable
           target: x86_64-pc-windows-msvc
-          cross: false
         - build: aarch64-macos
           os: macos-latest
           rust: stable
           target: aarch64-apple-darwin
-          cross: false
         - build: aarch64-windows
           os: windows-11-arm
           rust: stable
           target: aarch64-pc-windows-msvc
-          cross: false
-        # - build: riscv64-linux
-        #   os: ubuntu-22.04
-        #   rust: stable
-        #   target: riscv64gc-unknown-linux-gnu
-        #   cross: true
-        # - build: x86_64-win-gnu
-        #   os: windows-2019
-        #   rust: stable-x86_64-gnu
-        #   target: x86_64-pc-windows-gnu
-        # - build: win32-msvc
-        #   os: windows-2019
-        #   rust: stable
-        #   target: i686-pc-windows-msvc
 
     steps:
       - name: Checkout sources
@@ -132,29 +106,16 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
 
-      # Install a pre-release version of Cross
-      # TODO: We need to pre-install Cross because we need cross-rs/cross#591 to
-      #       get a newer C++ compiler toolchain. Remove this step when Cross
-      #       0.3.0, which includes cross-rs/cross#591, is released.
-      - name: Install Cross
-        if: "matrix.cross"
-        run: |
-          cargo install cross --git https://github.com/cross-rs/cross.git --rev 47df5c76e7cba682823a0b6aa6d95c17b31ba63a
-          echo "CARGO=cross" >> $GITHUB_ENV
-        # echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
-        # echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
-
       - name: Show command used for Cargo
         run: |
-          echo "cargo command is: ${{ env.CARGO }}"
           echo "target flag is: ${{ env.TARGET_FLAGS }}"
 
       - name: Run cargo test
         if: "!matrix.skip_tests"
-        run: ${{ env.CARGO }} test --release --locked --target ${{ matrix.target }} --workspace
+        run: cargo test --release --locked --target ${{ matrix.target }} --workspace
 
       - name: Build release binary
-        run: ${{ env.CARGO }} build --profile opt --locked --target ${{ matrix.target }}
+        run: cargo build --profile opt --locked --target ${{ matrix.target }}
 
       - name: Build AppImage
         shell: bash


### PR DESCRIPTION
Follow-on of https://github.com/helix-editor/helix/pull/15557. We clean up the `cross` parts that were in the `release.yml`. 

For a future `risc-v` target, there is #15558.

For other targets, like freebsd, etc. there are other ways that don't need `cross`.