### PR TITLE
fix(term): file picker ends up empty when work tree root is ignored

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -32,10 +32,9 @@ pub use spinner::{ProgressSpinners, Spinner};
 pub use text::Text;
 
 use helix_view::Editor;
-use tui::text::{Span, Spans};
-
 use std::path::Path;
 use std::{error::Error, path::PathBuf};
+use tui::text::{Span, Spans};
 
 struct Utf8PathBuf {
     path: String,
@@ -251,7 +250,23 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
                 return None;
             }
             Some(entry.into_path())
-        });
+        })
+        .peekable();
+
+    let mut files: Box<dyn Iterator<Item = PathBuf> + Send> =
+        if config.file_picker.git_ignore && files.peek().is_none() {
+            let tracked_root = root.clone();
+            Box::new(
+                editor
+                    .diff_providers
+                    .tracked_files(&root)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(move |path| path.starts_with(&tracked_root) && path.is_file()),
+            )
+        } else {
+            Box::new(files)
+        };
     log::debug!("file_picker init {:?}", Instant::now().duration_since(now));
 
     let columns = [PickerColumn::new(

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -2,7 +2,7 @@ use anyhow::{bail, Context, Result};
 use arc_swap::ArcSwap;
 use gix::filter::plumbing::driver::apply::Delay;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use gix::bstr::ByteSlice;
@@ -81,6 +81,22 @@ pub fn get_current_head_name(file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
 
 pub fn for_each_changed_file(cwd: &Path, f: impl Fn(Result<FileChange>) -> bool) -> Result<()> {
     status(&open_repo(cwd)?.to_thread_local(), f)
+}
+
+/// Returns paths tracked by the repository index.
+pub fn tracked_files(cwd: &Path) -> Result<Vec<PathBuf>> {
+    let repo = open_repo(cwd)?.to_thread_local();
+    let work_dir = repo
+        .workdir()
+        .ok_or_else(|| anyhow::anyhow!("working tree not found"))?;
+    let index = repo.index_or_empty()?;
+    let mut files = Vec::with_capacity(index.entries().len());
+
+    for entry in index.entries() {
+        files.push(work_dir.join(entry.path(&index).to_path()?));
+    }
+
+    Ok(files)
 }
 
 fn open_repo(path: &Path) -> Result<ThreadSafeRepository> {

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -75,6 +75,20 @@ impl DiffProviderRegistry {
             }
         });
     }
+
+    /// Returns paths tracked by the first available VCS provider.
+    pub fn tracked_files(&self, cwd: &Path) -> Option<Vec<PathBuf>> {
+        self.providers
+            .iter()
+            .find_map(|provider| match provider.tracked_files(cwd) {
+                Ok(res) => Some(res),
+                Err(err) => {
+                    log::debug!("{err:#?}");
+                    log::debug!("failed to get tracked files for {}", cwd.display());
+                    None
+                }
+            })
+    }
 }
 
 impl Default for DiffProviderRegistry {
@@ -126,6 +140,14 @@ impl DiffProvider {
         match self {
             #[cfg(feature = "git")]
             Self::Git => git::for_each_changed_file(cwd, f),
+            Self::None => bail!("No diff support compiled in"),
+        }
+    }
+
+    fn tracked_files(&self, cwd: &Path) -> Result<Vec<PathBuf>> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git => git::tracked_files(cwd),
             Self::None => bail!("No diff support compiled in"),
         }
     }


### PR DESCRIPTION
`~/.gitignore` contains a single line with `/*`, which ignores the files from home directory that are neither in the Git index. Unfortunately the file picked ends up being empty with this policy.

Address the bug by including files from Git to the file picker list.