### PR TITLE
smerge-mode inspired conflict management

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -277,6 +277,10 @@
 | `goto_prev_xml_element` | Goto previous (X)HTML element | normal: `` [x ``, select: `` [x `` |
 | `goto_next_conflict` | Goto next conflict | normal: `` ]= ``, select: `` ]= `` |
 | `goto_prev_conflict` | Goto previous conflict | normal: `` [= ``, select: `` [= `` |
+| `conflict_accept_current` | Accept current change (<<<<<<< side) | normal: `` <space>xc ``, select: `` <space>xc `` |
+| `conflict_accept_incoming` | Accept incoming change (>>>>>>> side) | normal: `` <space>xi ``, select: `` <space>xi `` |
+| `conflict_accept_base` | Accept base change (||||||| side, diff3 only) | normal: `` <space>xb ``, select: `` <space>xb `` |
+| `conflict_accept_all` | Accept all changes | normal: `` <space>xa ``, select: `` <space>xa `` |
 | `goto_next_entry` | Goto next pairing | normal: `` ]e ``, select: `` ]e `` |
 | `goto_prev_entry` | Goto previous pairing | normal: `` [e ``, select: `` [e `` |
 | `goto_next_paragraph` | Goto next paragraph | normal: `` ]p ``, select: `` ]p `` |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -275,6 +275,8 @@
 | `goto_prev_test` | Goto previous test | normal: `` [T ``, select: `` [T `` |
 | `goto_next_xml_element` | Goto next (X)HTML element | normal: `` ]x ``, select: `` ]x `` |
 | `goto_prev_xml_element` | Goto previous (X)HTML element | normal: `` [x ``, select: `` [x `` |
+| `goto_next_conflict` | Goto next conflict | normal: `` ]= ``, select: `` ]= `` |
+| `goto_prev_conflict` | Goto previous conflict | normal: `` [= ``, select: `` [= `` |
 | `goto_next_entry` | Goto next pairing | normal: `` ]e ``, select: `` ]e `` |
 | `goto_prev_entry` | Goto previous pairing | normal: `` [e ``, select: `` [e `` |
 | `goto_next_paragraph` | Goto next paragraph | normal: `` ]p ``, select: `` ]p `` |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -281,6 +281,7 @@
 | `conflict_accept_incoming` | Accept incoming change (>>>>>>> side) | normal: `` <space>xi ``, select: `` <space>xi `` |
 | `conflict_accept_base` | Accept base change (||||||| side, diff3 only) | normal: `` <space>xb ``, select: `` <space>xb `` |
 | `conflict_accept_all` | Accept all changes | normal: `` <space>xa ``, select: `` <space>xa `` |
+| `conflict_cycle_diffs` | Cycle word-level conflict diffs | normal: `` <space>xr ``, select: `` <space>xr `` |
 | `goto_next_entry` | Goto next pairing | normal: `` ]e ``, select: `` ]e `` |
 | `goto_prev_entry` | Goto previous pairing | normal: `` [e ``, select: `` [e `` |
 | `goto_next_paragraph` | Goto next paragraph | normal: `` ]p ``, select: `` ]p `` |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -281,6 +281,7 @@
 | `conflict_accept_incoming` | Accept incoming change (>>>>>>> side) | normal: `` <space>xi ``, select: `` <space>xi `` |
 | `conflict_accept_base` | Accept base change (||||||| side, diff3 only) | normal: `` <space>xb ``, select: `` <space>xb `` |
 | `conflict_accept_all` | Accept all changes | normal: `` <space>xa ``, select: `` <space>xa `` |
+| `conflict_accept_at_cursor` | Accept change at cursor | normal: `` <space>xx ``, select: `` <space>xx `` |
 | `conflict_cycle_diffs` | Cycle word-level conflict diffs | normal: `` <space>xr ``, select: `` <space>xr `` |
 | `goto_next_entry` | Goto next pairing | normal: `` ]e ``, select: `` ]e `` |
 | `goto_prev_entry` | Goto previous pairing | normal: `` [e ``, select: `` [e `` |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -324,6 +324,19 @@ This layer is a kludge of mappings, mostly pickers.
 
 > 💡 Global search displays results in a fuzzy picker, use `Space + '` to bring it back up after opening a file.
 
+##### Conflict resolution
+
+Accessed by typing `Space x` in normal mode. Resolves merge conflict markers.
+
+| Key    | Description                                              | Command                    |
+| ------ | -----------                                              | -------                    |
+| `c`    | Accept current change (`<<<<<<<` side)                   | `conflict_accept_current`  |
+| `i`    | Accept incoming change (`>>>>>>>` side)                  | `conflict_accept_incoming` |
+| `b`    | Accept base change (`|||||||` side, diff3 only)          | `conflict_accept_base`     |
+| `a`    | Accept all changes                                       | `conflict_accept_all`      |
+| `x`    | Accept the change under the cursor                       | `conflict_accept_at_cursor`|
+| `r`    | Cycle word-level conflict diffs                          | `conflict_cycle_diffs`     |
+
 ##### Popup
 
 Displays documentation for item under cursor. Remapping currently not supported.
@@ -383,6 +396,8 @@ These mappings are in the style of [vim-unimpaired](https://github.com/tpope/vim
 | `[g`     | Go to previous change                        | `goto_prev_change`      |
 | `]G`     | Go to last change                            | `goto_last_change`      |
 | `[G`     | Go to first change                           | `goto_first_change`     |
+| `]=`     | Go to next conflict                          | `goto_next_conflict`    |
+| `[=`     | Go to previous conflict                      | `goto_prev_conflict`    |
 | `[x`     | Go to next (X)HTML element                   | `goto_next_xml_element` |
 | `]x`     | Go to previous (X)HTML element               | `goto_prev_xml_element` |
 | `]Space` | Add newline below                            | `add_newline_below`     |

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -36,6 +36,11 @@
 //!
 //! All three formats are unified into [`ConflictRegion`] with a `Vec<Section>`.
 
+use std::collections::HashMap;
+use std::ops::Range;
+
+use imara_diff::{Algorithm, Diff, InternedInput};
+
 use crate::Rope;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -83,6 +88,32 @@ pub struct ConflictRegion {
     pub sections: Vec<Section>,
     /// Exclusive end past the `>>>>>>> ...` line.
     pub end: usize,
+}
+
+impl ConflictRegion {
+    /// Number of C(N, 2) word-diff pairs that can be shown via refine.
+    pub fn num_refine_pairs(&self) -> usize {
+        let n = self.sections.len();
+        n * n.saturating_sub(1) / 2
+    }
+
+    /// Return the pair of section indices for refine `pair` index.
+    ///
+    /// Pairs are enumerated as (0,1), (0,2), …, (0,n-1), (1,2), …, (n-2,n-1).
+    /// Returns `None` if `pair >= num_refine_pairs()`.
+    pub fn refine_pair_indices(&self, pair: usize) -> Option<(usize, usize)> {
+        let n = self.sections.len();
+        let mut idx = 0;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                if idx == pair {
+                    return Some((i, j));
+                }
+                idx += 1;
+            }
+        }
+        None
+    }
 }
 
 // ── Parser ────────────────────────────────────────────────────────────────────
@@ -370,6 +401,135 @@ pub fn all_sides_content(text: &Rope, region: &ConflictRegion) -> String {
         .filter(|s| s.kind == SectionKind::Side)
         .map(|s| text.slice(s.content_start..s.content_end).to_string())
         .collect()
+}
+
+// ── Refine (word-level diff) ──────────────────────────────────────────────────
+
+/// Returns the content ranges `(left, right)` for refine pair `pair`.
+///
+/// Pairs are enumerated in (i, j) order with i < j over all section indices.
+/// Returns `None` if `pair >= region.num_refine_pairs()`.
+pub fn conflict_pair_sections(
+    region: &ConflictRegion,
+    pair: usize,
+) -> Option<((usize, usize), (usize, usize))> {
+    let (i, j) = region.refine_pair_indices(pair)?;
+    // When one section is Base, put it on the left (before) so that
+    // removed=red highlights what the base had, added=green highlights
+    // what the Side added on top.  Side↔Side pairs keep their order.
+    let (i, j) = match (region.sections[i].kind, region.sections[j].kind) {
+        (SectionKind::Side, SectionKind::Base) => (j, i),
+        _ => (i, j),
+    };
+    let left = (
+        region.sections[i].content_start,
+        region.sections[i].content_end,
+    );
+    let right = (
+        region.sections[j].content_start,
+        region.sections[j].content_end,
+    );
+    Some((left, right))
+}
+
+/// Look up the active refine pair for a conflict.
+///
+/// Defaults to `0` if no entry is present.
+pub fn conflict_refine_pair(state: &HashMap<usize, usize>, region: &ConflictRegion) -> usize {
+    let pair = state.get(&region.start).copied().unwrap_or(0);
+    let max = region.num_refine_pairs().saturating_sub(1);
+    pair.min(max)
+}
+
+// ── Word-level diff ───────────────────────────────────────────────────────────
+
+/// A word-token source backed by a contiguous substring of a `Rope`.
+///
+/// Tokens are non-whitespace runs of characters.
+/// To avoid double allocation, token strings are built on-demand during
+/// `tokenize()` rather than pre-collecting them. This amortizes the cost
+/// across the single `InternedInput::new()` call.
+struct WordTokens<'a> {
+    text: &'a Rope,
+    positions: Vec<(usize, usize)>,
+}
+
+impl<'a> WordTokens<'a> {
+    fn new(text: &'a Rope, start: usize, end: usize) -> Self {
+        let mut positions = Vec::new();
+        let mut tok_start: Option<usize> = None;
+        for (i, ch) in text.slice(start..end).chars().enumerate() {
+            let pos = start + i;
+            if ch.is_whitespace() {
+                if let Some(s) = tok_start.take() {
+                    positions.push((s, pos));
+                }
+            } else if tok_start.is_none() {
+                tok_start = Some(pos);
+            }
+        }
+        if let Some(s) = tok_start {
+            positions.push((s, end));
+        }
+        Self { text, positions }
+    }
+}
+
+impl<'a> imara_diff::TokenSource for WordTokens<'a> {
+    type Token = String;
+    type Tokenizer = Box<dyn Iterator<Item = String> + 'a>;
+
+    fn tokenize(&self) -> Self::Tokenizer {
+        let text = self.text;
+        let positions = self.positions.clone();
+        Box::new(
+            positions
+                .into_iter()
+                .map(move |(s, e)| text.slice(s..e).chars().collect()),
+        )
+    }
+
+    fn estimate_tokens(&self) -> u32 {
+        self.positions.len() as u32
+    }
+}
+
+/// Compute word-level diff between two sections of `text`.
+///
+/// Returns `(removed_ranges, added_ranges)` as half-open char-index intervals.
+pub fn refine_diff(
+    text: &Rope,
+    left: (usize, usize),
+    right: (usize, usize),
+) -> (Vec<Range<usize>>, Vec<Range<usize>>) {
+    let left_tokens = WordTokens::new(text, left.0, left.1);
+    let right_tokens = WordTokens::new(text, right.0, right.1);
+
+    let left_positions = left_tokens.positions.clone();
+    let right_positions = right_tokens.positions.clone();
+
+    let input = InternedInput::new(left_tokens, right_tokens);
+    let diff = Diff::compute(Algorithm::Histogram, &input);
+
+    let mut removed: Vec<Range<usize>> = Vec::new();
+    let mut added: Vec<Range<usize>> = Vec::new();
+
+    for hunk in diff.hunks() {
+        for &(s, e) in &left_positions[hunk.before.start as usize..hunk.before.end as usize] {
+            match removed.last_mut() {
+                Some(r) if r.end == s => r.end = e,
+                _ => removed.push(s..e),
+            }
+        }
+        for &(s, e) in &right_positions[hunk.after.start as usize..hunk.after.end as usize] {
+            match added.last_mut() {
+                Some(r) if r.end == s => r.end = e,
+                _ => added.push(s..e),
+            }
+        }
+    }
+
+    (removed, added)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -758,5 +918,159 @@ mod tests {
         assert_eq!(r.slice(s..e).to_string(), "shared content\n");
         let (s, e) = incoming_content(c);
         assert_eq!(r.slice(s..e).to_string(), "more\n");
+    }
+
+    // ── refine_diff ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn refine_diff_cases() {
+        for &(current, incoming) in &[
+            ("hello world", "hello world"),        // identical
+            ("hello world", "hello rust"),         // single word
+            ("foo bar", "baz qux"),                // completely different
+            ("hello world test", "hello foo bar"), // adjacent words
+        ] {
+            let text = format!(
+                "<<<<<<< HEAD\n{}\n=======\n{}\n>>>>>>> b\n",
+                current, incoming
+            );
+            let r = Rope::from(text.as_str());
+            let c = &find_conflicts(&r)[0];
+            let (removed, added) = refine_diff(&r, current_content(c), incoming_content(c));
+
+            if current == incoming {
+                assert!(removed.is_empty());
+                assert!(added.is_empty());
+                continue;
+            }
+
+            assert!(
+                !removed.is_empty(),
+                "expected removed for '{}' vs '{}'",
+                current,
+                incoming
+            );
+            assert!(
+                !added.is_empty(),
+                "expected added for '{}' vs '{}'",
+                current,
+                incoming
+            );
+
+            let removed_text: String = removed
+                .iter()
+                .map(|range| r.slice(range.clone()).to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let added_text: String = added
+                .iter()
+                .map(|range| r.slice(range.clone()).to_string())
+                .collect::<Vec<_>>()
+                .join(" ");
+
+            for word in current.split_whitespace() {
+                if !incoming.contains(word) {
+                    assert!(
+                        removed_text.contains(word),
+                        "'{word}' missing from removed: '{removed_text}'"
+                    );
+                }
+            }
+            for word in incoming.split_whitespace() {
+                if !current.contains(word) {
+                    assert!(
+                        added_text.contains(word),
+                        "'{word}' missing from added: '{added_text}'"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn refine_diff_identical_sections() {
+        // When both sides are identical, refine_diff should return no ranges.
+        let text = "<<<<<<< HEAD\nhello world\n=======\nhello world\n>>>>>>> branch\n";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        let left = current_content(&conflicts[0]);
+        let right = incoming_content(&conflicts[0]);
+        let (removed, added) = refine_diff(&r, left, right);
+        assert!(
+            removed.is_empty(),
+            "expected no removed ranges, got {:?}",
+            removed
+        );
+        assert!(
+            added.is_empty(),
+            "expected no added ranges, got {:?}",
+            added
+        );
+    }
+
+    #[test]
+    fn refine_diff_single_word_change() {
+        // "hello world" vs "hello rust" — only "world"/"rust" differ.
+        let text = "<<<<<<< HEAD\nhello world\n=======\nhello rust\n>>>>>>> branch\n";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        let left = current_content(&conflicts[0]);
+        let right = incoming_content(&conflicts[0]);
+        let (removed, added) = refine_diff(&r, left, right);
+
+        assert_eq!(
+            removed.len(),
+            1,
+            "expected 1 removed range, got {:?}",
+            removed
+        );
+        assert_eq!(added.len(), 1, "expected 1 added range, got {:?}", added);
+
+        let removed_word: String = r.slice(removed[0].clone()).chars().collect();
+        let added_word: String = r.slice(added[0].clone()).chars().collect();
+        assert_eq!(removed_word, "world");
+        assert_eq!(added_word, "rust");
+    }
+
+    #[test]
+    fn refine_diff_completely_different() {
+        // No words in common — all tokens should be flagged.
+        let text = "<<<<<<< HEAD\nfoo bar\n=======\nbaz qux\n>>>>>>> branch\n";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        let left = current_content(&conflicts[0]);
+        let right = incoming_content(&conflicts[0]);
+        let (removed, added) = refine_diff(&r, left, right);
+
+        // Both "foo" and "bar" removed; "baz" and "qux" added (may be merged).
+        assert!(!removed.is_empty(), "expected removed ranges");
+        assert!(!added.is_empty(), "expected added ranges");
+
+        let removed_text: String = removed
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let added_text: String = added
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            removed_text.contains("foo"),
+            "expected 'foo' in removed: {removed_text}"
+        );
+        assert!(
+            removed_text.contains("bar"),
+            "expected 'bar' in removed: {removed_text}"
+        );
+        assert!(
+            added_text.contains("baz"),
+            "expected 'baz' in added: {added_text}"
+        );
+        assert!(
+            added_text.contains("qux"),
+            "expected 'qux' in added: {added_text}"
+        );
     }
 }

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -43,6 +43,9 @@ use imara_diff::{Algorithm, Diff, InternedInput};
 
 use crate::Rope;
 
+/// Sentinel value for [`ConflictRefineEntry::pair`] — skip word-diff rendering.
+pub const NO_HIGHLIGHT_PAIR: usize = usize::MAX;
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 /// Pair of removed/added word-diff ranges for a conflict refine pair.
@@ -55,6 +58,7 @@ pub struct ConflictRefineEntry {
     /// For a 3-section diff3 conflict: 0 = current↔base, 1 = base↔incoming, 2 = current↔incoming.
     /// For N-way jj conflicts the ordering prioritises each side vs base,
     /// then side–side comparisons; remaining base-involving pairs are excluded.
+    /// Set to [`NO_HIGHLIGHT_PAIR`] to disable word-diff rendering.
     pub pair: usize,
     /// Cached word-diff results for the current `pair`:
     /// `(removed_ranges, added_ranges)`.
@@ -840,7 +844,7 @@ mod tests {
         assert_eq!(c.sections[2].kind, SectionKind::Side);
         assert_eq!(c.sections[3].kind, SectionKind::Base);
         assert_eq!(c.sections[4].kind, SectionKind::Side);
-        assert_eq!(c.num_refine_pairs(), 10); // C(5,2)
+        assert_eq!(c.num_refine_pairs(), 6);
     }
 
     // ── conflict_at ───────────────────────────────────────────────────────────

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -795,7 +795,6 @@ mod tests {
             "------- base\n",
             "base\n",
             "+++++++ side #3\n",
-            "s3\n",
             ">>>>>>> Conflict 1 of 1 ends\n",
         );
         let r = rope(text);

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -805,6 +805,7 @@ mod tests {
             "------- base\n",
             "base\n",
             "+++++++ side #3\n",
+            "s3\n",
             ">>>>>>> Conflict 1 of 1 ends\n",
         );
         let r = rope(text);

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -45,6 +45,28 @@ use crate::Rope;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/// Pair of removed/added word-diff ranges for a conflict refine pair.
+type RefineDiffs = (Vec<Range<usize>>, Vec<Range<usize>>);
+
+/// Per-conflict word-level diff cache entry, keyed by conflict start position.
+#[derive(Debug, Clone, Default)]
+pub struct ConflictRefineEntry {
+    /// Current refine pair index (see [`ConflictRegion::refine_pair_indices`]).
+    /// For a 3-section diff3 conflict: 0 = current↔base, 1 = base↔incoming, 2 = current↔incoming.
+    /// For N-way jj conflicts the ordering prioritises each side vs base,
+    /// then side–side comparisons; remaining base-involving pairs are excluded.
+    pub pair: usize,
+    /// Cached word-diff results for the current `pair`:
+    /// `(removed_ranges, added_ranges)`.
+    pub diffs: Option<RefineDiffs>,
+}
+
+/// Per-conflict word-diff refine state, keyed by [`ConflictRegion::start`].
+///
+/// Cleared on every edit; the active pair setting is preserved when the cursor
+/// was inside a conflict before the edit.
+pub type ConflictCache = HashMap<usize, ConflictRefineEntry>;
+
 /// Whether a section holds one side of a conflict or the common base.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SectionKind {

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -1,0 +1,762 @@
+//! Parsing and navigation of VCS merge conflict markers.
+//!
+//! Supports three conflict formats:
+//!
+//! **git 2-way:**
+//! ```text
+//! <<<<<<< current
+//! ... current text ...
+//! =======
+//! ... incoming text ...
+//! >>>>>>> incoming
+//! ```
+//!
+//! **git diff3 (3-way):**
+//! ```text
+//! <<<<<<< current
+//! ... current text ...
+//! ||||||| base
+//! ... base text ...
+//! =======
+//! ... incoming text ...
+//! >>>>>>> incoming
+//! ```
+//!
+//! **jj snapshot (N-way):**
+//! ```text
+//! <<<<<<< conflict
+//! +++++++ side #1
+//! ... side 1 text ...
+//! ------- base
+//! ... base text ...
+//! +++++++ side #2
+//! ... side 2 text ...
+//! >>>>>>> conflict ends
+//! ```
+//!
+//! All three formats are unified into [`ConflictRegion`] with a `Vec<Section>`.
+
+use crate::Rope;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/// Whether a section holds one side of a conflict or the common base.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionKind {
+    /// A `+++++++` side (jj format) or the current/incoming sides (git format).
+    Side,
+    /// A `-------` base (jj format) or the `|||||||` base (git diff3 format).
+    Base,
+}
+
+/// One section within a conflict region.
+///
+/// For git format the first section's `marker_start` equals the `<<<<<<<` line;
+/// for jj format every section starts with its own `+++++++` / `-------` marker.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Section {
+    pub kind: SectionKind,
+    /// Char index of the first character of this section's marker line.
+    ///
+    /// For the first side of a git-format conflict this is the `<<<<<<<` line.
+    /// For jj-format sections this is the `+++++++` or `-------` line.
+    /// For the last side of a git-format conflict this is the `=======` line.
+    pub marker_start: usize,
+    /// Char index of the first content character (the line *after* the marker).
+    pub content_start: usize,
+    /// Exclusive end of the content (= `marker_start` of next section, or `end`
+    /// of the whole conflict for the final section).
+    pub content_end: usize,
+}
+
+/// A single VCS merge conflict region found in a document.
+///
+/// All positions are **character indices** into the document rope.
+/// `start` points to the first character of the `<<<<<<<` marker line.
+/// `end` points to the character just past the last character of the `>>>>>>>`
+/// line (i.e. after the trailing newline, if present).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictRegion {
+    /// Start of the `<<<<<<< ...` line.
+    pub start: usize,
+    /// Ordered list of conflict sections.  There is always at least one `Side`.
+    pub sections: Vec<Section>,
+    /// Exclusive end past the `>>>>>>> ...` line.
+    pub end: usize,
+}
+
+// ── Parser ────────────────────────────────────────────────────────────────────
+
+/// Parse all conflict regions in `text`, in document order.
+///
+/// Supports git 2-way, git diff3 3-way, and jj snapshot N-way formats.
+/// Incomplete conflict blocks are silently ignored.
+pub fn find_conflicts(text: &Rope) -> Vec<ConflictRegion> {
+    /// A section whose `content_end` is not yet known.
+    #[derive(Debug, Clone)]
+    struct PartialSection {
+        kind: SectionKind,
+        marker_start: usize,
+        content_start: usize,
+    }
+
+    impl PartialSection {
+        fn finish(self, content_end: usize) -> Section {
+            Section {
+                kind: self.kind,
+                marker_start: self.marker_start,
+                content_start: self.content_start,
+                content_end,
+            }
+        }
+    }
+
+    #[derive(Debug, Default)]
+    enum State {
+        #[default]
+        Idle,
+        /// Inside a conflict region (git or jj format).
+        InConflict {
+            start: usize,
+            sections: Vec<Section>,
+            current: PartialSection,
+            format: ConflictFormat,
+        },
+    }
+
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    enum ConflictFormat {
+        Git,
+        Jj,
+    }
+
+    let mut conflicts: Vec<ConflictRegion> = Vec::new();
+    let mut state = State::Idle;
+    let mut line_char_start: usize = 0;
+
+    for line in text.lines() {
+        let line_len = line.len_chars();
+        let next_line_start = line_char_start + line_len;
+
+        let is_marker = |c: char| -> bool {
+            let mut chars = line.chars();
+            (&mut chars).take(7).all(|ch| ch == c)
+                && matches!(chars.next(), None | Some(' ') | Some('\r') | Some('\n'))
+        };
+
+        state = match std::mem::take(&mut state) {
+            State::Idle => {
+                if is_marker('<') {
+                    State::InConflict {
+                        start: line_char_start,
+                        sections: Vec::new(),
+                        current: PartialSection {
+                            kind: SectionKind::Side,
+                            marker_start: line_char_start,
+                            content_start: next_line_start,
+                        },
+                        format: ConflictFormat::Git,
+                    }
+                } else {
+                    State::Idle
+                }
+            }
+
+            State::InConflict {
+                start,
+                mut sections,
+                current,
+                format,
+            } => {
+                if is_marker('|') {
+                    sections.push(current.finish(line_char_start));
+                    State::InConflict {
+                        start,
+                        sections,
+                        current: PartialSection {
+                            kind: SectionKind::Base,
+                            marker_start: line_char_start,
+                            content_start: next_line_start,
+                        },
+                        format,
+                    }
+                } else if is_marker('=') {
+                    sections.push(current.finish(line_char_start));
+                    State::InConflict {
+                        start,
+                        sections,
+                        current: PartialSection {
+                            kind: SectionKind::Side,
+                            marker_start: line_char_start,
+                            content_start: next_line_start,
+                        },
+                        format,
+                    }
+                } else if is_marker('>') {
+                    let end = next_line_start;
+                    sections.push(current.finish(line_char_start));
+                    if sections.len() >= 2 {
+                        conflicts.push(ConflictRegion {
+                            start,
+                            sections,
+                            end,
+                        });
+                    }
+                    State::Idle
+                } else if is_marker('<') {
+                    State::InConflict {
+                        start: line_char_start,
+                        sections: Vec::new(),
+                        current: PartialSection {
+                            kind: SectionKind::Side,
+                            marker_start: line_char_start,
+                            content_start: next_line_start,
+                        },
+                        format: ConflictFormat::Git,
+                    }
+                } else if is_marker('+') || is_marker('-') {
+                    if format == ConflictFormat::Git {
+                        if current.content_start < line_char_start {
+                            sections.push(current.finish(line_char_start));
+                        }
+                    } else {
+                        sections.push(current.finish(line_char_start));
+                    }
+                    let kind = if is_marker('+') {
+                        SectionKind::Side
+                    } else {
+                        SectionKind::Base
+                    };
+                    State::InConflict {
+                        start,
+                        sections,
+                        current: PartialSection {
+                            kind,
+                            marker_start: line_char_start,
+                            content_start: next_line_start,
+                        },
+                        format: ConflictFormat::Jj,
+                    }
+                } else {
+                    State::InConflict {
+                        start,
+                        sections,
+                        current,
+                        format,
+                    }
+                }
+            }
+        };
+
+        line_char_start = next_line_start;
+    }
+
+    conflicts
+}
+
+// ── Cursor position helpers ───────────────────────────────────────────────────
+
+/// Return the index of the conflict in `conflicts` that contains `char_pos`,
+/// or `None` if the position is not inside any conflict region.
+pub fn conflict_at(conflicts: &[ConflictRegion], char_pos: usize) -> Option<usize> {
+    conflicts
+        .iter()
+        .position(|c| char_pos >= c.start && char_pos < c.end)
+}
+
+/// Return the index of the next conflict after `char_pos` (exclusive).
+pub fn next_conflict(conflicts: &[ConflictRegion], char_pos: usize) -> Option<usize> {
+    conflicts.iter().position(|c| c.start > char_pos)
+}
+
+/// Return the index of the previous conflict before `char_pos` (exclusive).
+pub fn prev_conflict(conflicts: &[ConflictRegion], char_pos: usize) -> Option<usize> {
+    conflicts.iter().rposition(|c| c.start < char_pos)
+}
+
+/// Return which section index of `region` the character position `char_pos` is in,
+/// or `None` if it is on a pure separator line (the `=======` line in git format)
+/// or outside `region`.
+///
+/// Marker lines are attributed to their own section (the `<<<<<<<` line is part
+/// of the first section, `+++++++`/`-------`/`|||||||` lines are part of their
+/// section, `>>>>>>>` is part of the last section).  Only the `=======`
+/// separator is a no-op since it doesn't logically belong to either side.
+pub fn conflict_section_at(region: &ConflictRegion, text: &Rope, char_pos: usize) -> Option<usize> {
+    // For git-format conflicts, the last section's marker is `=======`.
+    // A cursor sitting on that marker line belongs to no section (no-op).
+    // For jj-format, there is no `=======` — every marker line belongs to its section.
+    let sep_line_end = git_sep_line_end(region, text);
+
+    for (i, section) in region.sections.iter().enumerate() {
+        let section_end = if i == region.sections.len() - 1 {
+            region.end
+        } else {
+            region.sections[i + 1].marker_start
+        };
+
+        if char_pos >= section.marker_start && char_pos < section_end {
+            // If this is the last section in git format, the marker line is `=======`
+            // and should be a no-op zone.
+            if i == region.sections.len() - 1 {
+                if let Some(sep_end) = sep_line_end {
+                    let sep_start = section.marker_start;
+                    if char_pos >= sep_start && char_pos < sep_end {
+                        return None; // on the ======= line
+                    }
+                }
+            }
+            return Some(i);
+        }
+    }
+
+    // Shouldn't reach here if char_pos is inside the region.
+    None
+}
+
+/// For a git-format conflict, return the exclusive end of the `=======` line.
+/// Returns `None` for jj-format conflicts (which have no `=======`).
+fn git_sep_line_end(region: &ConflictRegion, text: &Rope) -> Option<usize> {
+    // In git format, the last section's marker is always `=======`.
+    // In jj format, the last section's marker is `+++++++` or `-------`.
+    let last = region.sections.last()?;
+    // A `=======` line starts with exactly 7 `=` and nothing else (or a space/newline)
+    let marker_char: char = text.char(last.marker_start);
+    if marker_char == '=' {
+        let sep_line = text.char_to_line(last.marker_start);
+        Some(text.line_to_char(sep_line + 1))
+    } else {
+        None
+    }
+}
+
+// ── Content helpers ───────────────────────────────────────────────────────────
+
+/// Return the char range of the first `Side` section ("current" change).
+pub fn current_content(region: &ConflictRegion) -> (usize, usize) {
+    let s = region
+        .sections
+        .iter()
+        .find(|s| s.kind == SectionKind::Side)
+        .expect("conflict must have at least one Side section");
+    (s.content_start, s.content_end)
+}
+
+/// Return the char range of the last `Side` section ("incoming" change).
+pub fn incoming_content(region: &ConflictRegion) -> (usize, usize) {
+    let s = region
+        .sections
+        .iter()
+        .rev()
+        .find(|s| s.kind == SectionKind::Side)
+        .expect("conflict must have at least one Side section");
+    (s.content_start, s.content_end)
+}
+
+/// Return the char range of the first `Base` section, or `None` if absent.
+pub fn base_content(region: &ConflictRegion) -> Option<(usize, usize)> {
+    let s = region
+        .sections
+        .iter()
+        .find(|s| s.kind == SectionKind::Base)?;
+    Some((s.content_start, s.content_end))
+}
+
+/// Return the content of all `Side` sections concatenated (for accept-all).
+pub fn all_sides_content(text: &Rope, region: &ConflictRegion) -> String {
+    region
+        .sections
+        .iter()
+        .filter(|s| s.kind == SectionKind::Side)
+        .map(|s| text.slice(s.content_start..s.content_end).to_string())
+        .collect()
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ropey::Rope;
+
+    fn rope(s: &str) -> Rope {
+        Rope::from(s)
+    }
+
+    fn parse_one(s: &str) -> (Rope, ConflictRegion) {
+        let r = Rope::from(s);
+        let mut c = find_conflicts(&r);
+        assert_eq!(c.len(), 1, "expected exactly one conflict");
+        (r, c.swap_remove(0))
+    }
+
+    // ── find_conflicts: git format ────────────────────────────────────────────
+
+    #[test]
+    fn no_conflicts() {
+        assert!(find_conflicts(&rope("hello\nworld\n")).is_empty());
+    }
+
+    #[test]
+    fn two_way_conflict_basic() {
+        let (r, c) = parse_one("<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> branch\n");
+        assert_eq!(c.sections.len(), 2);
+        assert_eq!(c.sections[0].kind, SectionKind::Side);
+        assert_eq!(c.sections[1].kind, SectionKind::Side);
+        assert_eq!(c.start, 0);
+        assert_eq!(c.end, r.len_chars());
+    }
+
+    #[test]
+    fn two_way_conflict_content() {
+        let (r, c) =
+            parse_one("<<<<<<< HEAD\ncurrent line\n=======\nincoming line\n>>>>>>> branch\n");
+        let (s, e) = current_content(&c);
+        assert_eq!(r.slice(s..e).to_string(), "current line\n");
+        let (s, e) = incoming_content(&c);
+        assert_eq!(r.slice(s..e).to_string(), "incoming line\n");
+    }
+
+    #[test]
+    fn three_way_conflict_basic() {
+        let (_, c) = parse_one(
+            "<<<<<<< HEAD\ncurrent\n||||||| base\noriginal\n=======\nincoming\n>>>>>>> branch\n",
+        );
+        assert_eq!(c.sections.len(), 3);
+        assert_eq!(c.sections[0].kind, SectionKind::Side);
+        assert_eq!(c.sections[1].kind, SectionKind::Base);
+        assert_eq!(c.sections[2].kind, SectionKind::Side);
+    }
+
+    #[test]
+    fn three_way_content() {
+        let text =
+            "<<<<<<< HEAD\ncurrent\n||||||| base\nbase line\n=======\nincoming\n>>>>>>> branch\n";
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        let (s, e) = current_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "current\n");
+        let (s, e) = base_content(c).unwrap();
+        assert_eq!(r.slice(s..e).to_string(), "base line\n");
+        let (s, e) = incoming_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "incoming\n");
+    }
+
+    #[test]
+    fn multiple_conflicts() {
+        let text = concat!(
+            "before\n",
+            "<<<<<<< HEAD\na\n=======\nb\n>>>>>>> b\n",
+            "between\n",
+            "<<<<<<< HEAD\nc\n=======\nd\n>>>>>>> b\n",
+            "after\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 2);
+        assert!(conflicts[1].start > conflicts[0].end);
+    }
+
+    #[test]
+    fn conflict_no_trailing_newline() {
+        let text = "<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> branch";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].end, text.chars().count());
+    }
+
+    #[test]
+    fn incomplete_no_close_ignored() {
+        assert!(find_conflicts(&rope("<<<<<<< HEAD\ncurrent\n=======\nincoming\n")).is_empty());
+    }
+
+    #[test]
+    fn incomplete_no_separator_ignored() {
+        assert!(find_conflicts(&rope("<<<<<<< HEAD\ncurrent\n>>>>>>> branch\n")).is_empty());
+    }
+
+    #[test]
+    fn restarted_on_nested_open_marker() {
+        let text = concat!(
+            "<<<<<<< outer\n",
+            "<<<<<<< inner\n",
+            "current\n",
+            "=======\n",
+            "incoming\n",
+            ">>>>>>> inner\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].start, "<<<<<<< outer\n".chars().count());
+    }
+
+    #[test]
+    fn jj_style_git_diff3_labels() {
+        // jj produces diff3 markers with change IDs
+        let text = concat!(
+            "<<<<<<< ouyysnvk c9a24f82 \"first version\"\n",
+            "1st version\n",
+            "||||||| zxwrknxy 62f152a0 \"base\"\n",
+            "original\n",
+            "=======\n",
+            "2nd version\n",
+            ">>>>>>> kyqztmxm cf165681 \"second version\"\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+        let c = &conflicts[0];
+        assert_eq!(c.sections.len(), 3);
+        let (s, e) = current_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "1st version\n");
+        let (s, e) = base_content(c).unwrap();
+        assert_eq!(r.slice(s..e).to_string(), "original\n");
+        let (s, e) = incoming_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "2nd version\n");
+    }
+
+    #[test]
+    fn jj_snapshot_two_sides() {
+        // jj snapshot format: 2 sides + 1 base
+        let (r, c) = parse_one(concat!(
+            "<<<<<<< Conflict 1 of 1\n",
+            "+++++++ side #1\n",
+            "alpha\n",
+            "------- base\n",
+            "beta\n",
+            "+++++++ side #2\n",
+            "gamma\n",
+            ">>>>>>> Conflict 1 of 1 ends\n",
+        ));
+        assert_eq!(c.sections.len(), 3);
+        assert_eq!(c.sections[0].kind, SectionKind::Side);
+        assert_eq!(c.sections[1].kind, SectionKind::Base);
+        assert_eq!(c.sections[2].kind, SectionKind::Side);
+        let (s, e) = current_content(&c);
+        assert_eq!(r.slice(s..e).to_string(), "alpha\n");
+        let (s, e) = base_content(&c).unwrap();
+        assert_eq!(r.slice(s..e).to_string(), "beta\n");
+        let (s, e) = incoming_content(&c);
+        assert_eq!(r.slice(s..e).to_string(), "gamma\n");
+    }
+
+    #[test]
+    fn jj_snapshot_three_sides() {
+        // jj snapshot format: 3 sides + 1 base (4 sections)
+        let text = concat!(
+            "<<<<<<< Conflict 1 of 1\n",
+            "+++++++ side #1\n",
+            "s1\n",
+            "------- base\n",
+            "base\n",
+            "+++++++ side #2\n",
+            "s2\n",
+            "------- base\n",
+            "base\n",
+            "+++++++ side #3\n",
+            "s3\n",
+            ">>>>>>> Conflict 1 of 1 ends\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+        let c = &conflicts[0];
+        assert_eq!(c.sections.len(), 5);
+        assert_eq!(c.sections[0].kind, SectionKind::Side);
+        assert_eq!(c.sections[1].kind, SectionKind::Base);
+        assert_eq!(c.sections[2].kind, SectionKind::Side);
+        assert_eq!(c.sections[3].kind, SectionKind::Base);
+        assert_eq!(c.sections[4].kind, SectionKind::Side);
+    }
+
+    // ── conflict_at ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn conflict_at_inside() {
+        let text = "before\n<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> b\nafter\n";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        let before_len = "before\n".chars().count();
+        assert_eq!(conflict_at(&conflicts, before_len), Some(0));
+        assert_eq!(conflict_at(&conflicts, 0), None);
+        assert_eq!(conflict_at(&conflicts, conflicts[0].end + 1), None);
+
+        // Boundary: at start (inclusive) and at end (exclusive)
+        assert_eq!(conflict_at(&conflicts, conflicts[0].start), Some(0));
+        assert_eq!(conflict_at(&conflicts, conflicts[0].end), None);
+    }
+
+    // ── next/prev_conflict ────────────────────────────────────────────────────
+
+    #[test]
+    fn next_conflict_from_before() {
+        let text = concat!(
+            "before\n",
+            "<<<<<<< HEAD\na\n=======\nb\n>>>>>>> b\n",
+            "between\n",
+            "<<<<<<< HEAD\nc\n=======\nd\n>>>>>>> b\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(next_conflict(&conflicts, 0), Some(0));
+        assert_eq!(next_conflict(&conflicts, conflicts[0].start + 1), Some(1));
+        assert_eq!(next_conflict(&conflicts, conflicts[1].end), None);
+    }
+
+    #[test]
+    fn prev_conflict_from_after() {
+        let text = concat!(
+            "<<<<<<< HEAD\na\n=======\nb\n>>>>>>> b\n",
+            "between\n",
+            "<<<<<<< HEAD\nc\n=======\nd\n>>>>>>> b\n",
+            "after\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        let after_last = conflicts[1].end + 1;
+        assert_eq!(prev_conflict(&conflicts, after_last), Some(1));
+        let inside_second = conflicts[1].start + 1;
+        assert_eq!(prev_conflict(&conflicts, inside_second), Some(1));
+        assert_eq!(prev_conflict(&conflicts, conflicts[1].start), Some(0));
+        assert_eq!(prev_conflict(&conflicts, 0), None);
+    }
+
+    // ── conflict_section_at ───────────────────────────────────────────────────
+
+    #[test]
+    fn section_at_git_two_way() {
+        let text = "<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> b\n";
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        // On <<<<<<< line → section 0
+        assert_eq!(conflict_section_at(c, &r, 0), Some(0));
+        // In current content → section 0
+        let current_pos = "<<<<<<< HEAD\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, current_pos), Some(0));
+        // On ======= line → None
+        let sep_pos = "<<<<<<< HEAD\ncurrent\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, sep_pos), None);
+        // In incoming content → section 1
+        let incoming_pos = "<<<<<<< HEAD\ncurrent\n=======\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, incoming_pos), Some(1));
+        // On >>>>>>> line → section 1
+        let close_pos = "<<<<<<< HEAD\ncurrent\n=======\nincoming\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, close_pos), Some(1));
+    }
+
+    #[test]
+    fn section_at_git_three_way() {
+        let text = "<<<<<<< HEAD\ncurrent\n||||||| base\nbase\n=======\nincoming\n>>>>>>> b\n";
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        // On ||||||| line → section 1
+        let base_marker = "<<<<<<< HEAD\ncurrent\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, base_marker), Some(1));
+        // In base content → section 1
+        let base_pos = "<<<<<<< HEAD\ncurrent\n||||||| base\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, base_pos), Some(1));
+        // On ======= → None
+        let sep_pos = "<<<<<<< HEAD\ncurrent\n||||||| base\nbase\n"
+            .chars()
+            .count();
+        assert_eq!(conflict_section_at(c, &r, sep_pos), None);
+    }
+
+    #[test]
+    fn section_at_jj_snapshot() {
+        let text = concat!(
+            "<<<<<<< Conflict\n",
+            "+++++++ s1\n",
+            "hello\n",
+            "------- base\n",
+            "world\n",
+            "+++++++ s2\n",
+            "rust\n",
+            ">>>>>>> Conflict ends\n",
+        );
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        // On +++++++ s1 line → section 0
+        let s1_marker = "<<<<<<< Conflict\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, s1_marker), Some(0));
+        // On ------- line → section 1
+        let base_marker = "<<<<<<< Conflict\n+++++++ s1\nhello\n".chars().count();
+        assert_eq!(conflict_section_at(c, &r, base_marker), Some(1));
+        // On +++++++ s2 line → section 2
+        let s2_marker = "<<<<<<< Conflict\n+++++++ s1\nhello\n------- base\nworld\n"
+            .chars()
+            .count();
+        assert_eq!(conflict_section_at(c, &r, s2_marker), Some(2));
+        // On >>>>>>> line → section 2 (last)
+        let close = "<<<<<<< Conflict\n+++++++ s1\nhello\n------- base\nworld\n+++++++ s2\nrust\n"
+            .chars()
+            .count();
+        assert_eq!(conflict_section_at(c, &r, close), Some(2));
+    }
+
+    #[test]
+    fn all_sides_content_concatenates() {
+        let text = concat!(
+            "<<<<<<< Conflict\n",
+            "+++++++ s1\nfirst\n",
+            "------- base\nbase\n",
+            "+++++++ s2\nsecond\n",
+            "+++++++ s3\nthird\n",
+            ">>>>>>> Conflict ends\n",
+        );
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        let all = all_sides_content(&r, c);
+        assert!(all.contains("first"));
+        assert!(all.contains("second"));
+        assert!(all.contains("third"));
+        // Base should NOT be included
+        assert!(!all.contains("base\n"));
+    }
+
+    #[test]
+    fn empty_side_conflict() {
+        let text = "<<<<<<<\n=======\n>>>>>>>\n";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+        let c = &conflicts[0];
+        assert_eq!(c.sections.len(), 2);
+        let (s, e) = current_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "");
+        let (s, e) = incoming_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "");
+    }
+
+    #[test]
+    fn conflict_with_crlf() {
+        let text = "<<<<<<< HEAD\r\ncurrent\r\n=======\r\nincoming\r\n>>>>>>> b\r\n";
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+    }
+
+    #[test]
+    fn transition_to_jj_with_content_section() {
+        // Git→Jj transition where the implicit git side has content
+        let text = concat!(
+            "<<<<<<< Conflict\n",
+            "shared content\n",
+            "+++++++ side #1\n",
+            "more\n",
+            ">>>>>>> Conflict ends\n",
+        );
+        let r = rope(text);
+        let conflicts = find_conflicts(&r);
+        assert_eq!(conflicts.len(), 1);
+        let c = &conflicts[0];
+        // The git side with "shared content" should be preserved
+        assert_eq!(c.sections.len(), 2);
+        let (s, e) = current_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "shared content\n");
+        let (s, e) = incoming_content(c);
+        assert_eq!(r.slice(s..e).to_string(), "more\n");
+    }
+}

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -175,7 +175,9 @@ impl ConflictRegion {
 /// Parse all conflict regions in `text`, in document order.
 ///
 /// Supports git 2-way, git diff3 3-way, and jj snapshot N-way formats.
-/// Incomplete conflict blocks are silently ignored.
+/// Also recognises "bare" conflicts — a `<<<<<<<` / `>>>>>>>` pair with no
+/// inner markers — which arise after manually editing out unwanted sections.
+/// Incomplete conflict blocks (no closing `>>>>>>>`) are silently ignored.
 pub fn find_conflicts(text: &Rope) -> Vec<ConflictRegion> {
     /// A section whose `content_end` is not yet known.
     #[derive(Debug, Clone)]
@@ -280,7 +282,7 @@ pub fn find_conflicts(text: &Rope) -> Vec<ConflictRegion> {
                 } else if is_marker('>') {
                     let end = next_line_start;
                     sections.push(current.finish(line_char_start));
-                    if sections.len() >= 2 {
+                    if !sections.is_empty() {
                         conflicts.push(ConflictRegion {
                             start,
                             sections,
@@ -637,6 +639,19 @@ mod tests {
     }
 
     #[test]
+    fn bare_conflict() {
+        // A manually-edited conflict with no inner markers — just <<<<<<< / content / >>>>>>>
+        let (r, c) = parse_one("<<<<<<< HEAD\nhand-picked\n>>>>>>> branch\n");
+        assert_eq!(c.sections.len(), 1);
+        assert_eq!(c.sections[0].kind, SectionKind::Side);
+        let (s, e) = current_content(&c);
+        assert_eq!(r.slice(s..e).to_string(), "hand-picked\n");
+        let (s, e) = incoming_content(&c);
+        assert_eq!(r.slice(s..e).to_string(), "hand-picked\n");
+        assert!(base_content(&c).is_none());
+    }
+
+    #[test]
     fn two_way_conflict_basic() {
         let (r, c) = parse_one("<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> branch\n");
         assert_eq!(c.sections.len(), 2);
@@ -708,11 +723,6 @@ mod tests {
     #[test]
     fn incomplete_no_close_ignored() {
         assert!(find_conflicts(&rope("<<<<<<< HEAD\ncurrent\n=======\nincoming\n")).is_empty());
-    }
-
-    #[test]
-    fn incomplete_no_separator_ignored() {
-        assert!(find_conflicts(&rope("<<<<<<< HEAD\ncurrent\n>>>>>>> branch\n")).is_empty());
     }
 
     #[test]

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -548,91 +548,221 @@ pub fn conflict_refine_pair(state: &HashMap<usize, usize>, region: &ConflictRegi
     pair.min(max)
 }
 
-// ── Word-level diff ───────────────────────────────────────────────────────────
+// ── Multi-level refinement (jj-style) ─────────────────────────────────────────
 
-/// A word-token source backed by a contiguous substring of a `Rope`.
+/// Whether `c` is a word character.
 ///
-/// Tokens are non-whitespace runs of characters.
-/// To avoid double allocation, token strings are built on-demand during
-/// `tokenize()` rather than pre-collecting them. This amortizes the cost
-/// across the single `InternedInput::new()` call.
-struct WordTokens<'a> {
-    text: &'a Rope,
-    positions: Vec<(usize, usize)>,
+/// Unlike jj's `is_word_byte`, underscore is NOT included so that
+/// `snake_case` identifiers split into separate word tokens, giving
+/// finer-grained highlighting than jj's default behaviour.
+fn is_word_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c > '\x7F'
 }
 
-impl<'a> WordTokens<'a> {
-    fn new(text: &'a Rope, start: usize, end: usize) -> Self {
-        let mut positions = Vec::new();
-        let mut tok_start: Option<usize> = None;
-        for (i, ch) in text.slice(start..end).chars().enumerate() {
-            let pos = start + i;
-            if ch.is_whitespace() {
-                if let Some(s) = tok_start.take() {
-                    positions.push((s, pos));
-                }
-            } else if tok_start.is_none() {
-                tok_start = Some(pos);
-            }
+/// Tokenize a char range by lines. Each line (including trailing newline) becomes
+/// one token.
+fn tokenize_line_ranges(text: &Rope, range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut line_start = range.start;
+    for (i, ch) in text.slice(range.clone()).chars().enumerate() {
+        let pos = range.start + i;
+        if ch == '\n' {
+            ranges.push(line_start..pos + 1);
+            line_start = pos + 1;
         }
-        if let Some(s) = tok_start {
-            positions.push((s, end));
-        }
-        Self { text, positions }
     }
+    if line_start < range.end {
+        ranges.push(line_start..range.end);
+    }
+    ranges
 }
 
-impl<'a> imara_diff::TokenSource for WordTokens<'a> {
+/// Tokenize a char range by jj-style words.  Only runs of word characters
+/// become tokens; non-word characters are skipped.
+fn tokenize_word_ranges(text: &Rope, range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    let mut word_start: Option<usize> = None;
+    for (i, ch) in text.slice(range.clone()).chars().enumerate() {
+        let pos = range.start + i;
+        if is_word_char(ch) {
+            if word_start.is_none() {
+                word_start = Some(pos);
+            }
+        } else if let Some(start) = word_start.take() {
+            ranges.push(start..pos);
+        }
+    }
+    if let Some(start) = word_start {
+        ranges.push(start..range.end);
+    }
+    ranges
+}
+
+/// Tokenize a char range into individual non-word characters.
+/// Word characters are skipped — they were handled at the word level.
+fn tokenize_nonword_ranges(text: &Rope, range: Range<usize>) -> Vec<Range<usize>> {
+    let mut ranges = Vec::new();
+    for (i, ch) in text.slice(range.clone()).chars().enumerate() {
+        let pos = range.start + i;
+        if !is_word_char(ch) {
+            ranges.push(pos..pos + 1);
+        }
+    }
+    ranges
+}
+
+/// A generic token source backed by a `Rope` and a pre-computed range list.
+struct RopeTokenSource<'a> {
+    text: &'a Rope,
+    ranges: Vec<Range<usize>>,
+}
+
+impl<'a> imara_diff::TokenSource for RopeTokenSource<'a> {
     type Token = String;
     type Tokenizer = Box<dyn Iterator<Item = String> + 'a>;
 
     fn tokenize(&self) -> Self::Tokenizer {
         let text = self.text;
-        let positions = self.positions.clone();
-        Box::new(
-            positions
-                .into_iter()
-                .map(move |(s, e)| text.slice(s..e).chars().collect()),
-        )
+        let ranges = self.ranges.clone();
+        Box::new(ranges.into_iter().map(move |r| text.slice(r).to_string()))
     }
 
     fn estimate_tokens(&self) -> u32 {
-        self.positions.len() as u32
+        self.ranges.len() as u32
     }
 }
 
-/// Compute word-level diff between two sections of `text`.
+/// Run a single-level histogram diff of `left` vs `right` within `text`.
 ///
-/// Returns `(removed_ranges, added_ranges)` as half-open char-index intervals.
+/// Each matching token pair yields its own (left, right) char-range pair.
+/// This is critical when tokens are non-contiguous (e.g. nonword level
+/// skips word chars), so that each matched token stands alone and does
+/// not also cover the skipped characters between tokens.
+fn single_level_diff(
+    text: &Rope,
+    left: Range<usize>,
+    right: Range<usize>,
+    tokenizer: impl Fn(&Rope, Range<usize>) -> Vec<Range<usize>>,
+) -> Vec<(Range<usize>, Range<usize>)> {
+    let left_ranges = tokenizer(text, left);
+    let right_ranges = tokenizer(text, right);
+
+    if left_ranges.is_empty() || right_ranges.is_empty() {
+        return vec![];
+    }
+
+    let left_source = RopeTokenSource {
+        text,
+        ranges: left_ranges.clone(),
+    };
+    let right_source = RopeTokenSource {
+        text,
+        ranges: right_ranges.clone(),
+    };
+
+    let input = InternedInput::new(left_source, right_source);
+    let diff = Diff::compute(Algorithm::Histogram, &input);
+
+    let mut matches: Vec<(Range<usize>, Range<usize>)> = Vec::new();
+    let mut left_idx = 0usize;
+    let mut right_idx = 0usize;
+
+    for hunk in diff.hunks() {
+        let l_start = hunk.before.start as usize;
+        let l_end = hunk.before.end as usize;
+        let r_start = hunk.after.start as usize;
+        let r_end = hunk.after.end as usize;
+
+        // Emit one pair per matching token before this hunk.
+        while left_idx < l_start && right_idx < r_start {
+            matches.push((
+                left_ranges[left_idx].clone(),
+                right_ranges[right_idx].clone(),
+            ));
+            left_idx += 1;
+            right_idx += 1;
+        }
+
+        left_idx = l_end;
+        right_idx = r_end;
+    }
+
+    // Remaining matching tokens after the last hunk.
+    while left_idx < left_ranges.len() && right_idx < right_ranges.len() {
+        matches.push((
+            left_ranges[left_idx].clone(),
+            right_ranges[right_idx].clone(),
+        ));
+        left_idx += 1;
+        right_idx += 1;
+    }
+
+    matches
+}
+
+/// Refine existing matches by re-diffing each gap at a finer granularity.
+/// Returns a new match list with any sub-matches inserted.
+fn refine_matches(
+    text: &Rope,
+    matches: &[(Range<usize>, Range<usize>)],
+    tokenizer: impl Fn(&Rope, Range<usize>) -> Vec<Range<usize>>,
+) -> Vec<(Range<usize>, Range<usize>)> {
+    let mut refined = Vec::with_capacity(matches.len());
+    refined.push(matches[0].clone());
+
+    for window in matches.windows(2) {
+        let (prev_left, prev_right) = &window[0];
+        let (next_left, next_right) = &window[1];
+
+        if prev_left.end < next_left.start && prev_right.end < next_right.start {
+            let gap_left = prev_left.end..next_left.start;
+            let gap_right = prev_right.end..next_right.start;
+            refined.extend(single_level_diff(text, gap_left, gap_right, &tokenizer));
+        }
+
+        refined.push((next_left.clone(), next_right.clone()));
+    }
+
+    refined
+}
+
+/// Compute a jj-style multi-level diff between two sections of `text`.
+///
+/// First diffs by lines, then refines changed regions at word granularity,
+/// then at non-word character granularity.  Returns `(removed_ranges,
+/// added_ranges)` as half-open char-index intervals.
 pub fn refine_diff(
     text: &Rope,
     left: (usize, usize),
     right: (usize, usize),
 ) -> (Vec<Range<usize>>, Vec<Range<usize>>) {
-    let left_tokens = WordTokens::new(text, left.0, left.1);
-    let right_tokens = WordTokens::new(text, right.0, right.1);
+    // Level 1: line-level diff
+    let raw = single_level_diff(text, left.0..left.1, right.0..right.1, tokenize_line_ranges);
 
-    let left_positions = left_tokens.positions.clone();
-    let right_positions = right_tokens.positions.clone();
+    // Build match list with empty boundary sentinels.
+    let mut matches: Vec<(Range<usize>, Range<usize>)> = Vec::with_capacity(raw.len() + 2);
+    matches.push((left.0..left.0, right.0..right.0));
+    matches.extend(raw);
+    matches.push((left.1..left.1, right.1..right.1));
 
-    let input = InternedInput::new(left_tokens, right_tokens);
-    let diff = Diff::compute(Algorithm::Histogram, &input);
+    // Level 2: word-level refinement
+    matches = refine_matches(text, &matches, tokenize_word_ranges);
 
+    // Level 3: nonword-level refinement
+    matches = refine_matches(text, &matches, tokenize_nonword_ranges);
+
+    // Convert gaps between matches to removed/added ranges.
     let mut removed: Vec<Range<usize>> = Vec::new();
     let mut added: Vec<Range<usize>> = Vec::new();
+    for window in matches.windows(2) {
+        let (prev_left, prev_right) = &window[0];
+        let (next_left, next_right) = &window[1];
 
-    for hunk in diff.hunks() {
-        for &(s, e) in &left_positions[hunk.before.start as usize..hunk.before.end as usize] {
-            match removed.last_mut() {
-                Some(r) if r.end == s => r.end = e,
-                _ => removed.push(s..e),
-            }
+        if prev_left.end < next_left.start {
+            removed.push(prev_left.end..next_left.start);
         }
-        for &(s, e) in &right_positions[hunk.after.start as usize..hunk.after.end as usize] {
-            match added.last_mut() {
-                Some(r) if r.end == s => r.end = e,
-                _ => added.push(s..e),
-            }
+        if prev_right.end < next_right.start {
+            added.push(prev_right.end..next_right.start);
         }
     }
 
@@ -1307,5 +1437,183 @@ mod tests {
             added_text.contains("qux"),
             "expected 'qux' in added: {added_text}"
         );
+    }
+
+    #[test]
+    fn refine_diff_current_incoming_ws() {
+        // Regression: whitespace between None and } in current-incoming
+        // should highlight only the 4 extra spaces (common \n is skipped).
+        let text = concat!(
+            "<<<<<<< side #1\n",
+            "    let location =\n",
+            "        if args.onto.is_none() && args.insert_after.is_none() ",
+            "&& args.insert_before.is_none() {\n",
+            "            None\n",
+            "        } else {\n",
+            "            Some(compute_commit_location(\n",
+            "                ui,\n",
+            "                &workspace_command,\n",
+            "                args.onto.as_deref(),\n",
+            "                args.insert_after.as_deref(),\n",
+            "                args.insert_before.as_deref(),\n",
+            "                \"duplicated commits\",\n",
+            "            )?)\n",
+            "        };\n",
+            "||||||| base\n",
+            "    let location = if args.destination.is_none()\n",
+            "        && args.insert_after.is_none()\n",
+            "        && args.insert_before.is_none()\n",
+            "    {\n",
+            "        None\n",
+            "    } else {\n",
+            "        Some(compute_commit_location(\n",
+            "            ui,\n",
+            "            &workspace_command,\n",
+            "            args.destination.as_deref(),\n",
+            "            args.insert_after.as_deref(),\n",
+            "            args.insert_before.as_deref(),\n",
+            "            \"duplicated commits\",\n",
+            "        )?)\n",
+            "    };\n",
+            "=======\n",
+            "    let location = if args.destination.is_none()\n",
+            "        && args.insert_after.is_none()\n",
+            "        && args.insert_before.is_none()\n",
+            "    {\n",
+            "        None\n",
+            "    } else {\n",
+            "        Some(compute_commit_location(\n",
+            "            ui,\n",
+            "            &workspace_command,\n",
+            "            args.destination.as_deref(),\n",
+            "            args.insert_after.as_deref(),\n",
+            "            args.insert_before.as_deref(),\n",
+            "            \"duplicated revisions\",\n",
+            "        )?)\n",
+            "    };\n",
+            ">>>>>>> side #2\n",
+        );
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        let base = base_content(c).unwrap();
+        let current = current_content(c);
+        let incoming = incoming_content(c);
+
+        // ── current-base ──────────────────────────────────────────────────
+        let (removed, added) = refine_diff(&r, current, base);
+        let pos_cur = r
+            .to_string()
+            .find("None\n        ")
+            .expect("current-side None followed by 8 spaces");
+        assert!(!removed.is_empty(), "current-base: expected removed ranges");
+        assert!(!added.is_empty(), "current-base: expected added ranges");
+        // Same None→} whitespace diff as current-incoming (4 extra spaces).
+        // Match any 4-char removed range inside the "\n        }" gap.
+        assert!(
+            removed.iter().any(|range| {
+                range.start >= pos_cur + 5
+                    && range.end <= pos_cur + 13
+                    && range.end - range.start == 4
+            }),
+            "current-base: expected 4 extra spaces between None and }}"
+        );
+
+        // ── base-incoming ─────────────────────────────────────────────────
+        let (removed, added) = refine_diff(&r, base, incoming);
+        assert!(
+            !removed.is_empty(),
+            "base-incoming: expected removed ranges"
+        );
+        assert!(!added.is_empty(), "base-incoming: expected added ranges");
+        // Only the string differs — no whitespace changes.
+        let rem_text: String = removed
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            !rem_text.contains("None"),
+            "base-incoming: None should not be in removed: {rem_text:?}"
+        );
+
+        // ── current-incoming ──────────────────────────────────────────────
+        let (removed, added) = refine_diff(&r, current, incoming);
+        assert!(
+            !removed.is_empty(),
+            "current-incoming: expected removed ranges"
+        );
+        assert!(!added.is_empty(), "current-incoming: expected added ranges");
+        assert!(
+            removed.iter().any(|range| {
+                range.start >= pos_cur + 5
+                    && range.end <= pos_cur + 13
+                    && range.end - range.start == 4
+            }),
+            "current-incoming: expected 4 extra spaces between None and }}"
+        );
+    }
+
+    #[test]
+    fn refine_diff_underscore_word() {
+        // jj treats underscore and non-ASCII as word chars.
+        // "fn foo_bar() {}" → "fn foo_baz() {}" should highlight only
+        // "bar" vs "baz" — the fn, foo_, (){} should all match.
+        let text = "<<<<<<< HEAD\nfn foo_bar() {}\n=======\nfn foo_baz() {}\n>>>>>>> branch\n";
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        let (removed, added) = refine_diff(&r, current_content(c), incoming_content(c));
+        let rem_text: String = removed
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join("");
+        let add_text: String = added
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join("");
+        assert_eq!(
+            removed.len(),
+            1,
+            "expected 1 removed range, got {removed:?}"
+        );
+        assert_eq!(added.len(), 1, "expected 1 added range, got {added:?}");
+        // Underscore splits words, so only "bar" / "baz" are highlighted.
+        assert_eq!(rem_text, "bar");
+        assert_eq!(add_text, "baz");
+    }
+
+    #[test]
+    fn refine_diff_line_level_match() {
+        // Shared lines should be matched at the line level, not shown as changes.
+        let text = concat!(
+            "<<<<<<< HEAD\n",
+            "shared_prefix\n",
+            "only_in_current\n",
+            "shared_suffix\n",
+            "=======\n",
+            "shared_prefix\n",
+            "only_in_incoming\n",
+            "shared_suffix\n",
+            ">>>>>>> branch\n",
+        );
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+        let (removed, added) = refine_diff(&r, current_content(c), incoming_content(c));
+        let rem_text: String = removed
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join("");
+        let add_text: String = added
+            .iter()
+            .map(|range| r.slice(range.clone()).to_string())
+            .collect::<Vec<_>>()
+            .join("");
+        // Only the differing word within the differing line should be
+        // highlighted — "current" vs "incoming".  The rest is matched
+        // at line → word → nonword levels.
+        assert_eq!(rem_text, "current");
+        assert_eq!(add_text, "incoming");
     }
 }

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -91,27 +91,81 @@ pub struct ConflictRegion {
 }
 
 impl ConflictRegion {
-    /// Number of C(N, 2) word-diff pairs that can be shown via refine.
+    /// Number of word-diff pairs available via refine.
+    ///
+    /// Only phase-1 (each side vs adjacent base) and phase-2 (side–side) pairs
+    /// are counted; remaining pairs involving bases are never shown.
     pub fn num_refine_pairs(&self) -> usize {
         let n = self.sections.len();
-        n * n.saturating_sub(1) / 2
+        let mut count = 0;
+
+        // Phase 1
+        for i in 1..n {
+            if i == 1 || self.sections[i - 1].kind == SectionKind::Base {
+                count += 1;
+            }
+        }
+        // Phase 2
+        for skip in 1..n {
+            for i in 0..(n - skip) {
+                let (a, b) = (i, i + skip);
+                if self.sections[a].kind == SectionKind::Side
+                    && self.sections[b].kind == SectionKind::Side
+                    && !((a == 0 || self.sections[a].kind == SectionKind::Base) && b == a + 1)
+                {
+                    count += 1;
+                }
+            }
+        }
+        count
     }
 
     /// Return the pair of section indices for refine `pair` index.
     ///
-    /// Pairs are enumerated as (0,1), (0,2), …, (0,n-1), (1,2), …, (n-2,n-1).
+    /// Pairs are ordered so comparisons relevant to N-way conflicts come first:
+    ///   1. Each Side compared against its adjacent Base — `(0,1)` first, then
+    ///      all `(i,i+1)` where section `i` is a **Base**.
+    ///   2. All Side–Side pairs (both sections are `Side`), with the left side
+    ///      fixed as long as possible before advancing.
+    ///
+    /// For a standard git diff3 3-section conflict (Side,Base,Side) this still
+    /// produces (0,1)=current↔base, (1,2)=base↔incoming, (0,2)=current↔incoming.
     /// Returns `None` if `pair >= num_refine_pairs()`.
     pub fn refine_pair_indices(&self, pair: usize) -> Option<(usize, usize)> {
         let n = self.sections.len();
+        if pair >= self.num_refine_pairs() {
+            return None;
+        }
         let mut idx = 0;
-        for i in 0..n {
-            for j in (i + 1)..n {
+
+        // Phase 1: (0,1) first, then all (i,i+1) where sections[i] is Base.
+        for i in 1..n {
+            let in_phase1 = i == 1 || self.sections[i - 1].kind == SectionKind::Base;
+            if in_phase1 {
                 if idx == pair {
-                    return Some((i, j));
+                    return Some((i - 1, i));
                 }
                 idx += 1;
             }
         }
+
+        // Phase 2: Side–Side pairs, left side fixed as long as possible.
+        let side_indices: Vec<usize> = (0..n)
+            .filter(|i| self.sections[*i].kind == SectionKind::Side)
+            .collect();
+        for a_idx in 0..side_indices.len() {
+            for b_idx in (a_idx + 1)..side_indices.len() {
+                let (a, b) = (side_indices[a_idx], side_indices[b_idx]);
+                let already = (a == 0 || self.sections[a].kind == SectionKind::Base) && b == a + 1;
+                if !already {
+                    if idx == pair {
+                        return Some((a, b));
+                    }
+                    idx += 1;
+                }
+            }
+        }
+
         None
     }
 }
@@ -856,6 +910,107 @@ mod tests {
         assert_eq!(conflict_section_at(c, &r, close), Some(2));
     }
 
+    // ── refine pairs ──────────────────────────────────────────────────────────
+
+    type RefinePairCase<'a> = (&'a str, usize, &'a [(usize, usize)]);
+
+    #[test]
+    fn refine_pairs_cases() {
+        let cases: &[RefinePairCase<'_>] = &[
+            (
+                "<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> b\n",
+                1,
+                &[(0, 1)],
+            ),
+            (
+                "<<<<<<< HEAD\ncurrent\n||||||| base\nbase\n=======\nincoming\n>>>>>>> b\n",
+                3,
+                &[(0, 1), (1, 2), (0, 2)],
+            ),
+        ];
+        for &(text, num_pairs, pairs) in cases {
+            let c = &find_conflicts(&rope(text))[0];
+            assert_eq!(c.num_refine_pairs(), num_pairs);
+            for (i, &expected) in pairs.iter().enumerate() {
+                assert_eq!(c.refine_pair_indices(i), Some(expected));
+            }
+            assert_eq!(c.refine_pair_indices(pairs.len()), None);
+        }
+    }
+
+    #[test]
+    fn refine_pairs_four_sections() {
+        // 4 sections [S0,B1,S2,S3], pairs only from phases 1+2:
+        //   phase 1: (0,1),(1,2) = 2
+        //   phase 2 (Side–Side, fixed left): (0,2),(0,3),(2,3) = 3
+        //   total: 5  (pair (1,3)=B1,S3 is excluded)
+        let text = concat!(
+            "<<<<<<< Conflict\n",
+            "+++++++ s1\nA\n",
+            "------- base\nB\n",
+            "+++++++ s2\nC\n",
+            "+++++++ s3\nD\n",
+            ">>>>>>> Conflict ends\n",
+        );
+        let c = &find_conflicts(&rope(text))[0];
+        assert_eq!(c.sections.len(), 4);
+        assert_eq!(c.num_refine_pairs(), 5);
+        assert_eq!(c.refine_pair_indices(0), Some((0, 1)));
+        assert_eq!(c.refine_pair_indices(1), Some((1, 2)));
+        assert_eq!(c.refine_pair_indices(2), Some((0, 2)));
+        assert_eq!(c.refine_pair_indices(3), Some((0, 3)));
+        assert_eq!(c.refine_pair_indices(4), Some((2, 3)));
+        assert_eq!(c.refine_pair_indices(5), None);
+    }
+
+    #[test]
+    fn pair_sections_put_base_on_left() {
+        // diff3: sections = [Side(current), Base, Side(incoming)]
+        // Skip-distance ordering: (0,1), (1,2), (0,2)
+        // Pair 0 = (Side, Base) → MUST swap → left=base, right=current
+        // Pair 1 = (Base, Side) → already base-left, NO swap
+        // Pair 2 = (Side, Side) → order preserved
+        let text = "<<<<<<< HEAD\ncurrent\n||||||| base\nbase\n=======\nincoming\n>>>>>>> b\n";
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+
+        // pair 0 => indices (0,1) = (Side, Base) -> MUST swap to (Base, Side)
+        let (left, right) = conflict_pair_sections(c, 0).unwrap();
+        assert_eq!(r.slice(left.0..left.1).to_string(), "base\n"); // base on left (red)
+        assert_eq!(r.slice(right.0..right.1).to_string(), "current\n"); // side on right (green)
+
+        // pair 1 => indices (1,2) = (Base, Side) -> already base-left, NO swap
+        let (left, right) = conflict_pair_sections(c, 1).unwrap();
+        assert_eq!(r.slice(left.0..left.1).to_string(), "base\n"); // base on left
+        assert_eq!(r.slice(right.0..right.1).to_string(), "incoming\n"); // side on right
+
+        // pair 2 => indices (0,2) = (Side, Side) -> order preserved
+        let (left, right) = conflict_pair_sections(c, 2).unwrap();
+        assert_eq!(r.slice(left.0..left.1).to_string(), "current\n");
+        assert_eq!(r.slice(right.0..right.1).to_string(), "incoming\n");
+
+        assert!(conflict_pair_sections(c, 3).is_none());
+    }
+
+    #[test]
+    fn refine_pair_clamped_and_default() {
+        let text = "<<<<<<< HEAD\ncurrent\n=======\nincoming\n>>>>>>> b\n"; // 1 pair, max idx 0
+        let r = rope(text);
+        let c = &find_conflicts(&r)[0];
+
+        // Stale/out-of-range selection gets clamped to valid range
+        let mut state = HashMap::new();
+        state.insert(c.start, 99);
+        assert_eq!(conflict_refine_pair(&state, c), 0);
+
+        // Empty state defaults to 0
+        assert_eq!(conflict_refine_pair(&HashMap::new(), c), 0);
+
+        // Valid index passes through
+        state.clear();
+        state.insert(c.start, 0);
+        assert_eq!(conflict_refine_pair(&state, c), 0);
+    }
     #[test]
     fn all_sides_content_concatenates() {
         let text = concat!(

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -444,8 +444,8 @@ fn git_sep_line_end(region: &ConflictRegion, text: &Rope) -> Option<usize> {
 /// `-------`), and the closing `>>>>>>>`.
 ///
 /// The returned `Vec` is sorted and deduplicated.
-pub fn conflict_marker_lines(text: &Rope) -> Vec<usize> {
-    let mut lines: Vec<usize> = find_conflicts(text)
+pub fn conflict_marker_lines(conflicts: &[ConflictRegion], text: &Rope) -> Vec<usize> {
+    let mut lines: Vec<usize> = conflicts
         .iter()
         .flat_map(|region| {
             // Section marker lines (includes the opening <<<<<<< via sections[0].marker_start).
@@ -840,6 +840,7 @@ mod tests {
         assert_eq!(c.sections[2].kind, SectionKind::Side);
         assert_eq!(c.sections[3].kind, SectionKind::Base);
         assert_eq!(c.sections[4].kind, SectionKind::Side);
+        assert_eq!(c.num_refine_pairs(), 10); // C(5,2)
     }
 
     // ── conflict_at ───────────────────────────────────────────────────────────
@@ -1076,7 +1077,8 @@ mod tests {
             "after\n",
         );
         let r = rope(text);
-        let lines = conflict_marker_lines(&r);
+        let conflicts = find_conflicts(&r);
+        let lines = conflict_marker_lines(&conflicts, &r);
         assert!(!lines.is_empty());
         for i in 0..lines.len() - 1 {
             assert!(lines[i] < lines[i + 1]);

--- a/helix-core/src/conflict.rs
+++ b/helix-core/src/conflict.rs
@@ -415,6 +415,31 @@ fn git_sep_line_end(region: &ConflictRegion, text: &Rope) -> Option<usize> {
     }
 }
 
+/// Returns the document line numbers of every conflict marker line in `text`:
+/// the opening `<<<<<<<`, every section marker (`|||||||`, `=======`, `+++++++`,
+/// `-------`), and the closing `>>>>>>>`.
+///
+/// The returned `Vec` is sorted and deduplicated.
+pub fn conflict_marker_lines(text: &Rope) -> Vec<usize> {
+    let mut lines: Vec<usize> = find_conflicts(text)
+        .iter()
+        .flat_map(|region| {
+            // Section marker lines (includes the opening <<<<<<< via sections[0].marker_start).
+            let section_lines = region
+                .sections
+                .iter()
+                .map(|s| text.char_to_line(s.marker_start));
+            // Closing >>>>>>> line — `end` is exclusive and points past the trailing
+            // newline, so subtract 1 to land somewhere on the last line.
+            let end_line = std::iter::once(text.char_to_line(region.end.saturating_sub(1)));
+            section_lines.chain(end_line)
+        })
+        .collect();
+    lines.sort_unstable();
+    lines.dedup();
+    lines
+}
+
 // ── Content helpers ───────────────────────────────────────────────────────────
 
 /// Return the char range of the first `Side` section ("current" change).
@@ -1011,6 +1036,23 @@ mod tests {
         state.insert(c.start, 0);
         assert_eq!(conflict_refine_pair(&state, c), 0);
     }
+    #[test]
+    fn conflict_marker_lines_returns_sorted() {
+        let text = concat!(
+            "before\n",
+            "<<<<<<< HEAD\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> b\n",
+            "after\n",
+        );
+        let r = rope(text);
+        let lines = conflict_marker_lines(&r);
+        assert!(!lines.is_empty());
+        for i in 0..lines.len() - 1 {
+            assert!(lines[i] < lines[i + 1]);
+        }
+        let dedup_check: Vec<_> = lines.iter().collect();
+        assert_eq!(dedup_check.len(), lines.len());
+    }
+
     #[test]
     fn all_sides_content_concatenates() {
         let text = concat!(

--- a/helix-core/src/lib.rs
+++ b/helix-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod command_line;
 pub mod comment;
 pub mod completion;
 pub mod config;
+pub mod conflict;
 pub mod diagnostic;
 pub mod diff;
 pub mod doc_formatter;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -584,6 +584,7 @@ impl MappableCommand {
         conflict_accept_incoming, "Accept incoming change (>>>>>>> side)",
         conflict_accept_base, "Accept base change (||||||| side, diff3 only)",
         conflict_accept_all, "Accept all changes",
+        conflict_cycle_diffs, "Cycle word-level conflict diffs",
         goto_next_entry, "Goto next pairing",
         goto_prev_entry, "Goto previous pairing",
         goto_next_paragraph, "Goto next paragraph",
@@ -6295,6 +6296,29 @@ fn conflict_accept_base(cx: &mut Context) {
 
 fn conflict_accept_all(cx: &mut Context) {
     resolve_conflict_impl(cx, ConflictResolution::All);
+}
+
+fn conflict_cycle_diffs(cx: &mut Context) {
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text();
+    let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
+
+    let conflicts = helix_core::conflict::find_conflicts(text);
+    let idx = match helix_core::conflict::conflict_at(&conflicts, cursor) {
+        Some(i) => i,
+        None => return,
+    };
+    let region = &conflicts[idx];
+
+    // 2-way conflicts have no base section — refine is a no-op.
+    if region.num_refine_pairs() == 0 {
+        return;
+    }
+
+    let key = region.start;
+    let current = doc.conflict_refine_state.get(&key).copied().unwrap_or(0);
+    let next = (current + 1) % region.num_refine_pairs();
+    doc.conflict_refine_state.insert(key, next);
 }
 
 #[derive(Clone, Copy)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6232,7 +6232,7 @@ fn goto_conflict_impl(cx: &mut Context, direction: Direction) {
     let count = cx.count();
     let (view, doc) = current!(cx.editor);
     let text = doc.text();
-    let conflicts = helix_core::conflict::find_conflicts(text);
+    let conflicts = doc.conflicts();
 
     if conflicts.is_empty() {
         cx.editor
@@ -6246,16 +6246,16 @@ fn goto_conflict_impl(cx: &mut Context, direction: Direction) {
 
         // Walk `count` steps in `direction`.
         let mut idx = match direction {
-            Direction::Forward => helix_core::conflict::next_conflict(&conflicts, cursor),
-            Direction::Backward => helix_core::conflict::prev_conflict(&conflicts, cursor),
+            Direction::Forward => helix_core::conflict::next_conflict(conflicts, cursor),
+            Direction::Backward => helix_core::conflict::prev_conflict(conflicts, cursor),
         };
 
         for _ in 1..count {
             let Some(current) = idx else { break };
             let next_pos = conflicts[current].start;
             idx = match direction {
-                Direction::Forward => helix_core::conflict::next_conflict(&conflicts, next_pos),
-                Direction::Backward => helix_core::conflict::prev_conflict(&conflicts, next_pos),
+                Direction::Forward => helix_core::conflict::next_conflict(conflicts, next_pos),
+                Direction::Backward => helix_core::conflict::prev_conflict(conflicts, next_pos),
             };
         }
 
@@ -6299,13 +6299,13 @@ fn conflict_accept_all(cx: &mut Context) {
 }
 
 fn conflict_accept_at_cursor(cx: &mut Context) {
-    use helix_core::conflict::{conflict_at, conflict_section_at, find_conflicts};
+    use helix_core::conflict::{conflict_at, conflict_section_at};
     let resolution = {
         let (view, doc) = current!(cx.editor);
         let text = doc.text();
         let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
-        let conflicts = find_conflicts(text);
-        let idx = match conflict_at(&conflicts, cursor) {
+        let conflicts = doc.conflicts();
+        let idx = match conflict_at(conflicts, cursor) {
             Some(i) => i,
             None => return,
         };
@@ -6322,8 +6322,8 @@ fn conflict_cycle_diffs(cx: &mut Context) {
     let text = doc.text();
     let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
 
-    let conflicts = helix_core::conflict::find_conflicts(text);
-    let idx = match helix_core::conflict::conflict_at(&conflicts, cursor) {
+    let conflicts = doc.conflicts();
+    let idx = match helix_core::conflict::conflict_at(conflicts, cursor) {
         Some(i) => i,
         None => return,
     };
@@ -6334,7 +6334,7 @@ fn conflict_cycle_diffs(cx: &mut Context) {
         return;
     }
 
-    let mut cache = doc.conflict_refine.borrow_mut();
+    let mut cache = doc.conflict_cache.borrow_mut();
     let entry = cache.entry(region.start).or_default();
     entry.pair = (entry.pair + 1) % region.num_refine_pairs();
     entry.diffs = None;
@@ -6359,14 +6359,14 @@ fn resolve_conflict_impl(cx: &mut Context, resolution: ConflictResolution) {
     let outcome = {
         let (view, doc) = current!(cx.editor);
         let text = doc.text();
-        let conflicts = helix_core::conflict::find_conflicts(text);
+        let conflicts = doc.conflicts();
 
         if conflicts.is_empty() {
             Outcome::Status("No conflict markers in current buffer")
         } else {
             let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
 
-            if let Some(idx) = helix_core::conflict::conflict_at(&conflicts, cursor) {
+            if let Some(idx) = helix_core::conflict::conflict_at(conflicts, cursor) {
                 let region = &conflicts[idx];
 
                 let replacement: Option<String> = match resolution {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -580,6 +580,10 @@ impl MappableCommand {
         goto_prev_xml_element, "Goto previous (X)HTML element",
         goto_next_conflict, "Goto next conflict",
         goto_prev_conflict, "Goto previous conflict",
+        conflict_accept_current, "Accept current change (<<<<<<< side)",
+        conflict_accept_incoming, "Accept incoming change (>>>>>>> side)",
+        conflict_accept_base, "Accept base change (||||||| side, diff3 only)",
+        conflict_accept_all, "Accept all changes",
         goto_next_entry, "Goto next pairing",
         goto_prev_entry, "Goto previous pairing",
         goto_next_paragraph, "Goto next paragraph",
@@ -6275,6 +6279,97 @@ fn goto_conflict_impl(cx: &mut Context, direction: Direction) {
         doc.set_selection(view.id, selection);
     };
     cx.editor.apply_motion(motion);
+}
+
+fn conflict_accept_current(cx: &mut Context) {
+    resolve_conflict_impl(cx, ConflictResolution::Current);
+}
+
+fn conflict_accept_incoming(cx: &mut Context) {
+    resolve_conflict_impl(cx, ConflictResolution::Incoming);
+}
+
+fn conflict_accept_base(cx: &mut Context) {
+    resolve_conflict_impl(cx, ConflictResolution::Base);
+}
+
+fn conflict_accept_all(cx: &mut Context) {
+    resolve_conflict_impl(cx, ConflictResolution::All);
+}
+
+#[derive(Clone, Copy)]
+enum ConflictResolution {
+    Current,
+    Incoming,
+    Base,
+    All,
+}
+
+fn resolve_conflict_impl(cx: &mut Context, resolution: ConflictResolution) {
+    // Phase 1 (read): compute the transaction inside a block to release borrows.
+    enum Outcome {
+        Apply(helix_view::ViewId, Transaction, usize), // view_id, transaction, cursor_pos
+        Status(&'static str),
+    }
+
+    let outcome = {
+        let (view, doc) = current!(cx.editor);
+        let text = doc.text();
+        let conflicts = helix_core::conflict::find_conflicts(text);
+
+        if conflicts.is_empty() {
+            Outcome::Status("No conflict markers in current buffer")
+        } else {
+            let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
+
+            if let Some(idx) = helix_core::conflict::conflict_at(&conflicts, cursor) {
+                let region = &conflicts[idx];
+
+                let replacement: Option<String> = match resolution {
+                    ConflictResolution::Current => {
+                        let (s, e) = helix_core::conflict::current_content(region);
+                        Some(text.slice(s..e).to_string())
+                    }
+                    ConflictResolution::Incoming => {
+                        let (s, e) = helix_core::conflict::incoming_content(region);
+                        Some(text.slice(s..e).to_string())
+                    }
+                    ConflictResolution::Base => helix_core::conflict::base_content(region)
+                        .map(|(s, e)| text.slice(s..e).to_string()),
+                    ConflictResolution::All => {
+                        Some(helix_core::conflict::all_sides_content(text, region))
+                    }
+                };
+
+                match replacement {
+                    Some(s) => {
+                        let cursor_pos = region.start;
+                        let transaction = Transaction::change(
+                            text,
+                            std::iter::once((region.start, region.end, Some(s.into()))),
+                        );
+                        Outcome::Apply(view.id, transaction, cursor_pos)
+                    }
+                    None => Outcome::Status("No base section (not a diff3 conflict)"),
+                }
+            } else {
+                Outcome::Status("Cursor is not inside a conflict region")
+            }
+        }
+    };
+
+    // Phase 2: act on the outcome (borrows from phase 1 are released).
+    match outcome {
+        Outcome::Status(msg) => cx.editor.set_status(msg),
+        Outcome::Apply(view_id, transaction, cursor_pos) => {
+            let (view, doc) = current!(cx.editor);
+            doc.apply(&transaction, view_id);
+            // Place cursor at the start of the resolved content.
+            let selection = Selection::point(cursor_pos);
+            doc.set_selection(view_id, selection);
+            doc.append_changes_to_history(view);
+        }
+    }
 }
 
 fn goto_next_entry(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -578,6 +578,8 @@ impl MappableCommand {
         goto_prev_test, "Goto previous test",
         goto_next_xml_element, "Goto next (X)HTML element",
         goto_prev_xml_element, "Goto previous (X)HTML element",
+        goto_next_conflict, "Goto next conflict",
+        goto_prev_conflict, "Goto previous conflict",
         goto_next_entry, "Goto next pairing",
         goto_prev_entry, "Goto previous pairing",
         goto_next_paragraph, "Goto next paragraph",
@@ -6210,6 +6212,69 @@ fn goto_next_xml_element(cx: &mut Context) {
 
 fn goto_prev_xml_element(cx: &mut Context) {
     goto_ts_object_impl(cx, "xml-element", Direction::Backward)
+}
+
+fn goto_next_conflict(cx: &mut Context) {
+    goto_conflict_impl(cx, Direction::Forward)
+}
+
+fn goto_prev_conflict(cx: &mut Context) {
+    goto_conflict_impl(cx, Direction::Backward)
+}
+
+fn goto_conflict_impl(cx: &mut Context, direction: Direction) {
+    let count = cx.count();
+    let motion = move |editor: &mut Editor| {
+        let (view, doc) = current!(editor);
+        let text = doc.text();
+        let conflicts = helix_core::conflict::find_conflicts(text);
+
+        if conflicts.is_empty() {
+            editor.set_status("No conflict markers in current buffer");
+            return;
+        }
+
+        let selection = doc.selection(view.id).clone().transform(|range| {
+            let cursor = range.cursor(text.slice(..));
+
+            // Walk `count` steps in `direction`.
+            let mut idx = match direction {
+                Direction::Forward => helix_core::conflict::next_conflict(&conflicts, cursor),
+                Direction::Backward => helix_core::conflict::prev_conflict(&conflicts, cursor),
+            };
+
+            for _ in 1..count {
+                let Some(current) = idx else { break };
+                let next_pos = conflicts[current].start;
+                idx = match direction {
+                    Direction::Forward => helix_core::conflict::next_conflict(&conflicts, next_pos),
+                    Direction::Backward => {
+                        helix_core::conflict::prev_conflict(&conflicts, next_pos)
+                    }
+                };
+            }
+
+            let Some(idx) = idx else {
+                return range;
+            };
+
+            let new_range = Range::point(conflicts[idx].start);
+            if editor.mode == Mode::Select {
+                let head = if new_range.head < range.anchor {
+                    new_range.anchor
+                } else {
+                    new_range.head
+                };
+                Range::new(range.anchor, head)
+            } else {
+                new_range
+            }
+        });
+
+        push_jump(view, doc);
+        doc.set_selection(view.id, selection);
+    };
+    cx.editor.apply_motion(motion);
 }
 
 fn goto_next_entry(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -584,6 +584,7 @@ impl MappableCommand {
         conflict_accept_incoming, "Accept incoming change (>>>>>>> side)",
         conflict_accept_base, "Accept base change (||||||| side, diff3 only)",
         conflict_accept_all, "Accept all changes",
+        conflict_accept_at_cursor, "Accept change at cursor",
         conflict_cycle_diffs, "Cycle word-level conflict diffs",
         goto_next_entry, "Goto next pairing",
         goto_prev_entry, "Goto previous pairing",
@@ -6298,6 +6299,25 @@ fn conflict_accept_all(cx: &mut Context) {
     resolve_conflict_impl(cx, ConflictResolution::All);
 }
 
+fn conflict_accept_at_cursor(cx: &mut Context) {
+    use helix_core::conflict::{conflict_at, conflict_section_at, find_conflicts};
+    let resolution = {
+        let (view, doc) = current!(cx.editor);
+        let text = doc.text();
+        let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
+        let conflicts = find_conflicts(text);
+        let idx = match conflict_at(&conflicts, cursor) {
+            Some(i) => i,
+            None => return,
+        };
+        match conflict_section_at(&conflicts[idx], text, cursor) {
+            Some(section_idx) => ConflictResolution::Section(section_idx),
+            None => return, // on ======= line, no-op
+        }
+    };
+    resolve_conflict_impl(cx, resolution);
+}
+
 fn conflict_cycle_diffs(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
     let text = doc.text();
@@ -6327,6 +6347,7 @@ enum ConflictResolution {
     Incoming,
     Base,
     All,
+    Section(usize),
 }
 
 fn resolve_conflict_impl(cx: &mut Context, resolution: ConflictResolution) {
@@ -6363,6 +6384,10 @@ fn resolve_conflict_impl(cx: &mut Context, resolution: ConflictResolution) {
                     ConflictResolution::All => {
                         Some(helix_core::conflict::all_sides_content(text, region))
                     }
+                    ConflictResolution::Section(idx) => region.sections.get(idx).map(|section| {
+                        let (s, e) = (section.content_start, section.content_end);
+                        text.slice(s..e).to_string()
+                    }),
                 };
 
                 match replacement {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6230,57 +6230,56 @@ fn goto_prev_conflict(cx: &mut Context) {
 
 fn goto_conflict_impl(cx: &mut Context, direction: Direction) {
     let count = cx.count();
-    let motion = move |editor: &mut Editor| {
-        let (view, doc) = current!(editor);
-        let text = doc.text();
-        let conflicts = helix_core::conflict::find_conflicts(text);
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text();
+    let conflicts = helix_core::conflict::find_conflicts(text);
 
-        if conflicts.is_empty() {
-            editor.set_status("No conflict markers in current buffer");
-            return;
+    if conflicts.is_empty() {
+        cx.editor
+            .set_status("No conflict markers in current buffer");
+        return;
+    }
+
+    let mode = cx.editor.mode;
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let cursor = range.cursor(text.slice(..));
+
+        // Walk `count` steps in `direction`.
+        let mut idx = match direction {
+            Direction::Forward => helix_core::conflict::next_conflict(&conflicts, cursor),
+            Direction::Backward => helix_core::conflict::prev_conflict(&conflicts, cursor),
+        };
+
+        for _ in 1..count {
+            let Some(current) = idx else { break };
+            let next_pos = conflicts[current].start;
+            idx = match direction {
+                Direction::Forward => helix_core::conflict::next_conflict(&conflicts, next_pos),
+                Direction::Backward => helix_core::conflict::prev_conflict(&conflicts, next_pos),
+            };
         }
 
-        let selection = doc.selection(view.id).clone().transform(|range| {
-            let cursor = range.cursor(text.slice(..));
+        let Some(idx) = idx else {
+            return range;
+        };
 
-            // Walk `count` steps in `direction`.
-            let mut idx = match direction {
-                Direction::Forward => helix_core::conflict::next_conflict(&conflicts, cursor),
-                Direction::Backward => helix_core::conflict::prev_conflict(&conflicts, cursor),
-            };
-
-            for _ in 1..count {
-                let Some(current) = idx else { break };
-                let next_pos = conflicts[current].start;
-                idx = match direction {
-                    Direction::Forward => helix_core::conflict::next_conflict(&conflicts, next_pos),
-                    Direction::Backward => {
-                        helix_core::conflict::prev_conflict(&conflicts, next_pos)
-                    }
-                };
-            }
-
-            let Some(idx) = idx else {
-                return range;
-            };
-
-            let new_range = Range::point(conflicts[idx].start);
-            if editor.mode == Mode::Select {
-                let head = if new_range.head < range.anchor {
-                    new_range.anchor
-                } else {
-                    new_range.head
-                };
-                Range::new(range.anchor, head)
+        let new_range = Range::point(conflicts[idx].start);
+        if mode == Mode::Select {
+            let head = if new_range.head < range.anchor {
+                new_range.anchor
             } else {
-                new_range
-            }
-        });
+                new_range.head
+            };
+            Range::new(range.anchor, head)
+        } else {
+            new_range
+        }
+    });
 
-        push_jump(view, doc);
-        doc.set_selection(view.id, selection);
-    };
-    cx.editor.apply_motion(motion);
+    let (view, doc) = current!(cx.editor);
+    push_jump(view, doc);
+    doc.set_selection(view.id, selection);
+    align_view(doc, view, Align::Top);
 }
 
 fn conflict_accept_current(cx: &mut Context) {

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6334,10 +6334,10 @@ fn conflict_cycle_diffs(cx: &mut Context) {
         return;
     }
 
-    let key = region.start;
-    let current = doc.conflict_refine_state.get(&key).copied().unwrap_or(0);
-    let next = (current + 1) % region.num_refine_pairs();
-    doc.conflict_refine_state.insert(key, next);
+    let mut cache = doc.conflict_refine.borrow_mut();
+    let entry = cache.entry(region.start).or_default();
+    entry.pair = (entry.pair + 1) % region.num_refine_pairs();
+    entry.diffs = None;
 }
 
 #[derive(Clone, Copy)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -6318,6 +6318,7 @@ fn conflict_accept_at_cursor(cx: &mut Context) {
 }
 
 fn conflict_cycle_diffs(cx: &mut Context) {
+    use helix_core::conflict::NO_HIGHLIGHT_PAIR;
     let (view, doc) = current!(cx.editor);
     let text = doc.text();
     let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
@@ -6336,7 +6337,13 @@ fn conflict_cycle_diffs(cx: &mut Context) {
 
     let mut cache = doc.conflict_cache.borrow_mut();
     let entry = cache.entry(region.start).or_default();
-    entry.pair = (entry.pair + 1) % region.num_refine_pairs();
+    entry.pair = if entry.pair == NO_HIGHLIGHT_PAIR {
+        0
+    } else if entry.pair + 1 < region.num_refine_pairs() {
+        entry.pair + 1
+    } else {
+        NO_HIGHLIGHT_PAIR
+    };
     entry.diffs = None;
 }
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -294,6 +294,12 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "C" => toggle_block_comments,
             "A-c" => toggle_line_comments,
             "?" => command_palette,
+            "x" => { "Conflict"
+                "c" => conflict_accept_current,
+                "i" => conflict_accept_incoming,
+                "b" => conflict_accept_base,
+                "a" => conflict_accept_all,
+            },
         },
         "z" => { "View"
             "z" | "c" => align_view_center,

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -299,6 +299,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
                 "i" => conflict_accept_incoming,
                 "b" => conflict_accept_base,
                 "a" => conflict_accept_all,
+                "x" => conflict_accept_at_cursor,
                 "r" => conflict_cycle_diffs,
             },
         },

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -299,6 +299,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
                 "i" => conflict_accept_incoming,
                 "b" => conflict_accept_base,
                 "a" => conflict_accept_all,
+                "r" => conflict_cycle_diffs,
             },
         },
         "z" => { "View"

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -121,6 +121,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "T" => goto_prev_test,
             "p" => goto_prev_paragraph,
             "x" => goto_prev_xml_element,
+            "=" => goto_prev_conflict,
             "space" => add_newline_above,
         },
         "]" => { "Right bracket"
@@ -136,6 +137,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "T" => goto_next_test,
             "p" => goto_next_paragraph,
             "x" => goto_next_xml_element,
+            "=" => goto_next_conflict,
             "space" => add_newline_below,
         },
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -14,7 +14,10 @@ use crate::{
 };
 
 use helix_core::{
-    conflict::{conflict_marker_lines, conflict_pair_sections, refine_diff, ConflictRegion},
+    conflict::{
+        conflict_marker_lines, conflict_pair_sections, refine_diff, ConflictRegion,
+        NO_HIGHLIGHT_PAIR,
+    },
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
@@ -723,6 +726,9 @@ impl EditorView {
             }
 
             let entry = cache.entry(region.start).or_default();
+            if entry.pair == NO_HIGHLIGHT_PAIR {
+                continue;
+            }
             let pair = entry.pair.min(region.num_refine_pairs().saturating_sub(1));
             let Some((left, right)) = conflict_pair_sections(region, pair) else {
                 continue;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -15,8 +15,8 @@ use crate::{
 
 use helix_core::{
     conflict::{
-        conflict_at, conflict_marker_lines, conflict_pair_sections, conflict_refine_pair,
-        find_conflicts, refine_diff,
+        conflict_marker_lines, conflict_pair_sections, conflict_refine_pair, find_conflicts,
+        refine_diff,
     },
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
@@ -706,27 +706,38 @@ impl EditorView {
             .or_else(|| theme.find_highlight("diff.plus"))?;
 
         let text = doc.text();
-        let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
+        let view_offset = doc.view_offset(view.id);
+        let inner = view.inner_area(doc);
+        let first_line = text.char_to_line(view_offset.anchor.min(text.len_chars()));
+        let last_line = first_line + inner.height as usize;
+
         let conflicts = find_conflicts(text);
-        let idx = conflict_at(&conflicts, cursor)?;
-        let region = &conflicts[idx];
 
-        let pair = conflict_refine_pair(&doc.conflict_refine_state, region);
-        let (left, right) = conflict_pair_sections(region, pair)?;
+        // Accumulate word-diff spans for every conflict visible in the viewport.
+        let mut spans: Vec<(syntax::Highlight, ops::Range<usize>)> = Vec::new();
+        for region in &conflicts {
+            let region_first_line = text.char_to_line(region.start);
+            let region_last_line = text.char_to_line(region.end);
+            if region_last_line < first_line || region_first_line > last_line {
+                continue;
+            }
 
-        let (removed, added) = refine_diff(text, left, right);
-        if removed.is_empty() && added.is_empty() {
+            let pair = conflict_refine_pair(&doc.conflict_refine_state, region);
+            let Some((left, right)) = conflict_pair_sections(region, pair) else {
+                continue;
+            };
+
+            let (removed, added) = refine_diff(text, left, right);
+            spans.extend(removed.into_iter().map(|r| (removed_hl, r)));
+            spans.extend(added.into_iter().map(|r| (added_hl, r)));
+        }
+
+        if spans.is_empty() {
             return None;
         }
 
-        // Merge removed and added into a single heterogeneous span list,
-        // sorted by start position (they belong to disjoint sections of the
-        // document so they can never overlap).
-        let mut spans: Vec<(syntax::Highlight, ops::Range<usize>)> = removed
-            .into_iter()
-            .map(|r| (removed_hl, r))
-            .chain(added.into_iter().map(|r| (added_hl, r)))
-            .collect();
+        // Sort by start position — regions are disjoint so spans from different
+        // conflicts never overlap, but we need a consistent order for rendering.
         spans.sort_unstable_by_key(|(_, r)| r.start);
 
         Some(OverlayHighlights::Heterogenous { highlights: spans })

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -14,6 +14,9 @@ use crate::{
 };
 
 use helix_core::{
+    conflict::{
+        conflict_at, conflict_pair_sections, conflict_refine_pair, find_conflicts, refine_diff,
+    },
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
@@ -144,6 +147,10 @@ impl EditorView {
         }
 
         Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
+
+        if let Some(overlay) = Self::doc_conflict_refine_highlights(doc, view, theme) {
+            overlays.push(overlay);
+        }
 
         if is_focused {
             if config.lsp.auto_document_highlight {
@@ -657,6 +664,49 @@ impl EditorView {
             ranges.extend(tabstop.ranges.iter().map(|range| range.start..range.end));
         }
         Some(OverlayHighlights::Homogeneous { highlight, ranges })
+    }
+
+    /// Word-level diff highlights for the conflict region the cursor is in.
+    ///
+    /// Returns `None` when the cursor is not inside a conflict, when there are
+    /// no differing tokens, or when the required theme scopes are absent.
+    pub fn doc_conflict_refine_highlights(
+        doc: &Document,
+        view: &View,
+        theme: &Theme,
+    ) -> Option<OverlayHighlights> {
+        let removed_hl = theme
+            .find_highlight("diff.conflict.removed")
+            .or_else(|| theme.find_highlight("diff.minus"))?;
+        let added_hl = theme
+            .find_highlight("diff.conflict.added")
+            .or_else(|| theme.find_highlight("diff.plus"))?;
+
+        let text = doc.text();
+        let cursor = doc.selection(view.id).primary().cursor(text.slice(..));
+        let conflicts = find_conflicts(text);
+        let idx = conflict_at(&conflicts, cursor)?;
+        let region = &conflicts[idx];
+
+        let pair = conflict_refine_pair(&doc.conflict_refine_state, region);
+        let (left, right) = conflict_pair_sections(region, pair)?;
+
+        let (removed, added) = refine_diff(text, left, right);
+        if removed.is_empty() && added.is_empty() {
+            return None;
+        }
+
+        // Merge removed and added into a single heterogeneous span list,
+        // sorted by start position (they belong to disjoint sections of the
+        // document so they can never overlap).
+        let mut spans: Vec<(syntax::Highlight, ops::Range<usize>)> = removed
+            .into_iter()
+            .map(|r| (removed_hl, r))
+            .chain(added.into_iter().map(|r| (added_hl, r)))
+            .collect();
+        spans.sort_unstable_by_key(|(_, r)| r.start);
+
+        Some(OverlayHighlights::Heterogenous { highlights: spans })
     }
 
     /// Render bufferline at the top

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use helix_core::{
     conflict::{
-        conflict_marker_lines, conflict_pair_sections, refine_diff, ConflictRegion,
+        conflict_marker_lines, conflict_pair_sections, refine_diff, ConflictRegion, SectionKind,
         NO_HIGHLIGHT_PAIR,
     },
     diagnostic::NumberOrString,
@@ -734,10 +734,18 @@ impl EditorView {
                 continue;
             };
 
+            // For side↔side pairs (no Base involved) both sides are
+            // "added" — neither is conceptually "removed" in a conflict.
+            let is_side_side = region.refine_pair_indices(pair).is_some_and(|(i, j)| {
+                region.sections[i].kind == SectionKind::Side
+                    && region.sections[j].kind == SectionKind::Side
+            });
+            let left_hl = if is_side_side { added_hl } else { removed_hl };
+
             let (removed, added) = entry
                 .diffs
                 .get_or_insert_with(|| refine_diff(text, left, right));
-            spans.extend(removed.iter().map(|r| (removed_hl, r.clone())));
+            spans.extend(removed.iter().map(|r| (left_hl, r.clone())));
             spans.extend(added.iter().map(|r| (added_hl, r.clone())));
         }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -14,10 +14,7 @@ use crate::{
 };
 
 use helix_core::{
-    conflict::{
-        conflict_marker_lines, conflict_pair_sections, conflict_refine_pair, find_conflicts,
-        refine_diff,
-    },
+    conflict::{conflict_marker_lines, conflict_pair_sections, find_conflicts, refine_diff},
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
@@ -713,6 +710,8 @@ impl EditorView {
 
         let conflicts = find_conflicts(text);
 
+        let mut cache = doc.conflict_refine.borrow_mut();
+
         // Accumulate word-diff spans for every conflict visible in the viewport.
         let mut spans: Vec<(syntax::Highlight, ops::Range<usize>)> = Vec::new();
         for region in &conflicts {
@@ -722,14 +721,17 @@ impl EditorView {
                 continue;
             }
 
-            let pair = conflict_refine_pair(&doc.conflict_refine_state, region);
+            let entry = cache.entry(region.start).or_default();
+            let pair = entry.pair.min(region.num_refine_pairs().saturating_sub(1));
             let Some((left, right)) = conflict_pair_sections(region, pair) else {
                 continue;
             };
 
-            let (removed, added) = refine_diff(text, left, right);
-            spans.extend(removed.into_iter().map(|r| (removed_hl, r)));
-            spans.extend(added.into_iter().map(|r| (added_hl, r)));
+            let (removed, added) = entry
+                .diffs
+                .get_or_insert_with(|| refine_diff(text, left, right));
+            spans.extend(removed.iter().map(|r| (removed_hl, r.clone())));
+            spans.extend(added.iter().map(|r| (added_hl, r.clone())));
         }
 
         if spans.is_empty() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -405,7 +405,19 @@ impl EditorView {
             }
         };
 
+        let conflicts = helix_core::conflict::find_conflicts(doc.text());
+
         for diagnostic in doc.diagnostics() {
+            // Skip diagnostics that overlap any conflict region. The LSP sees
+            // conflict markers as broken code and produces spurious diagnostics
+            // that are distracting and meaningless to the user.
+            if conflicts
+                .iter()
+                .any(|c| diagnostic.range.start < c.end && diagnostic.range.end > c.start)
+            {
+                continue;
+            }
+
             // Separate diagnostics into different Vecs by severity.
             let vec = match diagnostic.severity {
                 Some(Severity::Info) => &mut info_vec,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 use helix_core::{
-    conflict::{conflict_marker_lines, conflict_pair_sections, find_conflicts, refine_diff},
+    conflict::{conflict_marker_lines, conflict_pair_sections, refine_diff, ConflictRegion},
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
     movement::Direction,
@@ -95,12 +95,15 @@ impl EditorView {
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
 
+        // Parse conflicts once — all consumers reuse these results.
+        let conflicts = doc.conflicts();
+
         // Conflict section/marker backgrounds — registered first so they have
         // the lowest priority and are overwritten by cursorline and DAP highlights.
-        if let Some(deco) = Self::conflict_section_line_deco(doc, view, theme) {
+        if let Some(deco) = Self::conflict_section_line_deco(doc, view, theme, conflicts) {
             decorations.add_decoration(deco);
         }
-        if let Some(deco) = Self::conflict_marker_line_deco(doc, view, theme) {
+        if let Some(deco) = Self::conflict_marker_line_deco(doc, view, theme, conflicts) {
             decorations.add_decoration(deco);
         }
 
@@ -153,9 +156,9 @@ impl EditorView {
             overlays.push(overlay);
         }
 
-        Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays);
+        Self::doc_diagnostics_highlights_into(doc, theme, &mut overlays, conflicts);
 
-        if let Some(overlay) = Self::doc_conflict_refine_highlights(doc, view, theme) {
+        if let Some(overlay) = Self::doc_conflict_refine_highlights(doc, view, theme, conflicts) {
             overlays.push(overlay);
         }
 
@@ -366,6 +369,7 @@ impl EditorView {
         doc: &Document,
         theme: &Theme,
         overlay_highlights: &mut Vec<OverlayHighlights>,
+        conflicts: &[ConflictRegion],
     ) {
         // Skip redundant work if no diagnostics.
         if doc.diagnostics().is_empty() {
@@ -412,8 +416,6 @@ impl EditorView {
                 _ => vec.push(range.start..range.end),
             }
         };
-
-        let conflicts = helix_core::conflict::find_conflicts(doc.text());
 
         for diagnostic in doc.diagnostics() {
             // Skip diagnostics that overlap any conflict region. The LSP sees
@@ -694,6 +696,7 @@ impl EditorView {
         doc: &Document,
         view: &View,
         theme: &Theme,
+        conflicts: &[ConflictRegion],
     ) -> Option<OverlayHighlights> {
         let removed_hl = theme
             .find_highlight("diff.conflict.removed")
@@ -708,13 +711,11 @@ impl EditorView {
         let first_line = text.char_to_line(view_offset.anchor.min(text.len_chars()));
         let last_line = first_line + inner.height as usize;
 
-        let conflicts = find_conflicts(text);
-
-        let mut cache = doc.conflict_refine.borrow_mut();
+        let mut cache = doc.conflict_cache.borrow_mut();
 
         // Accumulate word-diff spans for every conflict visible in the viewport.
         let mut spans: Vec<(syntax::Highlight, ops::Range<usize>)> = Vec::new();
-        for region in &conflicts {
+        for region in conflicts {
             let region_first_line = text.char_to_line(region.start);
             let region_last_line = text.char_to_line(region.end);
             if region_last_line < first_line || region_first_line > last_line {
@@ -757,6 +758,7 @@ impl EditorView {
         doc: &Document,
         view: &View,
         theme: &Theme,
+        conflicts: &[ConflictRegion],
     ) -> Option<impl Decoration + 'a> {
         let styles = [
             theme.try_get("diff.conflict.current"),
@@ -768,7 +770,7 @@ impl EditorView {
         }
         let text = doc.text();
         // Collect (line_start, line_end_excl, slot) for every section content range.
-        let ranges: Vec<(usize, usize, usize)> = find_conflicts(text)
+        let ranges: Vec<(usize, usize, usize)> = conflicts
             .iter()
             .flat_map(|region| {
                 region.sections.iter().enumerate().map(|(i, s)| {
@@ -810,9 +812,10 @@ impl EditorView {
         doc: &Document,
         view: &View,
         theme: &Theme,
+        conflicts: &[ConflictRegion],
     ) -> Option<impl Decoration + 'a> {
         let style = theme.try_get("diff.conflict.marker")?;
-        let lines = conflict_marker_lines(doc.text());
+        let lines = conflict_marker_lines(conflicts, doc.text());
         let inner = view.inner_area(doc);
         Some(move |renderer: &mut TextRenderer, pos: LinePos| {
             if lines.binary_search(&pos.doc_line).is_ok() {

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -15,7 +15,8 @@ use crate::{
 
 use helix_core::{
     conflict::{
-        conflict_at, conflict_pair_sections, conflict_refine_pair, find_conflicts, refine_diff,
+        conflict_at, conflict_marker_lines, conflict_pair_sections, conflict_refine_pair,
+        find_conflicts, refine_diff,
     },
     diagnostic::NumberOrString,
     graphemes::{next_grapheme_boundary, prev_grapheme_boundary},
@@ -96,6 +97,15 @@ impl EditorView {
 
         let text_annotations = view.text_annotations(doc, Some(theme));
         let mut decorations = DecorationManager::default();
+
+        // Conflict section/marker backgrounds — registered first so they have
+        // the lowest priority and are overwritten by cursorline and DAP highlights.
+        if let Some(deco) = Self::conflict_section_line_deco(doc, view, theme) {
+            decorations.add_decoration(deco);
+        }
+        if let Some(deco) = Self::conflict_marker_line_deco(doc, view, theme) {
+            decorations.add_decoration(deco);
+        }
 
         if is_focused && config.cursorline {
             decorations.add_decoration(Self::cursorline(doc, view, theme));
@@ -187,8 +197,6 @@ impl EditorView {
             );
         }
 
-        Self::render_rulers(editor, doc, view, inner, surface, theme);
-
         let primary_cursor = doc
             .selection(view.id)
             .primary()
@@ -223,6 +231,9 @@ impl EditorView {
             theme,
             decorations,
         );
+        // Rulers are painted after render_document so they always appear on top
+        // of decoration backgrounds (conflict sections, cursorline, etc.).
+        Self::render_rulers(editor, doc, view, inner, surface, theme);
 
         // if we're not at the edge of the screen, draw a right border
         if viewport.right() != view.area.right() {
@@ -721,7 +732,82 @@ impl EditorView {
         Some(OverlayHighlights::Heterogenous { highlights: spans })
     }
 
-    /// Render bufferline at the top
+    /// Returns a decoration that paints per-section background colors across
+    /// every line of each conflict section:
+    ///   - `diff.conflict.current`  — section index % 3 == 0 (ours / first side)
+    ///   - `diff.conflict.base`     — section index % 3 == 1 (common base)
+    ///   - `diff.conflict.incoming` — section index % 3 == 2 (theirs / last side)
+    ///
+    /// For jj N-way conflicts the colors cycle through the three slots by section
+    /// index.  Returns `None` if none of the three scopes are defined in the theme.
+    pub fn conflict_section_line_deco<'a>(
+        doc: &Document,
+        view: &View,
+        theme: &Theme,
+    ) -> Option<impl Decoration + 'a> {
+        let styles = [
+            theme.try_get("diff.conflict.current"),
+            theme.try_get("diff.conflict.base"),
+            theme.try_get("diff.conflict.incoming"),
+        ];
+        if styles.iter().all(|s| s.is_none()) {
+            return None;
+        }
+        let text = doc.text();
+        // Collect (line_start, line_end_excl, slot) for every section content range.
+        let ranges: Vec<(usize, usize, usize)> = find_conflicts(text)
+            .iter()
+            .flat_map(|region| {
+                region.sections.iter().enumerate().map(|(i, s)| {
+                    let l0 = text.char_to_line(s.content_start);
+                    let l1 = text.char_to_line(s.content_end);
+                    let slot = match s.kind {
+                        helix_core::conflict::SectionKind::Base => 1,
+                        helix_core::conflict::SectionKind::Side => {
+                            let side_idx = region.sections[..i]
+                                .iter()
+                                .filter(|s| s.kind == helix_core::conflict::SectionKind::Side)
+                                .count();
+                            if side_idx % 2 == 0 {
+                                0
+                            } else {
+                                2
+                            }
+                        }
+                    };
+                    (l0, l1, slot)
+                })
+            })
+            .collect();
+        let inner = view.inner_area(doc);
+        Some(move |renderer: &mut TextRenderer, pos: LinePos| {
+            for &(l0, l1, slot) in &ranges {
+                if pos.doc_line >= l0 && pos.doc_line < l1 {
+                    if let Some(style) = styles[slot] {
+                        renderer
+                            .set_style(Rect::new(inner.x, pos.visual_line, inner.width, 1), style);
+                    }
+                    break;
+                }
+            }
+        })
+    }
+
+    pub fn conflict_marker_line_deco<'a>(
+        doc: &Document,
+        view: &View,
+        theme: &Theme,
+    ) -> Option<impl Decoration + 'a> {
+        let style = theme.try_get("diff.conflict.marker")?;
+        let lines = conflict_marker_lines(doc.text());
+        let inner = view.inner_area(doc);
+        Some(move |renderer: &mut TextRenderer, pos: LinePos| {
+            if lines.binary_search(&pos.doc_line).is_ok() {
+                renderer.set_style(Rect::new(inner.x, pos.visual_line, inner.width, 1), style);
+            }
+        })
+    }
+
     pub fn render_bufferline(editor: &Editor, viewport: Rect, surface: &mut Surface) {
         let scratch = PathBuf::from(SCRATCH_BUFFER_NAME); // default filename to use for scratch buffer
         surface.clear_with(

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -979,10 +979,12 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 }
             }
 
+            let conflicts = doc.conflicts();
             EditorView::doc_diagnostics_highlights_into(
                 doc,
                 &cx.editor.theme,
                 &mut overlay_highlights,
+                conflicts,
             );
 
             let mut decorations = DecorationManager::default();

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -2,6 +2,7 @@ use helix_term::application::Application;
 
 use super::*;
 
+mod conflicts;
 mod insert;
 mod movement;
 mod reverse_selection_contents;

--- a/helix-term/tests/test/commands/conflicts.rs
+++ b/helix-term/tests/test/commands/conflicts.rs
@@ -274,6 +274,220 @@ async fn accept_current_cursor_outside_conflict() -> anyhow::Result<()> {
     Ok(())
 }
 
+// ─── accept_change_at_cursor (<space>xx) ──────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_on_current_marker() -> anyhow::Result<()> {
+    // Cursor on <<<<<<< line → accepts current
+    test((
+        indoc::indoc! {"\
+            before
+            #[<|]#<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[o|]#urs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_in_current_content() -> anyhow::Result<()> {
+    // Cursor in ours content → accepts current
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            #[o|]#urs line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[o|]#urs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_on_separator() -> anyhow::Result<()> {
+    // Cursor on ======= line → no-op
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            ours line
+            #[=|]#======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            ours line
+            #[=|]#======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_in_incoming_content() -> anyhow::Result<()> {
+    // Cursor in theirs content → accepts incoming
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            ours line
+            =======
+            #[t|]#heirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[t|]#heirs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_on_incoming_marker() -> anyhow::Result<()> {
+    // Cursor on >>>>>>> line → accepts incoming
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            #[>|]#>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[t|]#heirs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_on_base_marker() -> anyhow::Result<()> {
+    // Cursor on ||||||| line → accepts base
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            ours line
+            #[||]#|||||| base
+            base line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[b|]#ase line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_in_base_content() -> anyhow::Result<()> {
+    // Cursor in base content → accepts base
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            ours line
+            ||||||| base
+            #[b|]#ase line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[b|]#ase line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_outside_conflict() -> anyhow::Result<()> {
+    // Cursor outside any conflict → no-op
+    test((
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn goto_prev_conflict_from_after() -> anyhow::Result<()> {
     // Cursor after the conflict → jumps to the <<<<<<< line
@@ -393,6 +607,277 @@ async fn goto_prev_conflict_before_first() -> anyhow::Result<()> {
             =======
             theirs
             >>>>>>> branch
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+// ─── jj snapshot format: resolution commands ──────────────────────────────────
+//
+// jj conflicts look like:
+//
+//   <<<<<<< Conflict 1 of 1
+//   +++++++ side #1
+//   s1
+//   ------- base
+//   base
+//   +++++++ side #2
+//   s2
+//   >>>>>>> Conflict 1 of 1 ends
+//
+// Sections (0-indexed): 0=Side(s1), 1=Base(base), 2=Side(s2)
+// accept_current  → first Side → s1
+// accept_incoming → last  Side → s2
+// accept_base     → first Base → base
+// accept_all      → all  Sides → s1 + s2
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_current_jj() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            #[s|]#1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xc",
+        indoc::indoc! {"\
+            before
+            #[s|]#1
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_incoming_jj() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            #[s|]#1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xi",
+        indoc::indoc! {"\
+            before
+            #[s|]#2
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_base_jj() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            #[s|]#1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xb",
+        indoc::indoc! {"\
+            before
+            #[b|]#ase
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_all_jj() -> anyhow::Result<()> {
+    // accept_all concatenates all Side sections (skips Base)
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            #[s|]#1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xa",
+        indoc::indoc! {"\
+            before
+            #[s|]#1
+            s2
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+// ─── jj snapshot format: accept_change_at_cursor (<space>xx) ──────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_jj_first_side_marker() -> anyhow::Result<()> {
+    // Cursor on first +++++++ line → accepts that side (section 0)
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            #[+|]#++++++ side #1
+            s1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[s|]#1
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_jj_first_side_content() -> anyhow::Result<()> {
+    // Cursor in first side content → accepts section 0
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            #[s|]#1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[s|]#1
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_jj_base_marker() -> anyhow::Result<()> {
+    // Cursor on ------- line → accepts base section
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            s1
+            #[-|]#------ base
+            base
+            +++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[b|]#ase
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_jj_second_side_marker() -> anyhow::Result<()> {
+    // Cursor on second +++++++ line → accepts that side (section 2)
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            s1
+            ------- base
+            base
+            #[+|]#++++++ side #2
+            s2
+            >>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[s|]#2
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_at_cursor_jj_close_marker() -> anyhow::Result<()> {
+    // Cursor on >>>>>>> line → accepts last section (section 2, the last Side)
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< Conflict 1 of 1
+            +++++++ side #1
+            s1
+            ------- base
+            base
+            +++++++ side #2
+            s2
+            #[>|]#>>>>>> Conflict 1 of 1 ends
+            after
+        "},
+        "<space>xx",
+        indoc::indoc! {"\
+            before
+            #[s|]#2
+            after
         "},
     ))
     .await?;

--- a/helix-term/tests/test/commands/conflicts.rs
+++ b/helix-term/tests/test/commands/conflicts.rs
@@ -144,7 +144,135 @@ async fn goto_next_conflict_count() -> anyhow::Result<()> {
     Ok(())
 }
 
-// ─── goto_prev_conflict ([X) ──────────────────────────────────────────────────
+// ─── Resolution commands (<space>x{c,i,b,a}) ─────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_current_two_way() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            #[o|]#urs line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xc",
+        indoc::indoc! {"\
+            before
+            #[o|]#urs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_incoming_two_way() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            #[o|]#urs line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xi",
+        indoc::indoc! {"\
+            before
+            #[t|]#heirs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_all_two_way() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            #[o|]#urs line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xa",
+        indoc::indoc! {"\
+            before
+            #[o|]#urs line
+            theirs line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_base_three_way() -> anyhow::Result<()> {
+    test((
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            #[o|]#urs line
+            ||||||| base
+            base line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xb",
+        indoc::indoc! {"\
+            before
+            #[b|]#ase line
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn accept_current_cursor_outside_conflict() -> anyhow::Result<()> {
+    // Cursor outside any conflict → no change
+    test((
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+        "<space>xc",
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours line
+            =======
+            theirs line
+            >>>>>>> branch
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn goto_prev_conflict_from_after() -> anyhow::Result<()> {

--- a/helix-term/tests/test/commands/conflicts.rs
+++ b/helix-term/tests/test/commands/conflicts.rs
@@ -1,0 +1,309 @@
+use super::*;
+
+// ─── goto_next_conflict (]X) ──────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_next_conflict_from_before() -> anyhow::Result<()> {
+    // Cursor before the conflict → jumps to the <<<<<<< line
+    // Note: #[<|]# selects the first '<', so the remaining text on that line
+    // must be "<<<<<< HEAD" (6 '<') to produce "<<<<<<< HEAD" (7 '<') total.
+    test((
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            after
+        "},
+        "]=",
+        indoc::indoc! {"\
+            before
+            #[<|]#<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_next_conflict_from_inside() -> anyhow::Result<()> {
+    // Cursor inside the first conflict → jumps to the second conflict
+    test((
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            #[o|]#urs
+            =======
+            theirs
+            >>>>>>> branch
+            <<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "},
+        "]=",
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            #[<|]#<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_next_conflict_no_conflict() -> anyhow::Result<()> {
+    // No conflict markers → cursor stays put
+    test(("#[h|]#ello\nworld\n", "]=", "#[h|]#ello\nworld\n")).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_next_conflict_after_last() -> anyhow::Result<()> {
+    // Cursor after the last conflict → no movement
+    test((
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            #[a|]#fter
+        "},
+        "]=",
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            #[a|]#fter
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_next_conflict_count() -> anyhow::Result<()> {
+    // 2]X skips two conflicts at once
+    test((
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            a
+            =======
+            b
+            >>>>>>> branch
+            between
+            <<<<<<< HEAD
+            c
+            =======
+            d
+            >>>>>>> branch
+            after
+        "},
+        "2]=",
+        indoc::indoc! {"\
+            before
+            <<<<<<< HEAD
+            a
+            =======
+            b
+            >>>>>>> branch
+            between
+            #[<|]#<<<<<< HEAD
+            c
+            =======
+            d
+            >>>>>>> branch
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+// ─── goto_prev_conflict ([X) ──────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_prev_conflict_from_after() -> anyhow::Result<()> {
+    // Cursor after the conflict → jumps to the <<<<<<< line
+    test((
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            #[a|]#fter
+        "},
+        "[=",
+        indoc::indoc! {"\
+            #[<|]#<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_prev_conflict_from_inside() -> anyhow::Result<()> {
+    // Cursor inside the second conflict (past its <<<<<<< line) → jumps to that
+    // conflict's own start (so navigation lands on its <<<<<<< line)
+    test((
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            <<<<<<< HEAD
+            #[o|]#urs2
+            =======
+            theirs2
+            >>>>>>> branch
+        "},
+        "[=",
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            #[<|]#<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_prev_conflict_on_marker_line() -> anyhow::Result<()> {
+    // Cursor exactly on the <<<<<<< line of the second conflict → jumps to the
+    // first conflict (since prev_conflict uses strict-less-than on start)
+    test((
+        indoc::indoc! {"\
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            #[<|]#<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "},
+        "[=",
+        indoc::indoc! {"\
+            #[<|]#<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+            <<<<<<< HEAD
+            ours2
+            =======
+            theirs2
+            >>>>>>> branch
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_prev_conflict_before_first() -> anyhow::Result<()> {
+    // Cursor before any conflict → no movement
+    test((
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+        "},
+        "[=",
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< HEAD
+            ours
+            =======
+            theirs
+            >>>>>>> branch
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}
+
+// ─── jj-style markers ─────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn goto_conflict_jj_style() -> anyhow::Result<()> {
+    // jj-style markers have change IDs and commit messages as labels on every
+    // marker line; navigation should work identically
+    test((
+        indoc::indoc! {"\
+            #[b|]#efore
+            <<<<<<< ouyysnvk c9a24f82 \"first version\"
+            1st version
+            ||||||| zxwrknxy 62f152a0 \"base\"
+            original
+            =======
+            2nd version
+            >>>>>>> kyqztmxm cf165681 \"second version\"
+            after
+        "},
+        "]=",
+        indoc::indoc! {"\
+            before
+            #[<|]#<<<<<< ouyysnvk c9a24f82 \"first version\"
+            1st version
+            ||||||| zxwrknxy 62f152a0 \"base\"
+            original
+            =======
+            2nd version
+            >>>>>>> kyqztmxm cf165681 \"second version\"
+            after
+        "},
+    ))
+    .await?;
+
+    Ok(())
+}

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -1,4 +1,4 @@
-use helix_core::conflict::{find_conflicts, ConflictRegion};
+use helix_core::conflict::ConflictRegion;
 use helix_core::diagnostic::Severity;
 use helix_core::doc_formatter::{FormattedGrapheme, TextFormat};
 use helix_core::text_annotations::LineAnnotation;
@@ -134,7 +134,7 @@ pub struct InlineDiagnosticAccumulator<'a> {
 
 impl<'a> InlineDiagnosticAccumulator<'a> {
     pub fn new(cursor: usize, doc: &'a Document, config: InlineDiagnosticsConfig) -> Self {
-        let conflicts = find_conflicts(doc.text());
+        let conflicts = doc.conflicts().to_vec();
         InlineDiagnosticAccumulator {
             idx: 0,
             doc,

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -1,3 +1,4 @@
+use helix_core::conflict::{find_conflicts, ConflictRegion};
 use helix_core::diagnostic::Severity;
 use helix_core::doc_formatter::{FormattedGrapheme, TextFormat};
 use helix_core::text_annotations::LineAnnotation;
@@ -126,10 +127,14 @@ pub struct InlineDiagnosticAccumulator<'a> {
     pub config: InlineDiagnosticsConfig,
     cursor: usize,
     cursor_line: bool,
+    /// Conflict regions in the document, pre-computed to suppress diagnostics
+    /// that fall inside a conflict block.
+    conflicts: Vec<ConflictRegion>,
 }
 
 impl<'a> InlineDiagnosticAccumulator<'a> {
     pub fn new(cursor: usize, doc: &'a Document, config: InlineDiagnosticsConfig) -> Self {
+        let conflicts = find_conflicts(doc.text());
         InlineDiagnosticAccumulator {
             idx: 0,
             doc,
@@ -137,6 +142,7 @@ impl<'a> InlineDiagnosticAccumulator<'a> {
             config,
             cursor,
             cursor_line: false,
+            conflicts,
         }
     }
 
@@ -202,6 +208,15 @@ impl<'a> InlineDiagnosticAccumulator<'a> {
         for diag in &self.doc.diagnostics[self.idx..] {
             if diag.range.start != grapheme.char_idx {
                 break;
+            }
+            // Skip diagnostics that overlap any conflict region.
+            if self
+                .conflicts
+                .iter()
+                .any(|c| diag.range.start < c.end && diag.range.end > c.start)
+            {
+                self.idx += 1;
+                continue;
             }
             self.stack.push((diag, anchor_col as u16));
             self.idx += 1;

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -225,6 +225,15 @@ pub struct Document {
     // of storing a copy on every doc. Then we can remove the surrounding `Arc` and use the
     // `ArcSwap` directly.
     syn_loader: Arc<ArcSwap<syntax::Loader>>,
+
+    /// Per-conflict refine pair state.
+    ///
+    /// Maps `ConflictRegion::start` (char position) to a pair index.
+    /// Defaults to 0 (first pair). N-way conflicts have C(n,2) pairs total.
+    ///
+    /// Entries become stale when the document is edited before the conflict,
+    /// causing a graceful reset to pair 0 (same behavior as smerge).
+    pub conflict_refine_state: HashMap<usize, usize>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -764,6 +773,7 @@ impl Document {
             previous_diagnostic_ids: HashMap::new(),
             pull_diagnostic_controller: TaskController::new(),
             document_link_controller: TaskController::new(),
+            conflict_refine_state: HashMap::new(),
         }
     }
 
@@ -1030,7 +1040,9 @@ impl Document {
                     if force {
                         std::fs::DirBuilder::new().recursive(true).create(parent)?;
                     } else {
-                        bail!("can't save file, parent directory does not exist (use :w! to create it)");
+                        bail!(
+                            "can't save file, parent directory does not exist (use :w! to create it)"
+                        );
                     }
                 }
             }
@@ -1244,12 +1256,18 @@ impl Document {
                 Ok(metadata) => match metadata.modified() {
                     Ok(mtime) => mtime,
                     Err(err) => {
-                        log::debug!("Could not fetch file system's mtime, falling back to current system time: {}", err);
+                        log::debug!(
+                            "Could not fetch file system's mtime, falling back to current system time: {}",
+                            err
+                        );
                         SystemTime::now()
                     }
                 },
                 Err(err) => {
-                    log::debug!("Could not fetch file system's mtime, falling back to current system time: {}", err);
+                    log::debug!(
+                        "Could not fetch file system's mtime, falling back to current system time: {}",
+                        err
+                    );
                     SystemTime::now()
                 }
             },

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -34,7 +34,7 @@ use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
 use helix_core::{
-    conflict::{conflict_at, find_conflicts, ConflictRefineEntry},
+    conflict::{conflict_at, find_conflicts, ConflictCache, ConflictRefineEntry, ConflictRegion},
     editor_config::EditorConfig,
     encoding,
     history::{History, State, UndoKind},
@@ -227,12 +227,13 @@ pub struct Document {
     // `ArcSwap` directly.
     syn_loader: Arc<ArcSwap<syntax::Loader>>,
 
-    /// Per-conflict refine cache: pair index + optional word-diff results.
-    ///
-    /// Key: `ConflictRegion::start` (char position).
+    /// Cached conflict regions, eagerly recomputed on every edit.
+    conflict_regions: Vec<ConflictRegion>,
+
+    /// Per-conflict refine state keyed by [`ConflictRegion::start`].
     /// Cleared on every edit; the pair setting is preserved when the cursor
     /// was inside a conflict before the edit.
-    pub conflict_refine: RefCell<HashMap<usize, ConflictRefineEntry>>,
+    pub conflict_cache: RefCell<ConflictCache>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -728,6 +729,7 @@ impl Document {
         let line_ending = config.load().default_line_ending.into();
         let changes = ChangeSet::new(text.slice(..));
         let old_state = None;
+        let conflict_regions = find_conflicts(&text);
 
         Self {
             id: DocumentId::default(),
@@ -772,7 +774,8 @@ impl Document {
             previous_diagnostic_ids: HashMap::new(),
             pull_diagnostic_controller: TaskController::new(),
             document_link_controller: TaskController::new(),
-            conflict_refine: RefCell::new(HashMap::new()),
+            conflict_regions,
+            conflict_cache: RefCell::new(ConflictCache::default()),
         }
     }
 
@@ -1468,7 +1471,7 @@ impl Document {
                 let conflicts = find_conflicts(&old_doc);
                 conflict_at(&conflicts, cursor).map(|idx| conflicts[idx].start)
             })
-            .and_then(|key| self.conflict_refine.borrow().get(&key).map(|e| e.pair));
+            .and_then(|key| self.conflict_cache.borrow().get(&key).map(|e| e.pair));
 
         let changes = transaction.changes();
         if !changes.apply(&mut self.text) {
@@ -1501,19 +1504,21 @@ impl Document {
                 .ensure_invariants(self.text.slice(..));
         }
 
-        // Clear conflict refine cache; preserve cursor's pair if still in a conflict.
-        self.conflict_refine.borrow_mut().clear();
-        if let Some(pair) = saved_pair {
-            let cursor = self
-                .selection(view_id)
-                .primary()
-                .cursor(self.text().slice(..));
-            let conflicts = find_conflicts(self.text());
-            if let Some(idx) = conflict_at(&conflicts, cursor) {
-                self.conflict_refine
-                    .borrow_mut()
-                    .entry(conflicts[idx].start)
-                    .or_insert_with(|| ConflictRefineEntry { pair, diffs: None });
+        // Eagerly recompute conflict regions; clear refine cache.
+        self.conflict_regions = find_conflicts(self.text());
+        {
+            let mut cache = self.conflict_cache.borrow_mut();
+            cache.clear();
+            if let Some(pair) = saved_pair {
+                let cursor = self
+                    .selection(view_id)
+                    .primary()
+                    .cursor(self.text().slice(..));
+                if let Some(idx) = conflict_at(&self.conflict_regions, cursor) {
+                    cache
+                        .entry(self.conflict_regions[idx].start)
+                        .or_insert_with(|| ConflictRefineEntry { pair, diffs: None });
+                }
             }
         }
 
@@ -2094,6 +2099,12 @@ impl Document {
     #[inline]
     pub fn text(&self) -> &Rope {
         &self.text
+    }
+
+    /// Returns eagerly-computed conflict regions, re-computed on
+    /// every document edit.
+    pub fn conflicts(&self) -> &[ConflictRegion] {
+        &self.conflict_regions
     }
 
     #[inline]

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -23,7 +23,7 @@ use ::parking_lot::Mutex;
 use serde::de::{self, Deserialize, Deserializer};
 use serde::Serialize;
 use std::borrow::Cow;
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::future::Future;
@@ -34,6 +34,7 @@ use std::sync::{Arc, Weak};
 use std::time::SystemTime;
 
 use helix_core::{
+    conflict::{conflict_at, find_conflicts, ConflictRefineEntry},
     editor_config::EditorConfig,
     encoding,
     history::{History, State, UndoKind},
@@ -226,14 +227,12 @@ pub struct Document {
     // `ArcSwap` directly.
     syn_loader: Arc<ArcSwap<syntax::Loader>>,
 
-    /// Per-conflict refine pair state.
+    /// Per-conflict refine cache: pair index + optional word-diff results.
     ///
-    /// Maps `ConflictRegion::start` (char position) to a pair index.
-    /// Defaults to 0 (first pair). N-way conflicts have C(n,2) pairs total.
-    ///
-    /// Entries become stale when the document is edited before the conflict,
-    /// causing a graceful reset to pair 0 (same behavior as smerge).
-    pub conflict_refine_state: HashMap<usize, usize>,
+    /// Key: `ConflictRegion::start` (char position).
+    /// Cleared on every edit; the pair setting is preserved when the cursor
+    /// was inside a conflict before the edit.
+    pub conflict_refine: RefCell<HashMap<usize, ConflictRefineEntry>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -773,7 +772,7 @@ impl Document {
             previous_diagnostic_ids: HashMap::new(),
             pull_diagnostic_controller: TaskController::new(),
             document_link_controller: TaskController::new(),
-            conflict_refine_state: HashMap::new(),
+            conflict_refine: RefCell::new(HashMap::new()),
         }
     }
 
@@ -1459,6 +1458,18 @@ impl Document {
         use helix_core::Assoc;
 
         let old_doc = self.text().clone();
+
+        // Save refine pair for the cursor's conflict before the edit.
+        let saved_pair = self
+            .selections
+            .get(&view_id)
+            .and_then(|sel| {
+                let cursor = sel.primary().cursor(old_doc.slice(..));
+                let conflicts = find_conflicts(&old_doc);
+                conflict_at(&conflicts, cursor).map(|idx| conflicts[idx].start)
+            })
+            .and_then(|key| self.conflict_refine.borrow().get(&key).map(|e| e.pair));
+
         let changes = transaction.changes();
         if !changes.apply(&mut self.text) {
             return false;
@@ -1488,6 +1499,22 @@ impl Document {
                 .map(transaction.changes())
                 // Ensure all selections across all views still adhere to invariants.
                 .ensure_invariants(self.text.slice(..));
+        }
+
+        // Clear conflict refine cache; preserve cursor's pair if still in a conflict.
+        self.conflict_refine.borrow_mut().clear();
+        if let Some(pair) = saved_pair {
+            let cursor = self
+                .selection(view_id)
+                .primary()
+                .cursor(self.text().slice(..));
+            let conflicts = find_conflicts(self.text());
+            if let Some(idx) = conflict_at(&conflicts, cursor) {
+                self.conflict_refine
+                    .borrow_mut()
+                    .entry(conflicts[idx].start)
+                    .or_insert_with(|| ConflictRefineEntry { pair, diffs: None });
+            }
         }
 
         for view_data in self.view_data.values_mut() {

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -48,6 +48,8 @@
 "diff.plus" = "base0B"
 "diff.delta" = "base09"
 "diff.minus" = "base08"
+"diff.conflict.removed" = { bg = "#3d2020" }
+"diff.conflict.added"   = { bg = "#1e3020" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 "ui.gutter" = { bg = "base01" }

--- a/runtime/themes/base16_default_dark.toml
+++ b/runtime/themes/base16_default_dark.toml
@@ -48,8 +48,12 @@
 "diff.plus" = "base0B"
 "diff.delta" = "base09"
 "diff.minus" = "base08"
-"diff.conflict.removed" = { bg = "#3d2020" }
-"diff.conflict.added"   = { bg = "#1e3020" }
+"diff.conflict.removed"  = { bg = "#3d2020" }
+"diff.conflict.added"    = { bg = "#1e3020" }
+"diff.conflict.marker"   = { bg = "#202020" }
+"diff.conflict.current"  = { bg = "#1c1c22" }
+"diff.conflict.base"     = { bg = "#202020" }
+"diff.conflict.incoming" = { bg = "#1c221c" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 "ui.gutter" = { bg = "base01" }

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -48,6 +48,8 @@
 "diff.plus" = "base0B"
 "diff.delta" = "base09"
 "diff.minus" = "base08"
+"diff.conflict.removed" = { bg = "#f2d0d0" }
+"diff.conflict.added"   = { bg = "#d0ead0" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 "ui.gutter" = { bg = "base01" }

--- a/runtime/themes/base16_default_light.toml
+++ b/runtime/themes/base16_default_light.toml
@@ -48,8 +48,12 @@
 "diff.plus" = "base0B"
 "diff.delta" = "base09"
 "diff.minus" = "base08"
-"diff.conflict.removed" = { bg = "#f2d0d0" }
-"diff.conflict.added"   = { bg = "#d0ead0" }
+"diff.conflict.removed"  = { bg = "#f2d0d0" }
+"diff.conflict.added"    = { bg = "#d0ead0" }
+"diff.conflict.marker"   = { bg = "#f0f0f0" }
+"diff.conflict.current"  = { bg = "#f8f0f0" }
+"diff.conflict.base"     = { bg = "#f0f0f0" }
+"diff.conflict.incoming" = { bg = "#f0f8f0" }
 
 "diagnostic" = { modifiers = ["underlined"] }
 "ui.gutter" = { bg = "base01" }

--- a/runtime/themes/base16_terminal.toml
+++ b/runtime/themes/base16_terminal.toml
@@ -45,6 +45,8 @@
 "diff.plus" = "light-green"
 "diff.delta" = "yellow"
 "diff.minus" = "light-red"
+"diff.conflict.removed" = { fg = "light-red", modifiers = ["reversed"] }
+"diff.conflict.added"   = { fg = "light-green", modifiers = ["reversed"] }
 
 "diagnostic" = { modifiers = ["underlined"] }
 "ui.gutter" = { bg = "black" }

--- a/runtime/themes/base16_transparent.toml
+++ b/runtime/themes/base16_transparent.toml
@@ -69,6 +69,8 @@
 "diff.delta" = "light-blue"
 "diff.delta.moved" = "blue"
 "diff.minus" = "light-red"
+"diff.conflict.removed" = { fg = "light-red", modifiers = ["reversed"] }
+"diff.conflict.added"   = { fg = "light-green", modifiers = ["reversed"] }
 
 "ui.gutter" = "gray"
 "info" = "light-blue"

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -57,6 +57,8 @@ variable = { fg = "fg" }
 "diff.delta.moved" = { fg = "blue" }
 "diff.minus" = { fg = "delete" }
 "diff.plus" = { fg = "add" }
+"diff.conflict.removed" = { bg = "#372731" }
+"diff.conflict.added"   = { bg = "#243b47" }
 
 error = { fg = "error" }
 warning = { fg = "yellow" }

--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -57,8 +57,12 @@ variable = { fg = "fg" }
 "diff.delta.moved" = { fg = "blue" }
 "diff.minus" = { fg = "delete" }
 "diff.plus" = { fg = "add" }
-"diff.conflict.removed" = { bg = "#372731" }
-"diff.conflict.added"   = { bg = "#243b47" }
+"diff.conflict.removed"  = { bg = "#662644" }
+"diff.conflict.added"    = { bg = "#005572" }
+"diff.conflict.marker"   = { bg = "#1f242e" }
+"diff.conflict.current"  = { bg = "#092334" }
+"diff.conflict.base"     = { bg = "#1e2025" }
+"diff.conflict.incoming" = { bg = "#142610" }
 
 error = { fg = "error" }
 warning = { fg = "yellow" }

--- a/theme.toml
+++ b/theme.toml
@@ -40,6 +40,10 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 "diff.plus" = "#35bf86"
 "diff.minus" = "#f22c86"
 "diff.delta" = "#6f44f0"
+"diff.conflict.marker"   = { bg = "#463553" }
+"diff.conflict.current"  = { bg = "#442b56" }
+"diff.conflict.base"     = { bg = "#382e40" }
+"diff.conflict.incoming" = { bg = "#382e53" }
 
 # TODO: differentiate doc comment
 # concat (ERROR) @error.syntax and "MISSING ;" selectors for errors


### PR DESCRIPTION

This PR introduces several improvements to the merge conflict resolution experience in Helix, aiming for better visual clarity and a more focused workflow. The changes are partially inspired by Emacs' `smerge-mode`.

* **Visual Separation via Background Colors**
Distinct background styling is now applied to the different sections of a conflict (Current, Base, Incoming) and the conflict markers themselves. This provides immediate visual boundaries, making it easier to parse dense conflict blocks.

* **Diff Highlighting Between Conflict Sides**
To assist in decision-making, the editor can now highlight specific differences between two sides of a conflict. This is a great help in understanding what the actual differences are.

* **LSP Diagnostic Suppression**
LSP diagnostics are now silenced within the bounds of a conflict text block. Because conflict markers often break syntax or create temporary "broken" states, diagnostic noise frequently obscures the code. This change ensures the workspace remains clean while the resolution is in progress.

* **Conflict Navigation & Resolution Keymaps**
Added dedicated keymaps to streamline the resolution process:
  * **Jump:** Quickly move between the next and previous conflict markers.
  * **Accept:** Commands to accept a specific side (or all sides) of the conflict.

<img width="1152" height="870" alt="image" src="https://github.com/user-attachments/assets/7b8034c8-1e17-4f35-88e9-817167f00d8a" />

and for the record, how it looks without this change:


<img width="1141" height="877" alt="before" src="https://github.com/user-attachments/assets/2e4ce9bd-f67a-4627-80f8-a08b8871d593" />
