### PR TITLE
fix: remove view_data in remove_view

### DIFF
--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1424,6 +1424,7 @@ impl Document {
     /// Remove a view's selection and inlay hints from this document.
     pub fn remove_view(&mut self, view_id: ViewId) {
         self.selections.remove(&view_id);
+        self.view_data.remove(&view_id);
         self.inlay_hints.remove(&view_id);
         self.jump_labels.remove(&view_id);
         self.document_highlights.remove(&view_id);


### PR DESCRIPTION
Currently `view_data` continues to grow, even when views are closed which is a memory leak (though probably not that noticeable in practice). Since the `view_data` is also per view, I assume it should also be cleared in the same way as the other fields. 