### PR TITLE
perf: forbid `std::collections::Hash[Map|Set]`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1449,6 +1449,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1478,6 +1480,7 @@ dependencies = [
  "encoding_rs",
  "foldhash 0.2.0",
  "globset",
+ "hashbrown 0.17.1",
  "helix-loader",
  "helix-parsec",
  "helix-stdx",
@@ -1511,6 +1514,7 @@ dependencies = [
  "anyhow",
  "futures-executor",
  "futures-util",
+ "hashbrown 0.17.1",
  "helix-core",
  "helix-dap-types",
  "helix-stdx",
@@ -1528,6 +1532,7 @@ dependencies = [
 name = "helix-dap-types"
 version = "25.7.1"
 dependencies = [
+ "hashbrown 0.17.1",
  "serde",
  "serde_json",
 ]
@@ -1554,6 +1559,7 @@ dependencies = [
  "cc",
  "etcetera",
  "globset",
+ "hashbrown 0.17.1",
  "helix-stdx",
  "log",
  "once_cell",
@@ -1575,6 +1581,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "globset",
+ "hashbrown 0.17.1",
  "helix-core",
  "helix-loader",
  "helix-lsp-types",
@@ -1595,6 +1602,7 @@ name = "helix-lsp-types"
 version = "0.95.1"
 dependencies = [
  "bitflags",
+ "hashbrown 0.17.1",
  "helix-stdx",
  "serde",
  "serde_json",
@@ -1637,6 +1645,7 @@ dependencies = [
  "grep-matcher",
  "grep-regex",
  "grep-searcher",
+ "hashbrown 0.17.1",
  "helix-core",
  "helix-dap",
  "helix-event",
@@ -1679,6 +1688,7 @@ dependencies = [
  "bitflags",
  "cassowary",
  "crossterm",
+ "hashbrown 0.17.1",
  "helix-core",
  "helix-view",
  "log",
@@ -1717,6 +1727,7 @@ dependencies = [
  "crossterm",
  "foldhash 0.2.0",
  "futures-util",
+ "hashbrown 0.17.1",
  "helix-core",
  "helix-dap",
  "helix-event",
@@ -3479,6 +3490,7 @@ dependencies = [
 name = "xtask"
 version = "25.7.1"
 dependencies = [
+ "hashbrown 0.17.1",
  "helix-core",
  "helix-loader",
  "helix-stdx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ globset = "0.4"
 etcetera = "0.11"
 arc-swap = "1.9"
 arrayvec = "0.7"
+hashbrown = { version = "0.17", default-features = false, features = ["default-hasher", "inline-more", "serde"] }
 
 # dev dependencies
 criterion = { version = "0.8", default-features = false, features = ["cargo_bench_support"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-types = [
+    { path = "std::collections::HashMap", reason = "Use hashbrown::HashMap instead for better performance." },
+    { path = "std::collections::HashSet", reason = "Use hashbrown::HashSet instead for better performance." },
+]

--- a/helix-core/Cargo.toml
+++ b/helix-core/Cargo.toml
@@ -38,6 +38,7 @@ arc-swap = "1"
 regex = "1"
 bitflags.workspace = true
 foldhash.workspace = true
+hashbrown.workspace = true
 
 log = "0.4"
 anyhow = "1.0"

--- a/helix-core/src/auto_pairs.rs
+++ b/helix-core/src/auto_pairs.rs
@@ -2,7 +2,7 @@
 //! this module provides the functionality to insert the paired closing character.
 
 use crate::{graphemes, movement::Direction, Change, Deletion, Range, Rope, Tendril};
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 // Heavily based on https://github.com/codemirror/closebrackets/
 pub const DEFAULT_PAIRS: &[(char, char)] = &[

--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -25,7 +25,8 @@
 //! This module also defines structs for configuring the parsing of the command line for a
 //! command. See `Flag` and `Signature`.
 
-use std::{borrow::Cow, collections::HashMap, error::Error, fmt, ops, slice, vec};
+use hashbrown::HashMap;
+use std::{borrow::Cow, error::Error, fmt, ops, slice, vec};
 
 /// Splits a command line into the command and arguments parts.
 ///

--- a/helix-core/src/editor_config.rs
+++ b/helix-core/src/editor_config.rs
@@ -8,8 +8,8 @@
 //! At time of writing, this module follows the [spec](https://spec.editorconfig.org/) at
 //! version 0.17.2.
 
+use hashbrown::HashMap;
 use std::{
-    collections::HashMap,
     fs,
     num::{NonZeroU16, NonZeroU8},
     path::Path,

--- a/helix-core/src/history.rs
+++ b/helix-core/src/history.rs
@@ -1,4 +1,5 @@
 use crate::{Assoc, ChangeSet, Range, Rope, Selection, Transaction};
+use hashbrown::HashSet;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::num::NonZeroUsize;
@@ -181,7 +182,6 @@ impl History {
     }
 
     fn lowest_common_ancestor(&self, mut a: usize, mut b: usize) -> usize {
-        use std::collections::HashSet;
         let mut a_path_set = HashSet::new();
         let mut b_path_set = HashSet::new();
         loop {

--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -1,7 +1,5 @@
-use std::{
-    borrow::Cow,
-    collections::{HashMap, HashSet},
-};
+use hashbrown::{HashMap, HashSet};
+use std::borrow::Cow;
 
 use helix_stdx::rope::RopeSliceExt;
 use tree_house::TREE_SITTER_MATCH_LIMIT;

--- a/helix-core/src/macros.rs
+++ b/helix-core/src/macros.rs
@@ -7,7 +7,7 @@ macro_rules! hashmap {
     ($($key:expr => $value:expr),*) => {
         {
             let _cap = hashmap!(@count $($key),*);
-            let mut _map = ::std::collections::HashMap::with_capacity(_cap);
+            let mut _map = hashbrown::HashMap::with_capacity(_cap);
             $(
                 let _ = _map.insert($key, $value);
             )*

--- a/helix-core/src/snippets/active.rs
+++ b/helix-core/src/snippets/active.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 
-use foldhash::HashSet;
+use hashbrown::HashSet;
 use helix_stdx::range::{is_exact_subset, is_subset};
 use helix_stdx::Range;
 use ropey::Rope;

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -2,7 +2,6 @@ pub mod config;
 
 use std::{
     borrow::Cow,
-    collections::HashMap,
     fmt, iter,
     ops::{self, RangeBounds},
     path::Path,
@@ -13,7 +12,7 @@ use std::{
 use anyhow::{Context, Result};
 use arc_swap::{ArcSwap, Guard};
 use config::{Configuration, FileType, LanguageConfiguration, LanguageServerConfiguration};
-use foldhash::HashSet;
+use hashbrown::{HashMap, HashSet};
 use helix_loader::grammar::get_language;
 use helix_stdx::rope::RopeSliceExt as _;
 use once_cell::sync::OnceCell;

--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -1,11 +1,11 @@
 use crate::{auto_pairs::AutoPairs, diagnostic::Severity, Language};
 
+use hashbrown::{HashMap, HashSet};
 use helix_stdx::rope;
 use serde::{ser::SerializeSeq as _, Deserialize, Serialize};
 use serde_json::Value;
 
 use std::{
-    collections::{HashMap, HashSet},
     fmt::{self, Display},
     num::NonZeroU8,
     path::PathBuf,

--- a/helix-dap-types/Cargo.toml
+++ b/helix-dap-types/Cargo.toml
@@ -13,3 +13,4 @@ homepage.workspace = true
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+hashbrown.workspace = true

--- a/helix-dap-types/src/lib.rs
+++ b/helix-dap-types/src/lib.rs
@@ -1,6 +1,7 @@
+use hashbrown::HashMap;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
+
 use std::path::PathBuf;
 
 #[derive(

--- a/helix-dap/Cargo.toml
+++ b/helix-dap/Cargo.toml
@@ -28,3 +28,4 @@ futures-executor.workspace = true
 futures-util.workspace = true
 tokio-stream.workspace = true
 sonic-rs.workspace = true
+hashbrown.workspace = true

--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -11,7 +11,6 @@ use serde_json::Value;
 
 use anyhow::anyhow;
 use std::{
-    collections::HashMap,
     future::Future,
     net::{IpAddr, Ipv4Addr, SocketAddr},
     path::PathBuf,
@@ -25,6 +24,8 @@ use tokio::{
     sync::mpsc::{channel, unbounded_channel, UnboundedReceiver, UnboundedSender},
     time,
 };
+
+use hashbrown::HashMap;
 
 #[derive(Debug)]
 pub struct Client {

--- a/helix-dap/src/lib.rs
+++ b/helix-dap/src/lib.rs
@@ -6,8 +6,8 @@ pub use client::Client;
 pub use helix_dap_types::*;
 pub use transport::{Payload, Response, Transport};
 
+use hashbrown::HashMap;
 use serde::de::DeserializeOwned;
-use std::collections::HashMap;
 
 use thiserror::Error;
 #[derive(Error, Debug)]

--- a/helix-dap/src/transport.rs
+++ b/helix-dap/src/transport.rs
@@ -1,10 +1,11 @@
 use crate::{registry::DebugAdapterId, Error, Result};
 use anyhow::Context;
+use hashbrown::HashMap;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::fmt::Debug;
 use std::sync::Arc;
-use std::{collections::HashMap, fmt::Debug};
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     sync::{

--- a/helix-event/Cargo.toml
+++ b/helix-event/Cargo.toml
@@ -13,11 +13,11 @@ homepage.workspace = true
 
 [dependencies]
 foldhash.workspace = true
-hashbrown = "0.17"
+hashbrown.workspace = true
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "sync", "parking_lot", "macros"] }
 # the event registry is essentially read only but must be an rwlock so we can
 # setup new events on initialization, hardware-lock-elision hugely benefits this case
-# as it essentially makes the lock entirely free as long as there is no writes 
+# as it essentially makes the lock entirely free as long as there is no writes
 parking_lot = { workspace = true, features = ["hardware-lock-elision"] }
 once_cell = "1.21"
 

--- a/helix-loader/Cargo.toml
+++ b/helix-loader/Cargo.toml
@@ -35,3 +35,5 @@ threadpool = { version = "1.0" }
 tempfile.workspace = true
 
 tree-house.workspace = true
+
+hashbrown.workspace = true

--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -1,11 +1,11 @@
 use anyhow::{anyhow, bail, Context, Result};
+use hashbrown::HashSet;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::{
-    collections::HashSet,
     path::{Path, PathBuf},
     process::Command,
     sync::mpsc::channel,

--- a/helix-loader/src/workspace_trust.rs
+++ b/helix-loader/src/workspace_trust.rs
@@ -37,8 +37,8 @@
 //! repository that happens to land under a matching directory, including ones cloned there later. An
 //! explicit exclude still wins over a matching glob.
 
+use hashbrown::HashMap;
 use std::{
-    collections::HashMap,
     fmt::Write,
     fs,
     path::{Path, PathBuf},

--- a/helix-lsp-types/Cargo.toml
+++ b/helix-lsp-types/Cargo.toml
@@ -25,6 +25,7 @@ bitflags.workspace = true
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 helix-stdx = { path = "../helix-stdx" }
+hashbrown.workspace = true
 
 [features]
 default = []

--- a/helix-lsp-types/src/document_diagnostic.rs
+++ b/helix-lsp-types/src/document_diagnostic.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
@@ -6,6 +6,8 @@ use crate::{
     Diagnostic, PartialResultParams, StaticRegistrationOptions, TextDocumentIdentifier,
     TextDocumentRegistrationOptions, Url, WorkDoneProgressOptions, WorkDoneProgressParams,
 };
+
+use hashbrown::HashMap;
 
 /// Client capabilities specific to diagnostic pull requests.
 ///

--- a/helix-lsp-types/src/formatting.rs
+++ b/helix-lsp-types/src/formatting.rs
@@ -1,11 +1,10 @@
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
     DocumentSelector, DynamicRegistrationClientCapabilities, Range, TextDocumentIdentifier,
     TextDocumentPositionParams, WorkDoneProgressParams,
 };
-
-use std::collections::HashMap;
 
 pub type DocumentFormattingClientCapabilities = DynamicRegistrationClientCapabilities;
 pub type DocumentRangeFormattingClientCapabilities = DynamicRegistrationClientCapabilities;

--- a/helix-lsp-types/src/lib.rs
+++ b/helix-lsp-types/src/lib.rs
@@ -19,8 +19,9 @@ able to parse any URI, such as `urn:isbn:0451450523`.
 
 use bitflags::bitflags;
 
-use std::{collections::HashMap, fmt::Debug};
+use std::fmt::Debug;
 
+use hashbrown::HashMap;
 pub use helix_stdx::Url;
 use serde::{de, de::Error as Error_, Deserialize, Serialize};
 use serde_json::Value;

--- a/helix-lsp-types/src/window.rs
+++ b/helix-lsp-types/src/window.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
+use hashbrown::HashMap;
 use serde_json::Value;
 
 use crate::{Range, Url};

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -32,3 +32,4 @@ arc-swap = "1"
 slotmap.workspace = true
 thiserror.workspace = true
 sonic-rs.workspace = true
+hashbrown.workspace = true

--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -11,6 +11,7 @@ use crate::lsp::{
     DidChangeWorkspaceFoldersParams, OneOf, PositionEncodingKind, SignatureHelp, Url,
     WorkspaceFolder, WorkspaceFoldersChangeEvent,
 };
+use hashbrown::HashMap;
 use helix_core::{
     find_workspace,
     syntax::config::{LanguageServerFeature, RootMarkers},
@@ -21,7 +22,7 @@ use helix_stdx::path;
 use parking_lot::Mutex;
 use serde::Deserialize;
 use serde_json::Value;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
 use std::{
     ffi::OsStr,
     sync::{

--- a/helix-lsp/src/file_event.rs
+++ b/helix-lsp/src/file_event.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, path::PathBuf, sync::Weak};
+use hashbrown::HashMap;
+use std::{path::PathBuf, sync::Weak};
 
 use globset::{GlobBuilder, GlobSetBuilder};
 use tokio::sync::mpsc;

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -20,8 +20,8 @@ use helix_stdx::path;
 use slotmap::SlotMap;
 use tokio::sync::mpsc::UnboundedReceiver;
 
+use hashbrown::HashMap;
 use std::{
-    collections::HashMap,
     fs,
     path::{Path, PathBuf},
     sync::Arc,

--- a/helix-lsp/src/transport.rs
+++ b/helix-lsp/src/transport.rs
@@ -4,10 +4,10 @@ use crate::{
     Error, LanguageServerId, Result,
 };
 use anyhow::Context;
+use hashbrown::HashMap;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::{

--- a/helix-term/Cargo.toml
+++ b/helix-term/Cargo.toml
@@ -53,6 +53,8 @@ helix-loader = { path = "../helix-loader" }
 anyhow = "1"
 once_cell = "1.21"
 
+hashbrown.workspace = true
+
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "io-util", "io-std", "time", "process", "macros", "fs", "parking_lot"] }
 tui = { path = "../helix-tui", package = "helix-tui", default-features = false, features = ["termina", "crossterm"] }
 termina = { workspace = true, features = ["event-stream"] }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -73,13 +73,14 @@ use crate::job::{self, Jobs};
 use std::{
     char::{ToLowercase, ToUppercase},
     cmp::Ordering,
-    collections::{HashMap, HashSet},
     error::Error,
     fmt,
     future::Future,
     io::Read,
     num::NonZeroUsize,
 };
+
+use hashbrown::{HashMap, HashSet};
 
 use std::{
     borrow::Cow,

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -13,7 +13,7 @@ use helix_view::editor::Breakpoint;
 use serde_json::{to_value, Value};
 use tui::text::Spans;
 
-use std::collections::HashMap;
+use hashbrown::HashMap;
 use std::future::Future;
 use std::path::PathBuf;
 

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -33,12 +33,8 @@ use crate::{
     ui::{self, overlay::overlaid, FileLocation, Picker, Popup, PromptEvent},
 };
 
-use std::{
-    collections::{HashSet, VecDeque},
-    fmt::Display,
-    future::Future,
-    path::Path,
-};
+use hashbrown::HashSet;
+use std::{collections::VecDeque, fmt::Display, future::Future, path::Path};
 
 /// Gets the first language server that is attached to a document which supports a specific feature.
 /// If there is no configured language server that supports the feature, this displays a status message.

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     iter,
     path::{Path, PathBuf},
     sync::Arc,
@@ -9,6 +8,7 @@ use dashmap::DashMap;
 use futures_util::FutureExt;
 use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
+use hashbrown::HashSet;
 use helix_core::{
     syntax::{Loader, QueryMatchIterEvent},
     Rope, RopeSlice, Selection, Syntax, Uri,

--- a/helix-term/src/config.rs
+++ b/helix-term/src/config.rs
@@ -1,9 +1,9 @@
 use crate::keymap;
 use crate::keymap::{merge_keys, KeyTrie};
+use hashbrown::HashMap;
 use helix_loader::merge_toml_values;
 use helix_view::{document::Mode, theme};
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs;
 use std::io::Error as IOError;

--- a/helix-term/src/handlers/code_action_hint.rs
+++ b/helix-term/src/handlers/code_action_hint.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, time::Duration};
+use std::time::Duration;
 
 use futures_util::stream::FuturesUnordered;
 use helix_event::{cancelable_future, register_hook, send_blocking, AsyncHook};
@@ -13,6 +13,8 @@ use helix_view::{
 };
 use tokio::time::Instant;
 use tokio_stream::StreamExt;
+
+use hashbrown::HashSet;
 
 use crate::{commands::code_actions_for_range, job};
 

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use hashbrown::HashMap;
 use helix_core::chars::char_is_word;
 use helix_core::completion::CompletionProvider;
 use helix_core::syntax::config::LanguageServerFeature;

--- a/helix-term/src/handlers/completion/request.rs
+++ b/helix-term/src/handlers/completion/request.rs
@@ -1,9 +1,9 @@
-use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use futures_util::Future;
+use hashbrown::{HashMap, HashSet};
 use helix_core::completion::CompletionProvider;
 use helix_core::syntax::config::LanguageServerFeature;
 use helix_event::{cancelable_future, TaskController, TaskHandle};

--- a/helix-term/src/handlers/diagnostics.rs
+++ b/helix-term/src/handlers/diagnostics.rs
@@ -1,5 +1,5 @@
 use futures_util::stream::FuturesUnordered;
-use std::collections::HashSet;
+use hashbrown::HashSet;
 use std::mem;
 use std::time::Duration;
 use tokio::time::Instant;

--- a/helix-term/src/handlers/document_colors.rs
+++ b/helix-term/src/handlers/document_colors.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashSet, time::Duration};
+use hashbrown::HashSet;
+use std::time::Duration;
 
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use helix_core::{syntax::config::LanguageServerFeature, text_annotations::InlineAnnotation};

--- a/helix-term/src/handlers/document_links.rs
+++ b/helix-term/src/handlers/document_links.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashSet, time::Duration};
+use hashbrown::HashSet;
+use std::time::Duration;
 
 use futures_util::{stream::FuturesUnordered, StreamExt};
 use helix_core::{syntax::config::LanguageServerFeature, Assoc};

--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -1,5 +1,5 @@
+use hashbrown::HashSet;
 use std::{
-    collections::HashSet,
     path::PathBuf,
     sync::{Arc, Mutex},
 };

--- a/helix-term/src/health.rs
+++ b/helix-term/src/health.rs
@@ -1,10 +1,8 @@
 use crate::config::{Config, ConfigLoadError};
+use hashbrown::HashSet;
 use helix_core::config::{default_lang_config, user_lang_config};
 use helix_loader::grammar::load_runtime_file;
-use std::{
-    collections::HashSet,
-    io::{IsTerminal, Write},
-};
+use std::io::{IsTerminal, Write};
 use termina::{
     style::{ColorSpec, StyleExt as _, Stylized},
     Terminal as _,

--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -8,13 +8,14 @@ use arc_swap::{
     access::{DynAccess, DynGuard},
     ArcSwap,
 };
+use hashbrown::HashMap;
 use helix_view::{document::Mode, info::Info, input::KeyEvent};
 use indexmap::IndexMap;
 use macros::key;
 use serde::Deserialize;
 use std::{
     borrow::Cow,
-    collections::{BTreeSet, HashMap},
+    collections::BTreeSet,
     ops::{Deref, DerefMut},
     sync::Arc,
 };

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
 use super::macros::keymap;
 use super::{KeyTrie, Mode};

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -28,9 +28,9 @@ use tui::{
 
 use tui::widgets::Widget;
 
+use hashbrown::HashMap;
 use std::{
     borrow::Cow,
-    collections::HashMap,
     io::Read,
     path::Path,
     sync::{

--- a/helix-term/src/ui/picker/query.rs
+++ b/helix-term/src/ui/picker/query.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, mem, ops::Range, sync::Arc};
+use hashbrown::HashMap;
+use std::{mem, ops::Range, sync::Arc};
 
 #[derive(Debug)]
 pub(super) struct PickerQuery {

--- a/helix-term/src/ui/spinner.rs
+++ b/helix-term/src/ui/spinner.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, time::Instant};
+use hashbrown::HashMap;
+use std::time::Instant;
 
 use helix_lsp::LanguageServerId;
 

--- a/helix-tui/Cargo.toml
+++ b/helix-tui/Cargo.toml
@@ -26,6 +26,7 @@ termina = { workspace = true, optional = true }
 termini = "1.0"
 once_cell = "1.21"
 log = "~0.4"
+hashbrown.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 crossterm = { version = "0.28", optional = true }

--- a/helix-tui/src/layout.rs
+++ b/helix-tui/src/layout.rs
@@ -1,11 +1,11 @@
 //! Layout engine for terminal
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 
 use cassowary::strength::{REQUIRED, WEAK};
 use cassowary::WeightedRelation::*;
 use cassowary::{Constraint as CassowaryConstraint, Expression, Solver, Variable};
+use hashbrown::HashMap;
 
 use helix_view::graphics::{Margin, Rect};
 

--- a/helix-view/Cargo.toml
+++ b/helix-view/Cargo.toml
@@ -61,6 +61,8 @@ thiserror.workspace = true
 
 kstring = "2.0"
 
+hashbrown.workspace = true
+
 [target.'cfg(windows)'.dependencies]
 clipboard-win = { version = "5.4", features = ["std"] }
 crossterm = { version = "0.28", optional = true }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -24,7 +24,6 @@ use serde::de::{self, Deserialize, Deserializer};
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::future::Future;
 use std::io;
@@ -32,6 +31,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Weak};
 use std::time::SystemTime;
+
+use hashbrown::{HashMap, HashSet};
 
 use helix_core::{
     editor_config::EditorConfig,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -26,7 +26,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use std::{
     borrow::Cow,
     cell::Cell,
-    collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     fs,
     io::{self, stdin},
     num::{NonZeroU8, NonZeroUsize},
@@ -34,6 +34,8 @@ use std::{
     pin::Pin,
     sync::Arc,
 };
+
+use hashbrown::{HashMap, HashSet};
 
 use tokio::{
     sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},

--- a/helix-view/src/handlers/completion.rs
+++ b/helix-view/src/handlers/completion.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, sync::Arc};
+use hashbrown::HashMap;
+use std::sync::Arc;
 
 use helix_core::completion::CompletionProvider;
 use helix_event::{send_blocking, TaskController};

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -1,5 +1,5 @@
+use hashbrown::HashSet;
 use std::collections::btree_map::Entry;
-use std::collections::HashSet;
 use std::fmt::Display;
 
 use crate::editor::Action;

--- a/helix-view/src/handlers/word_index.rs
+++ b/helix-view/src/handlers/word_index.rs
@@ -5,7 +5,7 @@
 
 use std::{borrow::Cow, iter, sync::Arc, time::Duration};
 
-use foldhash::HashMap;
+use hashbrown::HashMap;
 use helix_core::{
     chars::char_is_word, diff::compare_ropes, fuzzy::fuzzy_match, ChangeSet, Rope, RopeSlice,
 };
@@ -526,9 +526,8 @@ pub mod bench {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
+    use hashbrown::{HashMap, HashSet};
     use quickcheck::{Arbitrary, Gen};
 
     impl WordIndex {
@@ -540,7 +539,7 @@ mod tests {
         /// The full reference-counted word multiset. Unlike [`WordIndex::words`] this keeps the
         /// counts, which the incremental update path must hold exactly in step with a fresh index:
         /// a word is only freed once its count falls to zero, so any drift leaks stale words.
-        fn counts(&self) -> std::collections::HashMap<String, u32> {
+        fn counts(&self) -> HashMap<String, u32> {
             let inner = self.inner.read();
             inner
                 .words

--- a/helix-view/src/register.rs
+++ b/helix-view/src/register.rs
@@ -1,7 +1,8 @@
-use std::{borrow::Cow, collections::HashMap, iter};
+use std::{borrow::Cow, iter};
 
 use anyhow::Result;
 use arc_swap::access::DynAccess;
+use hashbrown::HashMap;
 use helix_core::NATIVE_LINE_ENDING;
 
 use crate::{

--- a/helix-view/src/theme.rs
+++ b/helix-view/src/theme.rs
@@ -1,5 +1,5 @@
+use hashbrown::{HashMap, HashSet};
 use std::{
-    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     str,
 };

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -17,10 +17,9 @@ use helix_core::{
     VisualOffsetError::{PosAfterMaxRow, PosBeforeAnchorRow},
 };
 
-use std::{
-    collections::{HashMap, VecDeque},
-    fmt,
-};
+use std::{collections::VecDeque, fmt};
+
+use hashbrown::HashMap;
 
 const JUMP_LIST_CAPACITY: usize = 30;
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,3 +19,4 @@ helix-loader = { path = "../helix-loader" }
 helix-stdx = { path = "../helix-stdx" }
 ropey.workspace = true
 toml.workspace = true
+hashbrown.workspace = true

--- a/xtask/src/docgen.rs
+++ b/xtask/src/docgen.rs
@@ -7,7 +7,7 @@ use helix_term::commands::TYPABLE_COMMAND_LIST;
 use helix_term::health::TsFeature;
 use helix_view::document::Mode;
 
-use std::collections::HashSet;
+use hashbrown::HashSet;
 use std::fs;
 
 pub const TYPABLE_COMMANDS_MD_OUTPUT: &str = "typable-cmd.md";

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -8,7 +8,7 @@ type DynError = Box<dyn Error>;
 
 pub mod tasks {
     use crate::DynError;
-    use std::collections::HashSet;
+    use hashbrown::HashSet;
 
     pub fn docgen() -> Result<(), DynError> {
         use crate::docgen::*;


### PR DESCRIPTION
Add a `clippy.toml` and forbid `std::collections::Hash[Map|Set]` in favor of `hashbrown` variants. We have no need for the std default hasher, which is slower than the `foldhash` implementation which `hashbrown` uses. 

Changing this everywhere should hopefully speed up areas of frequent hashing.

I will note that there is a direct usage of `foldhash` in `helix-event`:
```rust
runtime_local! {
    static REGISTRY: RwLock<Registry> = RwLock::new(Registry {
        // hardcoded random number is good enough here we don't care about DOS resistance
        // and avoids the additional complexity of `Option<Registry>`
        events: HashMap::with_hasher(foldhash::fast::FixedState::with_seed(72536814787)),
        handlers: HashMap::with_hasher(foldhash::fast::FixedState::with_seed(72536814787)),
    });
}
```
But am leaving alone, as this PR is meant to be a quick find-replace as much as possible.