### PR TITLE
perf: change `String` to `Box<str>` in `Diagnostic`

### DIFF
--- a/helix-core/src/diagnostic.rs
+++ b/helix-core/src/diagnostic.rs
@@ -19,7 +19,7 @@ pub enum Severity {
 #[derive(Debug, Eq, Hash, PartialEq, Clone, Deserialize, Serialize)]
 pub enum NumberOrString {
     Number(i32),
-    String(String),
+    String(Box<str>),
 }
 
 #[derive(Debug, Clone)]
@@ -37,12 +37,12 @@ pub struct Diagnostic {
     pub starts_at_word: bool,
     pub zero_width: bool,
     pub line: usize,
-    pub message: String,
+    pub message: Box<str>,
     pub severity: Option<Severity>,
     pub code: Option<NumberOrString>,
     pub provider: DiagnosticProvider,
     pub tags: Vec<DiagnosticTag>,
-    pub source: Option<String>,
+    pub source: Option<Box<str>>,
     pub data: Option<serde_json::Value>,
 }
 

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -105,7 +105,7 @@ pub mod util {
         let code = match diag.code.clone() {
             Some(x) => match x {
                 NumberOrString::Number(x) => Some(lsp::NumberOrString::Number(x)),
-                NumberOrString::String(x) => Some(lsp::NumberOrString::String(x)),
+                NumberOrString::String(x) => Some(lsp::NumberOrString::String(x.into_string())),
             },
             None => None,
         };
@@ -131,11 +131,11 @@ pub mod util {
             range: range_to_lsp_range(doc, range, offset_encoding),
             severity,
             code,
-            source: diag.source.clone(),
-            message: diag.message.to_owned(),
+            source: diag.source.clone().map(|source| source.into_string()),
+            message: diag.message.clone().into_string(),
             related_information: None,
             tags,
-            data: diag.data.to_owned(),
+            data: diag.data.clone(),
             ..Default::default()
         }
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2799,9 +2799,11 @@ fn yank_diagnostic(
         .diagnostics()
         .iter()
         .filter(|d| primary.overlaps(&helix_core::Range::new(d.range.start, d.range.end)))
-        .map(|d| d.message.clone())
+        .map(|d| d.message.clone().into_string())
         .collect();
+
     let n = diag.len();
+
     if n == 0 {
         bail!("No diagnostics under primary selection");
     }

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -816,12 +816,16 @@ impl EditorView {
                     Some(Severity::Info) => info,
                     Some(Severity::Hint) => hint,
                 });
-            let text = Text::styled(&diagnostic.message, style);
+
+            let text = Text::styled(&*diagnostic.message, style);
+
             lines.extend(text.lines);
+
             let code = diagnostic.code.as_ref().map(|x| match x {
                 NumberOrString::Number(n) => format!("({n})"),
                 NumberOrString::String(s) => format!("({s})"),
             });
+
             if let Some(code) = code {
                 let span = Span::styled(code, style);
                 lines.push(span.into());

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -139,7 +139,7 @@ impl Renderer<'_, '_> {
         let text_fmt = self.config.text_fmt(text_col, self.renderer.viewport.width);
         let annotations = TextAnnotations::default();
         let formatter = DocumentFormatter::new_at_prev_checkpoint(
-            diag.message.as_str().trim().into(),
+            diag.message.trim().into(),
             &text_fmt,
             &annotations,
             0,

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -305,7 +305,7 @@ impl LineAnnotation for InlineDiagnostics<'_> {
             .drain(..)
             .map(|(diag, anchor)| {
                 let text_fmt = self.state.config.text_fmt(anchor, self.width);
-                softwrapped_dimensions(diag.message.as_str().trim().into(), &text_fmt).0
+                softwrapped_dimensions(diag.message.trim().into(), &text_fmt).0
             })
             .sum();
         Position::new(multi as usize + diagostic_height, 0)

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -2156,7 +2156,7 @@ impl Document {
         let code = match diagnostic.code.clone() {
             Some(x) => match x {
                 lsp::NumberOrString::Number(x) => Some(NumberOrString::Number(x)),
-                lsp::NumberOrString::String(x) => Some(NumberOrString::String(x)),
+                lsp::NumberOrString::String(x) => Some(NumberOrString::String(x.into())),
             },
             None => None,
         };
@@ -2186,11 +2186,11 @@ impl Document {
             starts_at_word,
             zero_width: start == end,
             line: diagnostic.range.start.line as usize,
-            message: diagnostic.message.clone(),
+            message: diagnostic.message.clone().into(),
             severity,
             code,
             tags,
-            source: diagnostic.source.clone(),
+            source: diagnostic.source.clone().map(|source| source.into()),
             data: diagnostic.data.clone(),
             provider,
         })
@@ -2220,11 +2220,9 @@ impl Document {
                     return true;
                 }
 
-                if let Some(source) = &d.source {
-                    unchanged_sources.contains(source)
-                } else {
-                    false
-                }
+                d.source
+                    .as_ref()
+                    .is_some_and(|source| unchanged_sources.iter().any(|s| **s == **source))
             });
         }
         self.diagnostics.extend(diagnostics);


### PR DESCRIPTION
This lowers the size of `Diagnostic` by 24 bytes (now down to 184 bytes). Its not much, but it saves 9.8k bytes in `typed.rs` when using an aggressive cargo clippy config for `rust-analyzer`. There could be more if there are other places that store the diagnostics that I am not aware of.

`into` internally calls `into_boxed_slice` on the bytes in `String`, and should make a `Box<str>` without allocating again. `into_string` should also turn a `Box<str>` into a `String` without allocating.

To further lower the size, we could `Box` some of the other fields (grouping them into a new struct) that are perhaps less frequently called. This would allow the ones that are called to fit better in cache. But this requires a deeper dive.

If this sounds good, I plan to try to do the same thing (`String` -> `Box<str>`) for the lsp types, as this could save some more memory.