### PR TITLE
feat(languages): add doxygen grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -56,6 +56,7 @@
 | dockerfile | ✓ | ✓ |  |  |  | `docker-langserver`, `docker-language-server` |
 | dot | ✓ |  |  |  |  | `dot-language-server` |
 | doxyfile | ✓ | ✓ | ✓ | ✓ |  |  |
+| doxygen | ✓ |  |  |  |  |  |
 | drools |  |  |  |  |  | `drools-lsp` |
 | dtd | ✓ |  |  |  |  |  |
 | dune | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -5509,3 +5509,18 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "concerto"
 source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "920ba23ea93af56b19dfc38fcddf80b3ddc62685" }
+
+[[language]]
+name = "doxygen"
+scope = "source.doxygen"
+injection-regex = "doxygen"
+file-types = [
+  "doxygen",
+  "dox",
+  { glob = "doc.md" },
+]
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "doxygen"
+source = { git = "https://codeberg.org/maribu/tree-sitter-doxygen", rev = "26afdde765b43dc42d2c90172c238a64a93cd53caff9adce795a0e2127f4bfc9" }

--- a/runtime/queries/c/injections.scm
+++ b/runtime/queries/c/injections.scm
@@ -4,3 +4,15 @@
 ((preproc_arg) @injection.content
  (#set! injection.language "c")
  (#set! injection.include-children))
+
+; Comments starting with `///`, `//!` are C++ style Doxygen comments, but
+; comments starting with `////` are not.
+((comment) @injection.content
+ (#match? @injection.content "^[\t ]*(//!|///[^/])")
+ (#set! injection.language "doxygen"))
+
+; Comments starting with `/**`, `/*!` are C style Doxygen, but comments
+; starting with `/***` are not.
+((comment) @injection.content
+ (#match? @injection.content "^[\t ]*(/\\*(!|\\*($|[^*])))")
+ (#set! injection.language "doxygen"))

--- a/runtime/queries/doxygen/highlights.scm
+++ b/runtime/queries/doxygen/highlights.scm
@@ -1,0 +1,53 @@
+; block commands
+(block_command
+  command: _ @keyword)
+(block_command
+  ["@" "\\"] @keyword )
+(block_command
+  (parameter) @variable.parameter)
+(block_command
+  (description (content) @string))
+
+; inline commands
+(inline_command
+  command: _ @keyword)
+(inline_command
+  ["@" "\\"] @keyword )
+(inline_command
+  (parameter) @variable.parameter)
+
+; @param command
+(param_attribute) @keyword.storage
+
+; markdown
+(header) @markup.heading
+(link) @markup.link.text
+(link
+  (link_uri) @markup.link.url)
+(link
+  (link_ref) @markup.link.url)
+(email) @markup.link.url
+
+; styling
+(bold) @markup.bold
+(inline_command command: "b"
+  (_) @markup.bold)
+(italic) @markup.italic
+(inline_command command: ["e" "em" "a"]
+  (_) @markup.italic)
+(code) @markup.raw.inline
+(inline_command command: "c"
+  (_) @markup.raw.inline)
+(code_block
+  (code_line) @markup.raw.block)
+
+; let important commands stick out
+(block_command
+  command: _ @_cmd @keyword
+  (description (content) @warning)
+  (#any-of? @_cmd "warning" "note"))
+
+(block_command
+  command: _ @_cmd @keyword
+  (description (content) @markup.heading)
+  (#any-of? @_cmd "brief"))

--- a/runtime/queries/doxygen/injections.scm
+++ b/runtime/queries/doxygen/injections.scm
@@ -1,0 +1,9 @@
+(markdown
+  (markdown_line) @injection.content
+  (#set! injection.language "markdown")
+  (#set! injection.combined))
+
+(code_block
+  (code_language) @injection.language
+  (code_line) @injection.content
+  (#set! injection.combined))


### PR DESCRIPTION
There is an alternative Doxygen grammar at
https://github.com/tree-sitter-grammars/tree-sitter-doxygen, but that
seems to be only causually maintained at best (specifically, it is
incompatible with recent versions of `tree-sitter`), and the grammar is
rather incomplete.

This adds the Doxygen grammar from
https://codeberg.org/maribu/tree-sitter-doxygen, which (disclaimer),
I authored. That version is incompatible with modern tree-sitter,
actively maintained, and does provide pretty solid and accurate
syntax highlighting (at least for all the code bases I tested in the
last two months).