### PR TITLE
fix typo in helix-lsp-types lib.rs

### DIFF
--- a/helix-lsp-types/src/lib.rs
+++ b/helix-lsp-types/src/lib.rs
@@ -2085,7 +2085,7 @@ pub struct WorkspaceServerCapabilities {
     pub file_operations: Option<WorkspaceFileOperationsServerCapabilities>,
 }
 
-/// General parameters to to register for a capability.
+/// General parameters to register for a capability.
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Registration {


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `parameters to to register` → `parameters to register` in `helix-lsp-types/src/lib.rs`.
