### PR TITLE
feat(highlights/rust): more exhaustively mark enum variants in match

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -433,8 +433,31 @@
 
 (match_pattern
   (scoped_identifier
-    name: ((identifier) @type.enum.variant
+    path: [(identifier) @type (scoped_identifier name: (identifier) @type)]
+    name: (identifier) @type.enum.variant
+    (#match? @type "^[A-Z]")
+    (#match? @type.enum.variant "^[A-Z]")))
+
+(match_pattern
+  (struct_pattern
+    type: (scoped_type_identifier
+      path: [(identifier) @type (scoped_identifier name: (identifier) @type)]
+      name: (type_identifier) @type.enum.variant
+      (#match? @type "^[A-Z]")
       (#match? @type.enum.variant "^[A-Z]"))))
+
+(match_pattern
+  (tuple_struct_pattern
+    type: (scoped_identifier
+      path: [(identifier) @type (scoped_identifier name: (identifier) @type)]
+      name: (identifier) @type.enum.variant
+      (#match? @type "^[A-Z]")
+      (#match? @type.enum.variant "^[A-Z]"))))
+
+(match_pattern
+  (scoped_identifier
+    name: (identifier) @constant
+    (#match? @constant "^[A-Z_]+$")))
 
 ; ---
 ; Macros


### PR DESCRIPTION
followup to #15596.

additionally marks the enum variants for struct and tuple struct patterns.

and also fix a few other cases, that were previously marked incorrectly:

- `namespace::Type` should be `@type`, not `@type.enum.variant`
- `Type::CONST` should be `@constant`, not `@type.enum.variant`

<img width="1099" height="696" alt="image" src="https://github.com/user-attachments/assets/8a3613e6-828c-4121-b872-74d5589b38b7" />
