### PR TITLE
fix(grammar): bump tree-sitter-hare to latest commit

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2685,7 +2685,7 @@ language-servers = [
 
 [[grammar]]
 name = "hare"
-source = { git = "https://git.sr.ht/~ecs/tree-sitter-hare", rev = "07035a248943575444aa0b893ffe306e1444c0ab" }
+source = { git = "https://git.sr.ht/~ecs/tree-sitter-hare", rev = "fb6ea01461441ec7c312e64e326649f5e9011a64" }
 
 [[language]]
 name = "devicetree"


### PR DESCRIPTION
This PR fixes the build failure when fetching the hare grammar from SourceHut.
The build would fail with `"Server does not allow request for unadvertised object"` when shallow-fetching commit `07035a248943575444aa0b893ffe306e1444c0ab` from tree-sitter-hare.

### Changes
Updated `tree-sitter-hare` revision from `07035a248943575444aa0b893ffe306e1444c0ab` to current HEAD `fb6ea01461441ec7c312e64e326649f5e9011a64`.

Fixes #15767
