### PR TITLE
Don't restore regex prompt snapshot to a different document

### DIFF
--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -98,9 +98,10 @@ pub fn raw_regex_prompt(
     fun: impl Fn(&mut crate::compositor::Context, rope::Regex, &str, PromptEvent) + 'static,
 ) {
     let (view, doc) = current!(cx.editor);
+    let view_id = view.id;
     let doc_id = view.doc;
-    let snapshot = doc.selection(view.id).clone();
-    let offset_snapshot = doc.view_offset(view.id);
+    let snapshot = doc.selection(view_id).clone();
+    let offset_snapshot = doc.view_offset(view_id);
     let config = cx.editor.config();
 
     let mut prompt = Prompt::new(
@@ -108,11 +109,25 @@ pub fn raw_regex_prompt(
         history_register,
         completion_fn,
         move |cx: &mut crate::compositor::Context, input: &str, event: PromptEvent| {
+            // The prompt is tied to the (view, doc) pair captured when it opened.
+            // Mouse clicks can shift focus to a different view without aborting
+            // the prompt, so restoring the snapshot via `current!` could write
+            // it into the wrong document and panic inside
+            // `Selection::ensure_invariants` when the snapshot's char indices
+            // exceed the new document's length (#13325).
+            let on_original_view = cx
+                .editor
+                .tree
+                .try_get(view_id)
+                .is_some_and(|v| v.doc == doc_id);
+
             match event {
                 PromptEvent::Abort => {
-                    let (view, doc) = current!(cx.editor);
-                    doc.set_selection(view.id, snapshot.clone());
-                    doc.set_view_offset(view.id, offset_snapshot);
+                    if on_original_view {
+                        let doc = doc_mut!(cx.editor, &doc_id);
+                        doc.set_selection(view_id, snapshot.clone());
+                        doc.set_view_offset(view_id, offset_snapshot);
+                    }
                 }
                 PromptEvent::Update | PromptEvent::Validate => {
                     // skip empty input
@@ -137,14 +152,17 @@ pub fn raw_regex_prompt(
                         .build(input)
                     {
                         Ok(regex) => {
-                            let (view, doc) = current!(cx.editor);
+                            if on_original_view {
+                                let doc = doc_mut!(cx.editor, &doc_id);
+                                // revert state to what it was before the last update
+                                doc.set_selection(view_id, snapshot.clone());
 
-                            // revert state to what it was before the last update
-                            doc.set_selection(view.id, snapshot.clone());
-
-                            if event == PromptEvent::Validate {
-                                // Equivalent to push_jump to store selection just before jump
-                                view.jumps.push((doc_id, snapshot.clone()));
+                                if event == PromptEvent::Validate {
+                                    // Equivalent to push_jump to store selection just before jump
+                                    view_mut!(cx.editor, view_id)
+                                        .jumps
+                                        .push((doc_id, snapshot.clone()));
+                                }
                             }
 
                             fun(cx, regex, input, event);
@@ -153,9 +171,11 @@ pub fn raw_regex_prompt(
                             view.ensure_cursor_in_view(doc, config.scrolloff);
                         }
                         Err(err) => {
-                            let (view, doc) = current!(cx.editor);
-                            doc.set_selection(view.id, snapshot.clone());
-                            doc.set_view_offset(view.id, offset_snapshot);
+                            if on_original_view {
+                                let doc = doc_mut!(cx.editor, &doc_id);
+                                doc.set_selection(view_id, snapshot.clone());
+                                doc.set_view_offset(view_id, offset_snapshot);
+                            }
 
                             if event == PromptEvent::Validate {
                                 let callback = async move {

--- a/helix-term/tests/test/splits.rs
+++ b/helix-term/tests/test/splits.rs
@@ -197,6 +197,99 @@ async fn test_changes_in_splits_apply_to_all_views() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_regex_prompt_abort_after_view_switch_does_not_panic() -> anyhow::Result<()> {
+    // See <https://github.com/helix-editor/helix/issues/13325>.
+    //
+    // Opening a regex prompt captures a selection snapshot for the focused
+    // (view, doc) pair. The prompt does not consume mouse events, so a click
+    // into a different view can shift focus without aborting the prompt.
+    // Aborting (or updating) the prompt afterwards must not restore the
+    // snapshot into the now-current document, since the snapshot's char
+    // indices may exceed the new document's length and panic inside
+    // `Selection::ensure_invariants`.
+    use helix_view::input::parse_macro;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    #[cfg(windows)]
+    use crossterm::event::KeyModifiers as TerminalKeyModifiers;
+    #[cfg(windows)]
+    use crossterm::event::{
+        Event as TerminalEvent, KeyEvent as TerminalKey, MouseButton, MouseEvent, MouseEventKind,
+    };
+    #[cfg(not(windows))]
+    use termina::event::Modifiers as TerminalKeyModifiers;
+    #[cfg(not(windows))]
+    use termina::event::{
+        Event as TerminalEvent, KeyEvent as TerminalKey, MouseButton, MouseEvent, MouseEventKind,
+    };
+
+    let file1 = tempfile::NamedTempFile::new()?;
+    let file2 = tempfile::NamedTempFile::new()?;
+
+    let mut app = AppBuilder::new().with_file(file1.path(), None).build()?;
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut rx_stream = UnboundedReceiverStream::new(rx);
+
+    let send_keys = |tx: &tokio::sync::mpsc::UnboundedSender<std::io::Result<TerminalEvent>>,
+                     macro_str: &str|
+     -> anyhow::Result<()> {
+        for key_event in parse_macro(macro_str)?.into_iter() {
+            let key = TerminalEvent::Key(TerminalKey::from(key_event));
+            tx.send(Ok(key))?;
+        }
+        Ok(())
+    };
+
+    // Populate file1 with three lines, vertical split, open file2 in the new
+    // view with one character, focus back to file1, then enter select mode
+    // with a non-empty selection. After this the prompt-target is file1.
+    let setup = format!(
+        "iline1<ret>line2<ret>line3<esc><C-w>v:o {}<ret>ia<esc><C-w>w%v",
+        file2.path().to_string_lossy()
+    );
+    send_keys(&tx, &setup)?;
+
+    // Open the regex prompt (`s` = select_regex). This captures a snapshot of
+    // the focused view+doc (file1, three lines).
+    send_keys(&tx, "s")?;
+
+    // Click into the right-hand view (file2). Mouse events pass through the
+    // prompt; the editor's mouse handler calls `editor.focus(view_id)` and
+    // shifts focus to file2 without aborting the prompt. Backend is 120
+    // columns wide so the vertical split places file2 around column 80.
+    let mouse = TerminalEvent::Mouse(MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column: 90,
+        row: 0,
+        modifiers: TerminalKeyModifiers::empty(),
+    });
+    tx.send(Ok(mouse))?;
+
+    // Abort the prompt. Pre-fix this restores the file1 snapshot into the
+    // now-current file2 document and panics in `ensure_invariants`.
+    send_keys(&tx, "<esc>")?;
+
+    app.event_loop_until_idle(&mut rx_stream).await;
+
+    // We never reach this point pre-fix; the panic above terminates the test
+    // thread.
+    helpers::assert_status_not_error(&app.editor);
+
+    // file2 must still be a single-character document; the file1 snapshot
+    // must not have leaked into it.
+    let file2_normalized = helix_stdx::path::normalize(file2.path());
+    let file2_doc = app
+        .editor
+        .documents()
+        .find(|d| d.path().is_some_and(|p| p == file2_normalized))
+        .expect("file2 should be open");
+    assert_eq!(file2_doc.text().len_chars(), 1);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_changes_in_splits_jumplist_sync() -> anyhow::Result<()> {
     // See <https://github.com/helix-editor/helix/issues/9833>
     // When jumping backwards (<C-o>) switches between two documents, we need to


### PR DESCRIPTION
The regex prompt (`/`, `?`, `s` select_regex, `S` split_selection) captures a snapshot of the focused (view, doc) when it opens and writes the snapshot back inside its event handlers using `current!`. Mouse events are not consumed by the prompt (`Prompt::handle_event` returns `Ignored` for them), so a left click is dispatched to the editor below the prompt, which calls `editor.focus(view_id)` and shifts focus to the clicked view. After this the prompt's snapshot points into a different document; restoring it via `Document::set_selection` panics in `Selection::ensure_invariants` whenever the snapshot's char indices exceed the new document's length:

```
thread 'main' panicked at ropey-1.6.1/src/slice.rs:360:41:
called `Result::unwrap()` on an `Err` value: Char index out of bounds: char index 88087, Rope/RopeSlice char length 10230
stack backtrace:
   3: helix_core::graphemes::nth_prev_grapheme_boundary
   4: helix_core::selection::Range::grapheme_aligned
   5: helix_core::selection::Selection::ensure_invariants
   6: helix_view::document::Document::set_selection
   7: helix_term::ui::raw_regex_prompt::{{closure}}
```

#13620 closes any active prompt on `DocumentFocusLost`, but that close is queued through `job::dispatch_blocking` while `Application::event_loop_until_idle`'s `tokio::select!` is `biased` and reads input events before job callbacks. A key event sent immediately after the mouse click (e.g. an `Esc` right after the click) reaches the prompt's handler with the stale snapshot before the close callback runs.

Capture the original `view_id` alongside `doc_id` and guard each snapshot-restoring `set_selection` / jumplist push against the view still showing the original document. `fun` continues to use `current!` because the user-visible search operation on the now-focused doc is intentional.

Sibling of #15246 (jumplist version of the same class of bug).

The test in `helix-term/tests/test/splits.rs` reproduces the panic by sending a constructed `MouseEventKind::Down(Left)` into the right-hand split followed by `<esc>`; it panics on master and passes with the fix.

Fixes #13325