### PR TITLE
Add a Git branch picker

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -110,6 +110,7 @@
 | `syntax_symbol_picker` | Open symbol picker from syntax information |  |
 | `lsp_or_syntax_symbol_picker` | Open symbol picker from LSP or syntax information | normal: `` <space>s ``, select: `` <space>s `` |
 | `changed_file_picker` | Open changed file picker | normal: `` <space>g ``, select: `` <space>g `` |
+| `git_branch_picker` | Open git branch picker | normal: `` <space>B ``, select: `` <space>B `` |
 | `select_references_to_symbol_under_cursor` | Select symbol references | normal: `` <space>h ``, select: `` <space>h `` |
 | `workspace_symbol_picker` | Open workspace symbol picker |  |
 | `syntax_workspace_symbol_picker` | Open workspace symbol picker from syntax information |  |

--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -291,6 +291,7 @@ This layer is a kludge of mappings, mostly pickers.
 | `f`     | Open file picker at LSP workspace root                                  | `file_picker`                              |
 | `F`     | Open file picker at current working directory                           | `file_picker_in_current_directory`         |
 | `b`     | Open buffer picker                                                      | `buffer_picker`                            |
+| `B`     | Open git branch picker                                                  | `git_branch_picker`                        |
 | `j`     | Open jumplist picker                                                    | `jumplist_picker`                          |
 | `g`     | Open changed file picker                                                | `changed_file_picker`                      |
 | `G`     | Debug (experimental)                                                    | N/A                                        |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -10,7 +10,7 @@ use helix_stdx::{
     path::{self, find_paths},
     rope::{self, RopeSliceExt},
 };
-use helix_vcs::{FileChange, Hunk};
+use helix_vcs::{Branch, BranchKind, FileChange, Hunk};
 pub use lsp::*;
 pub use syntax::*;
 use tui::{
@@ -48,6 +48,7 @@ use helix_view::{
     document::{FormatterError, Mode, SCRATCH_BUFFER_NAME},
     editor::{Action, Motion},
     expansion,
+    graphics::Modifier,
     info::Info,
     input::KeyEvent,
     keyboard::KeyCode,
@@ -413,6 +414,7 @@ impl MappableCommand {
         syntax_symbol_picker, "Open symbol picker from syntax information",
         lsp_or_syntax_symbol_picker, "Open symbol picker from LSP or syntax information",
         changed_file_picker, "Open changed file picker",
+        git_branch_picker, "Open git branch picker",
         select_references_to_symbol_under_cursor, "Select symbol references",
         workspace_symbol_picker, "Open workspace symbol picker",
         syntax_workspace_symbol_picker, "Open workspace symbol picker from syntax information",
@@ -3571,6 +3573,233 @@ fn changed_file_picker(cx: &mut Context) {
             }
         });
     cx.push_layer(Box::new(overlaid(picker)));
+}
+
+struct GitBranchPickerData {
+    style_current: Style,
+    style_local: Style,
+    style_remote: Style,
+    style_tracking: Style,
+    style_head: Style,
+}
+
+impl GitBranchPickerData {
+    fn branch_style(&self, branch: &Branch) -> Style {
+        if branch.is_current() {
+            self.style_current
+        } else {
+            match branch.kind() {
+                BranchKind::Local => self.style_local,
+                BranchKind::Remote => self.style_remote,
+            }
+        }
+    }
+}
+
+fn git_branch_current_cell<'a>(branch: &'a Branch, data: &'a GitBranchPickerData) -> Cell<'a> {
+    if branch.is_current() {
+        Span::styled("*", data.style_current)
+    } else {
+        Span::raw("")
+    }
+    .into()
+}
+
+fn git_branch_kind_cell<'a>(branch: &'a Branch, data: &'a GitBranchPickerData) -> Cell<'a> {
+    let (label, style) = match branch.kind() {
+        BranchKind::Local => ("local", data.style_local),
+        BranchKind::Remote => ("remote", data.style_remote),
+    };
+    Span::styled(label, style).into()
+}
+
+fn git_branch_name_cell<'a>(branch: &'a Branch, data: &'a GitBranchPickerData) -> Cell<'a> {
+    Span::styled(branch.name(), data.branch_style(branch)).into()
+}
+
+fn git_branch_upstream_cell<'a>(branch: &'a Branch, data: &'a GitBranchPickerData) -> Cell<'a> {
+    Span::styled(branch_upstream_text(branch), data.style_tracking).into()
+}
+
+fn git_branch_head_cell<'a>(branch: &'a Branch, data: &'a GitBranchPickerData) -> Cell<'a> {
+    Span::styled(branch.head(), data.style_head).into()
+}
+
+fn branch_upstream_text(branch: &Branch) -> String {
+    match (branch.upstream(), branch.tracking()) {
+        (Some(upstream), Some(tracking)) => format!("{upstream} ({tracking})"),
+        (Some(upstream), None) => upstream.to_string(),
+        (None, Some(tracking)) => format!("({tracking})"),
+        (None, None) => String::new(),
+    }
+}
+
+fn branch_switch_status(branch: &Branch, reloaded: usize) -> String {
+    let reload_status = match reloaded {
+        0 => String::new(),
+        1 => "; reloaded 1 buffer".to_string(),
+        count => format!("; reloaded {count} buffers"),
+    };
+
+    format!("Switched to branch {}{reload_status}", branch.name())
+}
+
+fn git_branch_picker(cx: &mut Context) {
+    let cwd = helix_stdx::env::current_working_dir();
+    if !cwd.exists() {
+        cx.editor
+            .set_error("Current working directory does not exist");
+        return;
+    }
+
+    let repository = match cx.editor.diff_providers.repository(&cwd) {
+        Ok(repository) => repository,
+        Err(err) => {
+            cx.editor.set_error(format!("{err:#}"));
+            return;
+        }
+    };
+
+    let branches = match repository.branches() {
+        Ok(branches) => branches,
+        Err(err) => {
+            cx.editor.set_error(format!("{err:#}"));
+            return;
+        }
+    };
+
+    if branches.is_empty() {
+        cx.editor.set_error("No git branches found");
+        return;
+    }
+
+    let initial_cursor = branches
+        .iter()
+        .position(|branch| branch.is_current())
+        .unwrap_or_default() as u32;
+
+    let current_style = cx.editor.theme.get("special").add_modifier(Modifier::BOLD);
+    let columns = [
+        PickerColumn::new("current", git_branch_current_cell),
+        PickerColumn::new("type", git_branch_kind_cell),
+        PickerColumn::new("branch", git_branch_name_cell),
+        PickerColumn::new("upstream", git_branch_upstream_cell),
+        PickerColumn::new("head", git_branch_head_cell),
+    ];
+
+    let work_dir = repository.work_dir().to_path_buf();
+    let picker = Picker::new(
+        columns,
+        2, // branch
+        branches,
+        GitBranchPickerData {
+            style_current: current_style,
+            style_local: cx.editor.theme.get("ui.text"),
+            style_remote: cx.editor.theme.get("ui.text.directory"),
+            style_tracking: cx.editor.theme.get("ui.text"),
+            style_head: cx.editor.theme.get("ui.virtual"),
+        },
+        move |cx, branch: &Branch, _action| {
+            if branch.is_current() {
+                cx.editor
+                    .set_status(format!("Already on branch {}", branch.name()));
+                return;
+            }
+
+            if let Some(buffer) = first_modified_buffer_under(cx.editor, &work_dir) {
+                cx.editor.set_error(format!(
+                    "Cannot switch branches with unsaved buffer: {buffer}"
+                ));
+                return;
+            }
+
+            match repository.switch_branch(branch) {
+                Ok(()) => {
+                    let reloaded = reload_open_documents_under(cx.editor, &work_dir);
+                    cx.editor.set_status(branch_switch_status(branch, reloaded));
+                }
+                Err(err) => cx.editor.set_error(format!("{err:#}")),
+            }
+        },
+    )
+    .with_initial_cursor(initial_cursor);
+
+    cx.push_layer(Box::new(overlaid(picker)));
+}
+
+fn first_modified_buffer_under(editor: &Editor, root: &Path) -> Option<String> {
+    let root = canonicalized_path(root);
+
+    editor
+        .documents()
+        .find(|doc| {
+            doc.is_modified() && doc.path().is_some_and(|path| path_starts_with(path, &root))
+        })
+        .map(|doc| doc.display_name().into_owned())
+}
+
+fn reload_open_documents_under(editor: &mut Editor, root: &Path) -> usize {
+    let root = canonicalized_path(root);
+    let scrolloff = editor.config().scrolloff;
+    let view_id = view!(editor).id;
+
+    let docs_view_ids: Vec<(DocumentId, Vec<ViewId>)> = editor
+        .documents_mut()
+        .filter_map(|doc| {
+            let path = doc.path()?.to_path_buf();
+            if !path_starts_with(&path, &root) {
+                return None;
+            }
+
+            let mut view_ids: Vec<_> = doc.selections().keys().cloned().collect();
+            if view_ids.is_empty() {
+                doc.ensure_view_init(view_id);
+                view_ids.push(view_id);
+            }
+
+            Some((doc.id(), view_ids))
+        })
+        .collect();
+
+    let diff_providers = editor.diff_providers.clone();
+    let mut reloaded = 0;
+
+    for (doc_id, view_ids) in docs_view_ids {
+        let doc = doc_mut!(editor, &doc_id);
+        let view = view_mut!(editor, view_ids[0]);
+        view.sync_changes(doc);
+
+        if let Err(error) = doc.reload(view, &diff_providers) {
+            editor.set_error(format!("{}", error));
+            continue;
+        }
+
+        if let Some(path) = doc.path().map(ToOwned::to_owned) {
+            editor
+                .language_servers
+                .file_event_handler
+                .file_changed(path);
+        }
+
+        for view_id in view_ids {
+            let view = view_mut!(editor, view_id);
+            if view.doc.eq(&doc_id) {
+                view.ensure_cursor_in_view(doc, scrolloff);
+            }
+        }
+
+        reloaded += 1;
+    }
+
+    reloaded
+}
+
+fn canonicalized_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn path_starts_with(path: &Path, root: &Path) -> bool {
+    canonicalized_path(path).starts_with(root)
 }
 
 pub fn command_palette(cx: &mut Context) {

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -234,6 +234,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "d" => diagnostics_picker,
             "D" => workspace_diagnostics_picker,
             "g" => changed_file_picker,
+            "B" => git_branch_picker,
             "a" => code_action,
             "'" => last_picker,
             "G" => { "Debug (experimental)" sticky=true

--- a/helix-vcs/src/branch.rs
+++ b/helix-vcs/src/branch.rs
@@ -1,0 +1,60 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BranchKind {
+    Local,
+    Remote,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Branch {
+    name: String,
+    kind: BranchKind,
+    is_current: bool,
+    head: String,
+    upstream: Option<String>,
+    tracking: Option<String>,
+}
+
+impl Branch {
+    #[cfg(feature = "git")]
+    pub(crate) fn new(
+        name: String,
+        kind: BranchKind,
+        is_current: bool,
+        head: String,
+        upstream: Option<String>,
+        tracking: Option<String>,
+    ) -> Self {
+        Self {
+            name,
+            kind,
+            is_current,
+            head,
+            upstream,
+            tracking,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn kind(&self) -> BranchKind {
+        self.kind
+    }
+
+    pub fn is_current(&self) -> bool {
+        self.is_current
+    }
+
+    pub fn head(&self) -> &str {
+        &self.head
+    }
+
+    pub fn upstream(&self) -> Option<&str> {
+        self.upstream.as_deref()
+    }
+
+    pub fn tracking(&self) -> Option<&str> {
+        self.tracking.as_deref()
+    }
+}

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -2,7 +2,8 @@ use anyhow::{bail, Context, Result};
 use arc_swap::ArcSwap;
 use gix::filter::plumbing::driver::apply::Delay;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
 use std::sync::Arc;
 
 use gix::bstr::ByteSlice;
@@ -17,10 +18,15 @@ use gix::status::{
 };
 use gix::{Commit, ObjectId, Repository, ThreadSafeRepository};
 
-use crate::FileChange;
+use crate::{
+    repository::RepositoryProvider, Branch, BranchKind, FileChange, Repository as VcsRepository,
+};
 
 #[cfg(test)]
 mod test;
+
+const BRANCH_FORMAT: &str =
+    "%(HEAD)%00%(refname)%00%(refname:short)%00%(objectname:short)%00%(upstream:short)%00%(upstream:track)";
 
 #[inline]
 fn get_repo_dir(file: &Path) -> Result<&Path> {
@@ -83,6 +89,62 @@ pub fn for_each_changed_file(cwd: &Path, f: impl Fn(Result<FileChange>) -> bool)
     status(&open_repo(cwd)?.to_thread_local(), f)
 }
 
+pub fn repository(cwd: &Path) -> Result<VcsRepository> {
+    let work_dir = repo_workdir(cwd).with_context(|| {
+        format!(
+            "current directory is not inside a git worktree: {}",
+            cwd.display()
+        )
+    })?;
+
+    Ok(VcsRepository::new(RepositoryProvider::Git, work_dir))
+}
+
+pub fn branches(work_dir: &Path) -> Result<Vec<Branch>> {
+    let output = git_output(
+        work_dir,
+        &[
+            "branch",
+            "--all",
+            "--sort=refname",
+            "--format",
+            BRANCH_FORMAT,
+        ],
+    )?;
+
+    let branches = output
+        .lines()
+        .filter_map(parse_branch_line)
+        .collect::<Vec<_>>();
+
+    Ok(branches)
+}
+
+pub fn switch_branch(work_dir: &Path, branch: &Branch) -> Result<()> {
+    if branch.is_current() {
+        return Ok(());
+    }
+
+    ensure_clean_worktree(work_dir)?;
+
+    match branch.kind() {
+        BranchKind::Local => {
+            git_run(work_dir, &["switch", branch.name()])?;
+        }
+        BranchKind::Remote => {
+            let local_branch = local_name_for_remote_branch(branch.name())?;
+
+            if local_branch_exists(work_dir, local_branch)? {
+                git_run(work_dir, &["switch", local_branch])?;
+            } else {
+                git_run(work_dir, &["switch", "--track", branch.name()])?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn open_repo(path: &Path) -> Result<ThreadSafeRepository> {
     // custom open options
     let mut git_open_opts_map = gix::sec::trust::Mapping::<gix::open::Options>::default();
@@ -123,6 +185,160 @@ fn open_repo(path: &Path) -> Result<ThreadSafeRepository> {
     )?;
 
     Ok(res)
+}
+
+fn repo_workdir(cwd: &Path) -> Result<PathBuf> {
+    let repo = open_repo(cwd)?.to_thread_local();
+    let work_dir = repo
+        .workdir()
+        .ok_or_else(|| anyhow::anyhow!("working tree not found"))?;
+
+    Ok(std::fs::canonicalize(work_dir).unwrap_or_else(|_| work_dir.to_path_buf()))
+}
+
+fn git_output(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = git_command(cwd, args)?;
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn git_run(cwd: &Path, args: &[&str]) -> Result<()> {
+    git_command(cwd, args).map(|_| ())
+}
+
+fn git_command(cwd: &Path, args: &[&str]) -> Result<Output> {
+    let output = git_command_output(cwd, args)?;
+    if !output.status.success() {
+        bail!("{}", git_failure_message(args, &output));
+    }
+
+    Ok(output)
+}
+
+fn git_command_output(cwd: &Path, args: &[&str]) -> Result<Output> {
+    Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_ASKPASS")
+        .env_remove("SSH_ASKPASS")
+        .env("GIT_TERMINAL_PROMPT", "false")
+        .output()
+        .with_context(|| format!("failed to run `git {}`", args.join(" ")))
+}
+
+fn git_failure_message(args: &[&str], output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    let message = if stderr.is_empty() {
+        format!("exit status {}", output.status)
+    } else {
+        stderr.to_string()
+    };
+    format!("git {} failed: {message}", args.join(" "))
+}
+
+struct BranchRecord<'a> {
+    head_marker: &'a str,
+    refname: &'a str,
+    name: &'a str,
+    head: &'a str,
+    upstream: &'a str,
+    tracking: &'a str,
+}
+
+impl<'a> BranchRecord<'a> {
+    fn parse(line: &'a str) -> Option<Self> {
+        let mut fields = line.split('\0');
+        Some(Self {
+            head_marker: fields.next()?,
+            refname: fields.next()?,
+            name: fields.next()?.trim(),
+            head: fields.next()?.trim(),
+            upstream: fields.next()?.trim(),
+            tracking: fields.next()?.trim(),
+        })
+    }
+}
+
+fn parse_branch_line(line: &str) -> Option<Branch> {
+    let record = BranchRecord::parse(line)?;
+    let kind = branch_kind(record.refname)?;
+
+    Some(Branch::new(
+        record.name.to_string(),
+        kind,
+        record.head_marker == "*",
+        record.head.to_string(),
+        non_empty_string(record.upstream),
+        tracking_status(record.tracking),
+    ))
+}
+
+fn branch_kind(refname: &str) -> Option<BranchKind> {
+    let kind = if refname.starts_with("refs/heads/") {
+        BranchKind::Local
+    } else if refname.starts_with("refs/remotes/") {
+        if refname.ends_with("/HEAD") {
+            return None;
+        }
+        BranchKind::Remote
+    } else {
+        return None;
+    };
+
+    Some(kind)
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn tracking_status(value: &str) -> Option<String> {
+    let value = value
+        .trim()
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn local_name_for_remote_branch(branch: &str) -> Result<&str> {
+    branch
+        .split_once('/')
+        .map(|(_, local)| local)
+        .filter(|local| !local.is_empty())
+        .context("remote branch name does not include a remote")
+}
+
+fn ensure_clean_worktree(cwd: &Path) -> Result<()> {
+    let output = git_output(
+        cwd,
+        &["status", "--porcelain=v1", "--untracked-files=normal"],
+    )?;
+    if let Some(first_change) = output.lines().next() {
+        bail!(
+            "worktree has uncommitted changes; commit, stash, or clean before switching branches (first change: {first_change})"
+        );
+    }
+    Ok(())
+}
+
+fn local_branch_exists(cwd: &Path, branch: &str) -> Result<bool> {
+    let refname = format!("refs/heads/{branch}");
+    let args = ["show-ref", "--verify", "--quiet", refname.as_str()];
+    let output = git_command_output(cwd, &args)?;
+
+    if output.status.success() {
+        return Ok(true);
+    }
+
+    if output.status.code() == Some(1) {
+        return Ok(false);
+    }
+
+    bail!("{}", git_failure_message(&args, &output))
 }
 
 /// Emulates the result of running `git status` from the command line.

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -33,6 +33,25 @@ fn exec_git_cmd(args: &str, git_dir: &Path) {
     }
 }
 
+fn git_output(args: &str, git_dir: &Path) -> String {
+    let res = Command::new("git")
+        .arg("-C")
+        .arg(git_dir)
+        .args(args.split_whitespace())
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_ASKPASS")
+        .env_remove("SSH_ASKPASS")
+        .env("GIT_TERMINAL_PROMPT", "false")
+        .output()
+        .unwrap_or_else(|_| panic!("`git {args}` failed"));
+    if !res.status.success() {
+        println!("{}", String::from_utf8_lossy(&res.stdout));
+        eprintln!("{}", String::from_utf8_lossy(&res.stderr));
+        panic!("`git {args}` failed (see output above)")
+    }
+    String::from_utf8_lossy(&res.stdout).trim().to_string()
+}
+
 fn create_commit(repo: &Path, add_modified: bool) {
     if add_modified {
         exec_git_cmd("add -A", repo);
@@ -124,6 +143,131 @@ fn symlink() {
 
     assert_eq!(git::get_diff_base(&file_link).unwrap(), contents);
     assert_eq!(git::get_diff_base(&file).unwrap(), contents);
+}
+
+#[test]
+fn branches_lists_current_and_local_branches() {
+    let temp_git = empty_git_repo();
+    let file = temp_git.path().join("file.txt");
+    File::create(&file).unwrap().write_all(b"main").unwrap();
+    create_commit(temp_git.path(), true);
+    exec_git_cmd("branch feature", temp_git.path());
+
+    let repository = git::repository(temp_git.path()).unwrap();
+    let work_dir = std::fs::canonicalize(temp_git.path()).unwrap();
+    assert_eq!(repository.work_dir(), work_dir.as_path());
+
+    let branches = repository.branches().unwrap();
+    let main = branches
+        .iter()
+        .find(|branch| branch.name() == "main")
+        .unwrap();
+    assert!(main.is_current());
+    assert_eq!(main.kind(), crate::BranchKind::Local);
+
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name() == "feature")
+        .unwrap();
+    assert!(!feature.is_current());
+    assert_eq!(feature.kind(), crate::BranchKind::Local);
+}
+
+#[test]
+fn repository_errors_outside_git_worktree() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir outside git");
+    let err = git::repository(temp_dir.path()).unwrap_err();
+
+    assert!(
+        format!("{err:#}").contains("current directory is not inside a git worktree"),
+        "{err:#}"
+    );
+}
+
+#[test]
+fn switch_branch_switches_clean_worktree() {
+    let temp_git = empty_git_repo();
+    let file = temp_git.path().join("file.txt");
+    File::create(&file).unwrap().write_all(b"main").unwrap();
+    create_commit(temp_git.path(), true);
+    exec_git_cmd("branch feature", temp_git.path());
+
+    let repository = git::repository(temp_git.path()).unwrap();
+    let branches = repository.branches().unwrap();
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name() == "feature")
+        .unwrap();
+
+    repository.switch_branch(feature).unwrap();
+
+    assert_eq!(
+        git_output("branch --show-current", temp_git.path()),
+        "feature"
+    );
+}
+
+#[test]
+fn switch_branch_tracks_remote_branch() {
+    let remote = tempfile::tempdir().expect("create temp dir for remote");
+    exec_git_cmd("init --bare", remote.path());
+
+    let temp_git = empty_git_repo();
+    let file = temp_git.path().join("file.txt");
+    File::create(&file).unwrap().write_all(b"main").unwrap();
+    create_commit(temp_git.path(), true);
+    exec_git_cmd(
+        &format!("remote add origin {}", remote.path().display()),
+        temp_git.path(),
+    );
+    exec_git_cmd("push -u origin main", temp_git.path());
+    exec_git_cmd("branch feature", temp_git.path());
+    exec_git_cmd("push origin feature", temp_git.path());
+    exec_git_cmd("branch -D feature", temp_git.path());
+
+    let repository = git::repository(temp_git.path()).unwrap();
+    let branches = repository.branches().unwrap();
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name() == "origin/feature")
+        .unwrap();
+    assert_eq!(feature.kind(), crate::BranchKind::Remote);
+
+    repository.switch_branch(feature).unwrap();
+
+    assert_eq!(
+        git_output("branch --show-current", temp_git.path()),
+        "feature"
+    );
+    assert_eq!(
+        git_output(
+            "rev-parse --abbrev-ref --symbolic-full-name @{u}",
+            temp_git.path()
+        ),
+        "origin/feature"
+    );
+}
+
+#[test]
+fn switch_branch_refuses_dirty_worktree() {
+    let temp_git = empty_git_repo();
+    let file = temp_git.path().join("file.txt");
+    File::create(&file).unwrap().write_all(b"main").unwrap();
+    create_commit(temp_git.path(), true);
+    exec_git_cmd("branch feature", temp_git.path());
+
+    File::create(&file).unwrap().write_all(b"dirty").unwrap();
+
+    let repository = git::repository(temp_git.path()).unwrap();
+    let branches = repository.branches().unwrap();
+    let feature = branches
+        .iter()
+        .find(|branch| branch.name() == "feature")
+        .unwrap();
+    let err = repository.switch_branch(feature).unwrap_err();
+
+    assert!(err.to_string().contains("uncommitted changes"));
+    assert_eq!(git_output("branch --show-current", temp_git.path()), "main");
 }
 
 /// Test that `get_diff_base` returns content when the file is a symlink to

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -1,6 +1,6 @@
-//! `helix_vcs` provides types for working with diffs from a Version Control System (VCS).
-//! Currently `git` is the only supported provider for diffs, but this architecture allows
-//! for other providers to be added in the future.
+//! `helix_vcs` provides editor-facing Version Control System (VCS) integration.
+//! Currently `git` is the only supported provider, but this architecture allows
+//! more providers to be added in the future.
 
 use anyhow::{anyhow, bail, Result};
 use arc_swap::ArcSwap;
@@ -12,22 +12,29 @@ use std::{
 #[cfg(feature = "git")]
 mod git;
 
+mod branch;
 mod diff;
+mod repository;
 
+pub use branch::{Branch, BranchKind};
 pub use diff::{DiffHandle, Hunk};
+pub use repository::Repository;
 
 mod status;
 
 pub use status::FileChange;
 
-/// Contains all active diff providers. Diff providers are compiled in via features. Currently
-/// only `git` is supported.
+/// Contains all active VCS providers. Providers are compiled in via features. Currently only
+/// `git` is supported.
 #[derive(Clone)]
-pub struct DiffProviderRegistry {
-    providers: Vec<DiffProvider>,
+pub struct VcsProviderRegistry {
+    providers: Vec<VcsProvider>,
 }
 
-impl DiffProviderRegistry {
+/// Compatibility alias for existing diff-specific callers.
+pub type DiffProviderRegistry = VcsProviderRegistry;
+
+impl VcsProviderRegistry {
     /// Get the given file from the VCS. This provides the unedited document as a "base"
     /// for a diff to be created.
     pub fn get_diff_base(&self, file: &Path) -> Option<Vec<u8>> {
@@ -75,58 +82,82 @@ impl DiffProviderRegistry {
             }
         });
     }
+
+    /// Find the repository containing `cwd`.
+    pub fn repository(&self, cwd: &Path) -> Result<Repository> {
+        let mut last_err = None;
+        for provider in &self.providers {
+            match provider.repository(cwd) {
+                Ok(repository) => return Ok(repository),
+                Err(err) => {
+                    if last_err.is_none() || !matches!(provider, VcsProvider::None) {
+                        last_err = Some(err);
+                    }
+                }
+            }
+        }
+        Err(last_err.unwrap_or_else(|| anyhow!("no VCS provider returns success")))
+    }
 }
 
-impl Default for DiffProviderRegistry {
+impl Default for VcsProviderRegistry {
     fn default() -> Self {
         // currently only git is supported
         // TODO make this configurable when more providers are added
         let providers = vec![
             #[cfg(feature = "git")]
-            DiffProvider::Git,
-            DiffProvider::None,
+            VcsProvider::Git,
+            VcsProvider::None,
         ];
-        DiffProviderRegistry { providers }
+        VcsProviderRegistry { providers }
     }
 }
 
-/// A union type that includes all types that implement [DiffProvider]. We need this type to allow
-/// cloning [DiffProviderRegistry] as `Clone` cannot be used in trait objects.
+/// A union type that includes all supported VCS providers. We need this type to allow cloning
+/// [VcsProviderRegistry] as `Clone` cannot be used in trait objects.
 ///
 /// `Copy` is simply to ensure the `clone()` call is the simplest it can be.
 #[derive(Copy, Clone)]
-enum DiffProvider {
+enum VcsProvider {
     #[cfg(feature = "git")]
     Git,
     None,
 }
 
-impl DiffProvider {
-    fn get_diff_base(&self, file: &Path) -> Result<Vec<u8>> {
+impl VcsProvider {
+    fn get_diff_base(&self, _file: &Path) -> Result<Vec<u8>> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git => git::get_diff_base(file),
+            Self::Git => git::get_diff_base(_file),
             Self::None => bail!("No diff support compiled in"),
         }
     }
 
-    fn get_current_head_name(&self, file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
+    fn get_current_head_name(&self, _file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git => git::get_current_head_name(file),
+            Self::Git => git::get_current_head_name(_file),
             Self::None => bail!("No diff support compiled in"),
         }
     }
 
     fn for_each_changed_file(
         &self,
-        cwd: &Path,
-        f: impl Fn(Result<FileChange>) -> bool,
+        _cwd: &Path,
+        _f: impl Fn(Result<FileChange>) -> bool,
     ) -> Result<()> {
         match self {
             #[cfg(feature = "git")]
-            Self::Git => git::for_each_changed_file(cwd, f),
+            Self::Git => git::for_each_changed_file(_cwd, _f),
             Self::None => bail!("No diff support compiled in"),
+        }
+    }
+
+    fn repository(&self, _cwd: &Path) -> Result<Repository> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git => git::repository(_cwd),
+            Self::None => bail!("No VCS support compiled in"),
         }
     }
 }

--- a/helix-vcs/src/repository.rs
+++ b/helix-vcs/src/repository.rs
@@ -1,0 +1,45 @@
+use anyhow::{bail, Result};
+use std::path::{Path, PathBuf};
+
+use crate::Branch;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RepositoryProvider {
+    #[cfg(feature = "git")]
+    Git,
+    #[allow(dead_code)]
+    None,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Repository {
+    provider: RepositoryProvider,
+    work_dir: PathBuf,
+}
+
+impl Repository {
+    #[cfg(feature = "git")]
+    pub(crate) fn new(provider: RepositoryProvider, work_dir: PathBuf) -> Self {
+        Self { provider, work_dir }
+    }
+
+    pub fn work_dir(&self) -> &Path {
+        &self.work_dir
+    }
+
+    pub fn branches(&self) -> Result<Vec<Branch>> {
+        match self.provider {
+            #[cfg(feature = "git")]
+            RepositoryProvider::Git => crate::git::branches(self.work_dir()),
+            RepositoryProvider::None => bail!("No VCS support compiled in"),
+        }
+    }
+
+    pub fn switch_branch(&self, _branch: &Branch) -> Result<()> {
+        match self.provider {
+            #[cfg(feature = "git")]
+            RepositoryProvider::Git => crate::git::switch_branch(self.work_dir(), _branch),
+            RepositoryProvider::None => bail!("No VCS support compiled in"),
+        }
+    }
+}


### PR DESCRIPTION
This adds a Git branch picker on `<space>B`. It lists local and remote branches, marks the current branch, and shows upstream/tracking info plus the short HEAD hash when Git has that information. Pressing Enter switches to the selected branch.

Switching is intentionally conservative: it refuses to run if the Git worktree is dirty, and it also blocks when Helix has unsaved buffers inside that worktree. Selecting a remote branch switches to an existing local branch when one is already present; otherwise it creates a tracking branch.

I also added a small repository abstraction in `helix-vcs` so branch operations do not live directly in `helix-term`, and so future Git/worktree commands have a clearer place to grow.