### PR TITLE
Add inline Git blame

### DIFF
--- a/base16_theme.toml
+++ b/base16_theme.toml
@@ -31,6 +31,7 @@
 "ui.statusline.insert" = { fg = "black", bg = "green" }
 "ui.statusline.select" = { fg = "black", bg = "blue" }
 "ui.virtual" = { fg = "gray", modifiers = ["italic"] }
+"ui.virtual.line-blame" = { fg = "gray", modifiers = ["italic"] }
 "ui.virtual.jump-label" = { fg = "blue", modifiers = ["bold", "underlined"] }
 "ui.virtual.ruler" = { bg = "black" }
 

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -37,6 +37,7 @@
 | `line-number` | Line number display: `absolute` simply shows each line's number, while `relative` shows the distance from the current line. When unfocused or in insert mode, `relative` will still show absolute line numbers | `"absolute"` |
 | `cursorline` | Highlight all lines with a cursor | `false` |
 | `cursorcolumn` | Highlight all columns with a cursor | `false` |
+| `inline-blame` | Show Git blame author and timestamp as inline virtual text on the cursor line | `false` |
 | `continue-comments` | if helix should automatically add a line comment token if you create a new line inside a comment. | `true` |
 | `gutters` | Gutters to display: Available are `diagnostics` and `diff` and `line-numbers` and `spacer`, note that `diagnostics` also includes other features like breakpoints, 1-width padding will be inserted if gutters is non-empty | `["diagnostics", "spacer", "line-numbers", "spacer", "diff"]` |
 | `auto-completion` | Enable automatic pop up of auto-completion | `true` |

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -344,6 +344,7 @@ These scopes are used for theming the editor interface:
 | `ui.virtual.ruler`                | Ruler columns (see the [`editor.rulers` config][editor-section])                               |
 | `ui.virtual.whitespace`           | Visible whitespace characters                                                                  |
 | `ui.virtual.indent-guide`         | Vertical indent width guides                                                                   |
+| `ui.virtual.line-blame`           | Inline Git blame author and timestamp on the cursor line                                       |
 | `ui.virtual.inlay-hint`           | Default style for inlay hints of all kinds                                                     |
 | `ui.virtual.inlay-hint.parameter` | Style for inlay hints of kind `parameter` (language servers are not required to set a kind)    |
 | `ui.virtual.inlay-hint.type`      | Style for inlay hints of kind `type` (language servers are not required to set a kind)         |

--- a/helix-term/src/handlers.rs
+++ b/helix-term/src/handlers.rs
@@ -21,6 +21,7 @@ pub mod diagnostics;
 mod document_colors;
 mod document_highlight;
 mod document_links;
+mod line_blame;
 mod prompt;
 mod signature_help;
 mod snippet;
@@ -34,6 +35,7 @@ pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
     let auto_save = AutoSaveHandler::new().spawn();
     let document_colors = DocumentColorsHandler::default().spawn();
     let document_links = DocumentLinksHandler::default().spawn();
+    let line_blame = line_blame::LineBlameHandler::default().spawn();
     let word_index = word_index::Handler::spawn();
     let pull_diagnostics = PullDiagnosticsHandler::default().spawn();
     let pull_all_documents_diagnostics = PullAllDocumentsDiagnosticHandler::default().spawn();
@@ -58,6 +60,7 @@ pub fn setup(config: Arc<ArcSwap<Config>>) -> Handlers {
     snippet::register_hooks(&handlers);
     document_colors::register_hooks(&handlers);
     document_links::register_hooks(&handlers);
+    line_blame::register_hooks(&handlers, line_blame);
     prompt::register_hooks(&handlers);
     workspace_trust::register_hooks(&handlers);
     handlers

--- a/helix-term/src/handlers/line_blame.rs
+++ b/helix-term/src/handlers/line_blame.rs
@@ -1,0 +1,211 @@
+use std::{collections::HashSet, path::PathBuf, time::Duration};
+
+use helix_event::{register_hook, send_blocking, AsyncHook};
+use helix_view::{
+    events::{ConfigDidChange, DocumentDidChange, DocumentDidOpen, SelectionDidChange},
+    handlers::Handlers,
+    DocumentId, Editor, ViewId,
+};
+use tokio::sync::mpsc::Sender;
+use tokio::time::Instant;
+
+use crate::job;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(super) struct LineBlameEvent {
+    doc_id: DocumentId,
+    view_id: ViewId,
+}
+
+#[derive(Default)]
+pub(super) struct LineBlameHandler {
+    requests: HashSet<LineBlameEvent>,
+}
+
+const LINE_BLAME_DEBOUNCE: Duration = Duration::from_millis(150);
+
+fn line_is_blank(text: helix_core::RopeSlice, line: usize) -> bool {
+    line >= text.len_lines() || text.line(line).chars().all(char::is_whitespace)
+}
+
+impl AsyncHook for LineBlameHandler {
+    type Event = LineBlameEvent;
+
+    fn handle_event(&mut self, event: Self::Event, _timeout: Option<Instant>) -> Option<Instant> {
+        self.requests.insert(event);
+        Some(Instant::now() + LINE_BLAME_DEBOUNCE)
+    }
+
+    fn finish_debounce(&mut self) {
+        let requests = std::mem::take(&mut self.requests);
+        job::dispatch_blocking(move |editor, _| {
+            for request in requests {
+                request_line_blame(editor, request.doc_id, request.view_id);
+            }
+        });
+    }
+}
+
+fn request_line_blame(editor: &mut Editor, doc_id: DocumentId, view_id: ViewId) {
+    let diff_providers = editor.diff_providers.clone();
+    let Some(doc) = editor.document_mut(doc_id) else {
+        return;
+    };
+
+    if !doc.config.load().inline_blame {
+        doc.clear_line_blame(view_id);
+        return;
+    }
+
+    let Some(path) = doc.path().map(ToOwned::to_owned) else {
+        doc.clear_line_blame(view_id);
+        return;
+    };
+
+    let Some(selection) = doc.selections().get(&view_id) else {
+        return;
+    };
+
+    let text = doc.text().slice(..);
+    let line = selection.primary().cursor_line(text);
+    if line_is_blank(text, line) {
+        doc.clear_line_blame(view_id);
+        return;
+    }
+
+    let contents = doc.is_modified().then(|| text.to_string());
+    let version = doc.version();
+
+    tokio::spawn(async move {
+        let blame_path = path.clone();
+        let blame = tokio::task::spawn_blocking(move || {
+            diff_providers.get_line_blame(&blame_path, contents.as_deref(), line)
+        })
+        .await
+        .ok()
+        .flatten();
+
+        job::dispatch(move |editor, _| {
+            apply_line_blame(editor, doc_id, view_id, path, version, line, blame);
+        })
+        .await;
+    });
+}
+
+fn apply_line_blame(
+    editor: &mut Editor,
+    doc_id: DocumentId,
+    view_id: ViewId,
+    path: PathBuf,
+    version: i32,
+    line: usize,
+    blame: Option<helix_vcs::BlameLine>,
+) {
+    let Some(doc) = editor.document_mut(doc_id) else {
+        return;
+    };
+
+    if !doc.config.load().inline_blame {
+        doc.clear_line_blame(view_id);
+        return;
+    }
+
+    if doc.version() != version || doc.path() != Some(path.as_path()) {
+        return;
+    }
+
+    let Some(selection) = doc.selections().get(&view_id) else {
+        return;
+    };
+
+    if selection.primary().cursor_line(doc.text().slice(..)) != line {
+        return;
+    }
+    if line_is_blank(doc.text().slice(..), line) {
+        doc.clear_line_blame(view_id);
+        return;
+    }
+
+    match blame {
+        Some(blame) => doc.set_line_blame(
+            view_id,
+            line,
+            format!("  {}, {}", blame.author(), blame.timestamp()),
+        ),
+        None => doc.clear_line_blame(view_id),
+    }
+}
+
+fn queue_line_blame(tx: &Sender<LineBlameEvent>, doc_id: DocumentId, view_id: ViewId) {
+    send_blocking(tx, LineBlameEvent { doc_id, view_id });
+}
+
+pub(super) fn register_hooks(_handlers: &Handlers, tx: Sender<LineBlameEvent>) {
+    let line_blame = tx.clone();
+    register_hook!(move |event: &mut SelectionDidChange<'_>| {
+        if event.doc.config.load().inline_blame {
+            let line = event
+                .doc
+                .selection(event.view)
+                .primary()
+                .cursor_line(event.doc.text().slice(..));
+            if line_is_blank(event.doc.text().slice(..), line) {
+                event.doc.clear_line_blame(event.view);
+                return Ok(());
+            }
+            if !event.doc.has_line_blame_for_line(event.view, line) {
+                event.doc.clear_line_blame(event.view);
+                queue_line_blame(&line_blame, event.doc.id(), event.view);
+            }
+        }
+        Ok(())
+    });
+
+    let line_blame = tx.clone();
+    register_hook!(move |event: &mut DocumentDidChange<'_>| {
+        if event.doc.config.load().inline_blame && !event.ghost_transaction {
+            event.doc.clear_line_blame(event.view);
+            let line = event
+                .doc
+                .selection(event.view)
+                .primary()
+                .cursor_line(event.doc.text().slice(..));
+            if !line_is_blank(event.doc.text().slice(..), line) {
+                queue_line_blame(&line_blame, event.doc.id(), event.view);
+            }
+        }
+        Ok(())
+    });
+
+    let line_blame = tx.clone();
+    register_hook!(move |event: &mut DocumentDidOpen<'_>| {
+        if !event.editor.config().inline_blame {
+            return Ok(());
+        }
+
+        let view_id = event.editor.tree.focus;
+        if event.editor.tree.try_get(view_id).is_some() {
+            queue_line_blame(&line_blame, event.doc, view_id);
+        }
+        Ok(())
+    });
+
+    register_hook!(move |event: &mut ConfigDidChange<'_>| {
+        if !event.old.inline_blame && event.new.inline_blame {
+            let view_id = event.editor.tree.focus;
+            let Some(view) = event.editor.tree.try_get(view_id) else {
+                return Ok(());
+            };
+            queue_line_blame(&tx, view.doc, view_id);
+            return Ok(());
+        }
+
+        if event.old.inline_blame && !event.new.inline_blame {
+            for doc in event.editor.documents_mut() {
+                doc.clear_all_line_blames();
+            }
+        }
+
+        Ok(())
+    });
+}

--- a/helix-vcs/src/blame.rs
+++ b/helix-vcs/src/blame.rs
@@ -1,0 +1,19 @@
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlameLine {
+    author: String,
+    timestamp: String,
+}
+
+impl BlameLine {
+    pub fn new(author: String, timestamp: String) -> Self {
+        Self { author, timestamp }
+    }
+
+    pub fn author(&self) -> &str {
+        &self.author
+    }
+
+    pub fn timestamp(&self) -> &str {
+        &self.timestamp
+    }
+}

--- a/helix-vcs/src/git.rs
+++ b/helix-vcs/src/git.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Context, Result};
 use arc_swap::ArcSwap;
 use gix::filter::plumbing::driver::apply::Delay;
-use std::io::Read;
-use std::path::Path;
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
 use std::sync::Arc;
 
 use gix::bstr::ByteSlice;
@@ -17,7 +18,7 @@ use gix::status::{
 };
 use gix::{Commit, ObjectId, Repository, ThreadSafeRepository};
 
-use crate::FileChange;
+use crate::{BlameLine, FileChange};
 
 #[cfg(test)]
 mod test;
@@ -79,6 +80,40 @@ pub fn get_current_head_name(file: &Path) -> Result<Arc<ArcSwap<Box<str>>>> {
     Ok(Arc::new(ArcSwap::from_pointee(name.into_boxed_str())))
 }
 
+pub fn line_blame(file: &Path, contents: Option<&str>, line: usize) -> Result<BlameLine> {
+    debug_assert!(!file.exists() || file.is_file());
+    debug_assert!(file.is_absolute());
+    let file = gix::path::realpath(file).context("resolve symlinks")?;
+
+    let repo_dir = get_repo_dir(&file)?;
+    let work_dir = repo_workdir(repo_dir)?;
+    let relative_path = file.strip_prefix(&work_dir)?;
+    let line_range = format!("{},+1", line + 1);
+
+    let output = if let Some(contents) = contents {
+        git_command_with_stdin_and_path(
+            &work_dir,
+            &[
+                "blame",
+                "--line-porcelain",
+                "--contents",
+                "-",
+                "-L",
+                line_range.as_str(),
+            ],
+            relative_path,
+            contents.as_bytes(),
+        )?
+    } else {
+        git_command_with_path(
+            &work_dir,
+            &["blame", "--line-porcelain", "-L", line_range.as_str()],
+            relative_path,
+        )?
+    };
+    parse_blame_output(&String::from_utf8_lossy(&output.stdout))
+}
+
 pub fn for_each_changed_file(cwd: &Path, f: impl Fn(Result<FileChange>) -> bool) -> Result<()> {
     status(&open_repo(cwd)?.to_thread_local(), f)
 }
@@ -123,6 +158,135 @@ fn open_repo(path: &Path) -> Result<ThreadSafeRepository> {
     )?;
 
     Ok(res)
+}
+
+fn repo_workdir(cwd: &Path) -> Result<PathBuf> {
+    let repo = open_repo(cwd)?.to_thread_local();
+    let work_dir = repo
+        .workdir()
+        .ok_or_else(|| anyhow::anyhow!("working tree not found"))?;
+
+    Ok(std::fs::canonicalize(work_dir).unwrap_or_else(|_| work_dir.to_path_buf()))
+}
+
+fn git_command_with_path(cwd: &Path, args: &[&str], path: &Path) -> Result<Output> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .arg("--")
+        .arg(path)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_ASKPASS")
+        .env_remove("SSH_ASKPASS")
+        .env("GIT_TERMINAL_PROMPT", "false")
+        .output()
+        .with_context(|| format!("failed to run `git {}`", args.join(" ")))?;
+    if !output.status.success() {
+        bail!("{}", git_failure_message(args, &output));
+    }
+
+    Ok(output)
+}
+
+fn git_command_with_stdin_and_path(
+    cwd: &Path,
+    args: &[&str],
+    path: &Path,
+    stdin: &[u8],
+) -> Result<Output> {
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(cwd)
+        .args(args)
+        .arg("--")
+        .arg(path)
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_ASKPASS")
+        .env_remove("SSH_ASKPASS")
+        .env("GIT_TERMINAL_PROMPT", "false")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to run `git {}`", args.join(" ")))?;
+
+    child
+        .stdin
+        .as_mut()
+        .context("failed to open git stdin")?
+        .write_all(stdin)
+        .context("failed to write git stdin")?;
+
+    let output = child
+        .wait_with_output()
+        .with_context(|| format!("failed to run `git {}`", args.join(" ")))?;
+    if !output.status.success() {
+        bail!("{}", git_failure_message(args, &output));
+    }
+
+    Ok(output)
+}
+
+fn git_failure_message(args: &[&str], output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    let message = if stderr.is_empty() {
+        format!("exit status {}", output.status)
+    } else {
+        stderr.to_string()
+    };
+    format!("git {} failed: {message}", args.join(" "))
+}
+
+fn parse_blame_output(output: &str) -> Result<BlameLine> {
+    let commit = output
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .context("missing blame commit")?;
+    if commit.chars().all(|ch| ch == '0') {
+        bail!("line has no committed blame");
+    }
+
+    let mut author = None;
+    let mut author_time = None;
+    let mut author_tz = None;
+
+    for line in output.lines().skip(1) {
+        if line.starts_with('\t') {
+            break;
+        }
+
+        if let Some(value) = line.strip_prefix("author ") {
+            author = Some(value.to_string());
+        } else if let Some(value) = line.strip_prefix("author-time ") {
+            author_time = Some(value.parse::<gix::date::SecondsSinceUnixEpoch>()?);
+        } else if let Some(value) = line.strip_prefix("author-tz ") {
+            author_tz = Some(parse_git_timezone(value)?);
+        }
+    }
+
+    let author = author.context("missing blame author")?;
+    let time = gix::date::Time {
+        seconds: author_time.context("missing blame author time")?,
+        offset: author_tz.context("missing blame author timezone")?,
+    };
+    let timestamp = time.format_or_unix(gix::date::time::CustomFormat::new("%Y-%m-%d %H:%M"));
+
+    Ok(BlameLine::new(author, timestamp))
+}
+
+fn parse_git_timezone(value: &str) -> Result<gix::date::OffsetInSeconds> {
+    let bytes = value.as_bytes();
+    if bytes.len() != 5 || !matches!(bytes[0], b'+' | b'-') {
+        bail!("invalid git timezone: {value}");
+    }
+
+    let hours = value[1..3].parse::<i32>()?;
+    let minutes = value[3..5].parse::<i32>()?;
+    let offset = hours * 60 * 60 + minutes * 60;
+    Ok(if bytes[0] == b'-' { -offset } else { offset })
 }
 
 /// Emulates the result of running `git status` from the command line.

--- a/helix-vcs/src/git/test.rs
+++ b/helix-vcs/src/git/test.rs
@@ -126,6 +126,63 @@ fn symlink() {
     assert_eq!(git::get_diff_base(&file).unwrap(), contents);
 }
 
+#[test]
+fn parse_blame_output_reads_author_and_timestamp() {
+    let output = "\
+abef92a9b341209aeae8802d30fc8c1f971a43df 1 1 1
+author Pascal Kuthe
+author-mail <pascal.kuthe@example.com>
+author-time 1679823847
+author-tz +0200
+summary message
+filename file.txt
+\tcontents
+";
+
+    let blame = git::parse_blame_output(output).unwrap();
+    assert_eq!(blame.author(), "Pascal Kuthe");
+    assert_eq!(blame.timestamp(), "2023-03-26 11:44");
+}
+
+#[test]
+fn parse_blame_output_ignores_uncommitted_lines() {
+    let output = "\
+0000000000000000000000000000000000000000 1 1 1
+author External file (--contents)
+author-time 1679823847
+author-tz +0200
+filename file.txt
+\tcontents
+";
+
+    assert!(git::parse_blame_output(output).is_err());
+}
+
+#[test]
+fn line_blame_reads_author_for_clean_file() {
+    let temp_git = empty_git_repo();
+    let file = temp_git.path().join("file.txt");
+    File::create(&file).unwrap().write_all(b"hello\n").unwrap();
+    create_commit(temp_git.path(), true);
+
+    let blame = git::line_blame(&file, None, 0).unwrap();
+    assert_eq!(blame.author(), "author");
+    assert!(!blame.timestamp().is_empty());
+}
+
+#[test]
+fn line_blame_uses_unsaved_contents() {
+    let temp_git = empty_git_repo();
+    let file = temp_git.path().join("file.txt");
+    File::create(&file).unwrap().write_all(b"hello\n").unwrap();
+    create_commit(temp_git.path(), true);
+
+    assert!(git::line_blame(&file, Some("new\nhello\n"), 0).is_err());
+
+    let blame = git::line_blame(&file, Some("new\nhello\n"), 1).unwrap();
+    assert_eq!(blame.author(), "author");
+}
+
 /// Test that `get_diff_base` returns content when the file is a symlink to
 /// another file that is in a git repo, but the symlink itself is not.
 #[cfg(any(unix, windows))]

--- a/helix-vcs/src/lib.rs
+++ b/helix-vcs/src/lib.rs
@@ -12,8 +12,10 @@ use std::{
 #[cfg(feature = "git")]
 mod git;
 
+mod blame;
 mod diff;
 
+pub use blame::BlameLine;
 pub use diff::{DiffHandle, Hunk};
 
 mod status;
@@ -55,6 +57,28 @@ impl DiffProviderRegistry {
                     None
                 }
             })
+    }
+
+    pub fn get_line_blame(
+        &self,
+        file: &Path,
+        contents: Option<&str>,
+        line: usize,
+    ) -> Option<BlameLine> {
+        self.providers.iter().find_map(|provider| {
+            match provider.get_line_blame(file, contents, line) {
+                Ok(res) => Some(res),
+                Err(err) => {
+                    log::debug!("{err:#?}");
+                    log::debug!(
+                        "failed to obtain line blame for {}:{}",
+                        file.display(),
+                        line + 1
+                    );
+                    None
+                }
+            }
+        })
     }
 
     /// Fire-and-forget changed file iteration. Runs everything in a background task. Keeps
@@ -114,6 +138,19 @@ impl DiffProvider {
         match self {
             #[cfg(feature = "git")]
             Self::Git => git::get_current_head_name(file),
+            Self::None => bail!("No diff support compiled in"),
+        }
+    }
+
+    fn get_line_blame(
+        &self,
+        _file: &Path,
+        _contents: Option<&str>,
+        _line: usize,
+    ) -> Result<BlameLine> {
+        match self {
+            #[cfg(feature = "git")]
+            Self::Git => git::line_blame(_file, _contents, _line),
             Self::None => bail!("No diff support compiled in"),
         }
     }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -40,7 +40,8 @@ use helix_core::{
     indent::{auto_detect_indent_style, IndentStyle},
     line_ending::auto_detect_line_ending,
     syntax::{self, config::LanguageConfiguration},
-    ChangeSet, Diagnostic, LineEnding, Range, Rope, RopeBuilder, Selection, Syntax, Transaction,
+    ChangeSet, Diagnostic, LineEnding, Range, Rope, RopeBuilder, RopeSlice, Selection, Syntax,
+    Transaction,
 };
 
 use crate::{
@@ -60,6 +61,25 @@ const DEFAULT_TAB_WIDTH: usize = 4;
 pub const DEFAULT_LANGUAGE_NAME: &str = "text";
 
 pub const SCRATCH_BUFFER_NAME: &str = "[scratch]";
+
+fn line_end_char_idx(text: RopeSlice, line: usize) -> Option<usize> {
+    if line >= text.len_lines() {
+        return None;
+    }
+
+    let line_start = text.line_to_char(line);
+    let next_line_start = text.line_to_char((line + 1).min(text.len_lines()));
+    let mut line_end = next_line_start;
+
+    if line_end > line_start && text.char(line_end - 1) == '\n' {
+        line_end -= 1;
+    }
+    if line_end > line_start && text.char(line_end - 1) == '\r' {
+        line_end -= 1;
+    }
+
+    Some(line_end)
+}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Mode {
@@ -149,6 +169,8 @@ pub struct Document {
     ///
     /// To know if they're up-to-date, check the `id` field in `DocumentInlayHints`.
     pub(crate) inlay_hints: HashMap<ViewId, DocumentInlayHints>,
+    /// Current-line VCS blame annotations for the document, by view.
+    pub(crate) line_blame_annotations: HashMap<ViewId, Vec<InlineAnnotation>>,
     /// Jump label overlays for each view.
     pub(crate) jump_labels: HashMap<ViewId, Vec<Overlay>>,
     /// LSP document highlights for each view, stored as char ranges.
@@ -731,6 +753,7 @@ impl Document {
             text,
             selections: HashMap::default(),
             inlay_hints: HashMap::default(),
+            line_blame_annotations: HashMap::default(),
             inlay_hints_oudated: false,
             view_data: Default::default(),
             indent_style: DEFAULT_INDENT,
@@ -1425,6 +1448,7 @@ impl Document {
     pub fn remove_view(&mut self, view_id: ViewId) {
         self.selections.remove(&view_id);
         self.inlay_hints.remove(&view_id);
+        self.line_blame_annotations.remove(&view_id);
         self.jump_labels.remove(&view_id);
         self.document_highlights.remove(&view_id);
         self.document_highlight_controllers.remove(&view_id);
@@ -2365,6 +2389,38 @@ impl Document {
 
     pub fn remove_jump_labels(&mut self, view_id: ViewId) {
         self.jump_labels.remove(&view_id);
+    }
+
+    pub fn set_line_blame(&mut self, view_id: ViewId, line: usize, text: String) {
+        let Some(char_idx) = line_end_char_idx(self.text().slice(..), line) else {
+            self.clear_line_blame(view_id);
+            return;
+        };
+
+        self.line_blame_annotations
+            .insert(view_id, vec![InlineAnnotation::new(char_idx, text)]);
+    }
+
+    pub fn clear_line_blame(&mut self, view_id: ViewId) {
+        self.line_blame_annotations.remove(&view_id);
+    }
+
+    pub fn clear_all_line_blames(&mut self) {
+        self.line_blame_annotations.clear();
+    }
+
+    pub fn has_line_blame_for_line(&self, view_id: ViewId, line: usize) -> bool {
+        let Some(annotation) = self
+            .line_blame_annotations
+            .get(&view_id)
+            .and_then(|annotations| annotations.first())
+        else {
+            return false;
+        };
+
+        self.text()
+            .char_to_line(annotation.char_idx.min(self.text().len_chars()))
+            == line
     }
 
     pub fn set_document_highlights(

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -310,6 +310,8 @@ pub struct Config {
     pub cursorline: bool,
     /// Highlight the columns cursors are currently on. Defaults to false.
     pub cursorcolumn: bool,
+    /// Show VCS blame author and timestamp on the cursor line. Defaults to false.
+    pub inline_blame: bool,
     #[serde(deserialize_with = "deserialize_gutter_seq_or_struct")]
     pub gutters: GutterConfig,
     /// Middle click paste support. Defaults to true.
@@ -1104,6 +1106,7 @@ impl Default for Config {
             line_number: LineNumber::Absolute,
             cursorline: false,
             cursorcolumn: false,
+            inline_blame: false,
             gutters: GutterConfig::default(),
             middle_click_paste: true,
             auto_pairs: AutoPairConfig::default(),

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -452,6 +452,16 @@ impl View {
             text_annotations.add_overlay(labels, style);
         }
 
+        if let Some(line_blame) = doc.line_blame_annotations.get(&self.id) {
+            let style = theme.and_then(|theme| {
+                theme
+                    .find_highlight_exact("ui.virtual.line-blame")
+                    .or_else(|| theme.find_highlight("comment"))
+                    .or_else(|| theme.find_highlight("ui.virtual"))
+            });
+            text_annotations.add_inline_annotations(line_blame, style);
+        }
+
         if let Some(DocumentInlayHints {
             id: _,
             type_inlay_hints,

--- a/theme.toml
+++ b/theme.toml
@@ -58,6 +58,7 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 "ui.text.inactive" = "sirocco"
 "ui.text.directory" = { fg = "lilac" }
 "ui.virtual" = { fg = "comet" }
+"ui.virtual.line-blame" = { fg = "comet", modifiers = ["italic"] }
 "ui.virtual.ruler" = { bg = "bossanova" }
 "ui.virtual.jump-label" = { fg = "apricot", modifiers = ["bold"] }
 


### PR DESCRIPTION
## Summary
- add optional `[editor] inline-blame` support for current-line Git blame annotations
- render blame as muted inline virtual text with author and timestamp only
- skip blank lines, uncommitted blame records, and stale cursor-line results

## Testing
- cargo check -p helix-term
- cargo test -p helix-vcs --features git
- cargo test -p helix-vcs
- git diff --check