### PR TITLE
fix(indent): require at least 2 indent samples before auto-detecting style

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -181,8 +181,10 @@ pub fn auto_detect_indent_style(document_text: &Rope) -> Option<IndentStyle> {
         .unwrap();
 
     // Return the auto-detected result if we're confident enough in its
-    // accuracy, based on some heuristics.
-    if indent_freq >= 1 && (indent_freq_2 as f64 / indent_freq as f64) < 0.66 {
+    // accuracy, based on some heuristics. Require at least 2 observed
+    // indentation increases to avoid false positives on very short files
+    // where a single data point would dominate the histogram.
+    if indent_freq >= 2 && (indent_freq_2 as f64 / indent_freq as f64) < 0.66 {
         Some(match indent {
             0 => IndentStyle::Tabs,
             _ => IndentStyle::Spaces(indent as u8),
@@ -1152,6 +1154,32 @@ mod test {
             indent_level_for_line(line.slice(..), tab_width, indent_width),
             2
         );
+    }
+
+    #[test]
+    fn test_auto_detect_indent_style() {
+        use crate::Rope;
+
+        // Enough samples → detected
+        let src = "fn foo() {\n  bar();\n  baz();\n}\nfn qux() {\n  quux();\n}\n";
+        assert_eq!(
+            auto_detect_indent_style(&Rope::from(src)),
+            Some(IndentStyle::Spaces(2))
+        );
+
+        // Tabs with enough samples → detected
+        let src = "fn foo() {\n\tbar();\n\tbaz();\n}\nfn qux() {\n\tquux();\n}\n";
+        assert_eq!(
+            auto_detect_indent_style(&Rope::from(src)),
+            Some(IndentStyle::Tabs)
+        );
+
+        // Only one indentation increase → not enough data, returns None
+        let src = "fn foo() {\n  bar();\n}\n";
+        assert_eq!(auto_detect_indent_style(&Rope::from(src)), None);
+
+        // Empty file → None
+        assert_eq!(auto_detect_indent_style(&Rope::from("")), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #9556.

The previous heuristic used `indent_freq >= 1` to decide whether the auto-detected indent style was confident enough to return. On very short files — such as a 3-line function with a single indented body — one sample would pass this check and lock in a result that could easily be wrong.

## Change

Raise the minimum to `indent_freq >= 2`. Detection now requires at least two observed indentation increases before committing to a result; otherwise `None` is returned and the user's configured default is used instead.

This matches the guidance in the issue discussion:
> "requiring at least 2-3 clear examples"

## Tests

Added `test_auto_detect_indent_style` covering:
- File with enough samples → correct style detected
- File with only one indent increase → `None` (not enough data)
- Empty file → `None`

## Before / after

```
// 3-line file with one 2-space indent
fn foo() {
  bar();
}
```

| | Result |
|--|--|
| Before | `Some(Spaces(2))` — false positive from 1 sample |
| After | `None` — defers to user's configured default |