### PR TITLE
perf: reorder `Buffer::diff` short circuit logic

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -9,7 +9,7 @@ pub const SYMBOL_CAPACITY: usize = 28;
 pub type Symbol = arrayvec::ArrayString<SYMBOL_CAPACITY>;
 
 /// One cell of the terminal. Contains one stylized grapheme.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct Cell {
     pub symbol: Symbol,
     /// Cached display width of `symbol` to avoid multiple recomputes in the hot path.
@@ -131,6 +131,19 @@ impl Default for Cell {
             underline_style: UnderlineStyle::Reset,
             modifier: Modifier::empty(),
         }
+    }
+}
+
+impl PartialEq for Cell {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.modifier == other.modifier
+            && self.underline_style == other.underline_style
+            && self.fg == other.fg
+            && self.bg == other.bg
+            && self.underline_color == other.underline_color
+            // Last as its the most expensive
+            && self.symbol == other.symbol
     }
 }
 
@@ -728,8 +741,8 @@ impl Buffer {
     /// Updates: `0: a, 1: コ` (double width symbol at index 1 - skip index 2)
     /// ```
     pub fn diff<'a>(&self, other: &'a Buffer) -> Vec<(u16, u16, &'a Cell)> {
-        let previous_buffer = &self.content;
-        let next_buffer = &other.content;
+        let previous_buffer = self.content.as_slice();
+        let next_buffer = other.content.as_slice();
         let width = self.area.width;
 
         let mut updates: Vec<(u16, u16, &Cell)> = vec![];
@@ -739,7 +752,7 @@ impl Buffer {
         // place (the skipped cells should be blank anyway):
         let mut to_skip: usize = 0;
         for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
-            if (current != previous || invalidated > 0) && to_skip == 0 {
+            if to_skip == 0 && (invalidated > 0 || current != previous) {
                 let x = (i % width as usize) as u16;
                 let y = (i / width as usize) as u16;
                 updates.push((x, y, &next_buffer[i]));


### PR DESCRIPTION
`Buffer::diff` shows up at ~11% in perf samples. The main two parts showing up are for `UnicodeStr::width` and `<Cell as PartialEq>::eq`. Given that we do not control `unicode-width`, I ultimately went about trying to reduce both the calls of and the speed of `Cell`'s `PartialEq`.

Seeing that the comparison of `current != previous` was the most expensive, I first reordered the comparisons so that there would be every opportunity top short circuit before doing the expensive comparison. This also had the benefit of improving partial diff performance, as well as the performance for wide chars(like emojis). After this, I then addressed the `PartialEq` implementation.

In `master`, `PartialEq` was derived, so I switched to a manual implementation for better control of the order in which the checks are done for better short circuiting. In profiling I saw that the comparison of the Cell's symbol was the most expensive, so I made the symbol comparison was last, giving every opportunity to break early before the string comparison. 

Doing this things I saw these benchmarks(#15229)(I seem to have some system noise affecting the benchmarks that is happening to catch at a regular interval, and happened twice in the benchmarking, which you can see):

```shell
buffer/empty/16         time:   [4.7213 µs 4.7235 µs 4.7257 µs]
                        change: [−4.6790% −4.2893% −3.9777%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) high mild
  11 (11.00%) high severe
buffer/empty/64         time:   [82.317 µs 82.410 µs 82.499 µs]
                        change: [−3.7764% −3.1045% −2.0507%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
buffer/empty/255        time:   [1.3152 ms 1.3175 ms 1.3201 ms]
                        change: [−3.0807% −2.3638% −1.3968%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

buffer/filled/16        time:   [5.2842 µs 5.2942 µs 5.3053 µs]
                        change: [+1.4992% +1.9612% +2.4179%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
buffer/filled/64        time:   [81.488 µs 81.574 µs 81.651 µs]
                        change: [−4.3184% −3.5642% −2.3369%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
buffer/filled/255       time:   [1.3113 ms 1.3128 ms 1.3142 ms]
                        change: [−4.0081% −3.3653% −2.3833%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

buffer/diff_no_change/16
                        time:   [2.2370 µs 2.2391 µs 2.2414 µs]
                        change: [−0.9227% −0.6744% −0.4481%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
buffer/diff_no_change/64
                        time:   [35.600 µs 35.612 µs 35.623 µs]
                        change: [−0.8598% −0.1665% +0.9001%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  3 (3.00%) high severe
buffer/diff_no_change/128
                        time:   [143.05 µs 143.10 µs 143.17 µs]
                        change: [−3.0356% −1.6578% −0.0095%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

buffer/diff_partial_change/16
                        time:   [2.4515 µs 2.4655 µs 2.4796 µs]
                        change: [−4.5690% −4.0725% −3.6028%] (p = 0.00 < 0.05)
                        Performance has improved.
buffer/diff_partial_change/64
                        time:   [38.490 µs 38.551 µs 38.606 µs]
                        change: [−8.3364% −7.3786% −6.0108%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) low severe
  1 (1.00%) low mild
  1 (1.00%) high severe
buffer/diff_partial_change/128
                        time:   [152.51 µs 152.97 µs 153.42 µs]
                        change: [−3.3775% −2.3604% −0.7075%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  7 (7.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe

buffer/diff_full_change/16
                        time:   [2.6385 µs 2.6445 µs 2.6497 µs]
                        change: [−0.6511% −0.1549% +0.3575%] (p = 0.56 > 0.05)
                        No change in performance detected.
Found 15 outliers among 100 measurements (15.00%)
  15 (15.00%) high mild
buffer/diff_full_change/64
                        time:   [39.018 µs 39.188 µs 39.386 µs]
                        change: [−0.4811% +0.7086% +2.3852%] (p = 0.40 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
buffer/diff_full_change/128
                        time:   [153.70 µs 153.74 µs 153.79 µs]
                        change: [+2.3340% +3.0994% +4.3846%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

buffer/diff_multi_width/16
                        time:   [2.2115 µs 2.2145 µs 2.2172 µs]
                        change: [−7.7331% −7.3321% −6.9405%] (p = 0.00 < 0.05)
                        Performance has improved.
buffer/diff_multi_width/64
                        time:   [33.517 µs 33.658 µs 33.822 µs]
                        change: [−9.5526% −8.4886% −7.0878%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

buffer/diff_emoji/16    time:   [2.7230 µs 2.7254 µs 2.7279 µs]
                        change: [−10.181% −9.8357% −9.5017%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
buffer/diff_emoji/64    time:   [37.547 µs 38.294 µs 39.115 µs]
                        change: [−20.149% −18.664% −17.033%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  8 (8.00%) high severe
```

The workload was to open `typed.rs` and select lines until right around line 1000. The overall samples of `Buffer::diff` with this workload went from ~11% to ~7%(See the end, I had some ranges for both, in what would be stressing partial updates by changing the background color by selecting the cell + the line movement were there could be the same text from one line to another but maybe some slight changes in color or if there is an underline.). So about ~4% faster overall. This scenario is something I would consider pathological, so there would be less work done in normal usage. Overall, its still very hard to try to get samples from a realistic workload.

As a small change, I changed the `&Vec<Celll>` of `content` to `&[Cell]`. It has about a 1-2% improvement in the benchmarks. Not much but better than nothing.

As for the calls to `unicode-width`, I wonder if there can be a fast-path opportunity, but need to explore more. This would not only help this area, but anywhere this is called.