### PR TITLE
perf: fast-path cell sameness in `Buffer::diff`

### DIFF
--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -7,7 +7,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use helix_view::graphics::{Color, Modifier, Rect, Style, UnderlineStyle};
 
 /// One cell of the terminal. Contains one stylized grapheme.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct Cell {
     pub symbol: String,
     pub fg: Color,
@@ -96,6 +96,19 @@ impl Default for Cell {
             underline_style: UnderlineStyle::Reset,
             modifier: Modifier::empty(),
         }
+    }
+}
+
+impl PartialEq for Cell {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.modifier == other.modifier
+            && self.underline_style == other.underline_style
+            && self.fg == other.fg
+            && self.bg == other.bg
+            && self.underline_color == other.underline_color
+            // Last as its the most expensive
+            && self.symbol == other.symbol
     }
 }
 
@@ -694,8 +707,8 @@ impl Buffer {
     /// Updates: `0: a, 1: コ` (double width symbol at index 1 - skip index 2)
     /// ```
     pub fn diff<'a>(&self, other: &'a Buffer) -> Vec<(u16, u16, &'a Cell)> {
-        let previous_buffer = &self.content;
-        let next_buffer = &other.content;
+        let previous_buffer = self.content.as_slice();
+        let next_buffer = other.content.as_slice();
         let width = self.area.width;
 
         let mut updates: Vec<(u16, u16, &Cell)> = vec![];
@@ -705,7 +718,7 @@ impl Buffer {
         // place (the skipped cells should be blank anyway):
         let mut to_skip: usize = 0;
         for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
-            if (current != previous || invalidated > 0) && to_skip == 0 {
+            if to_skip == 0 && (invalidated > 0 || current != previous) {
                 let x = (i % width as usize) as u16;
                 let y = (i / width as usize) as u16;
                 updates.push((x, y, &next_buffer[i]));

--- a/helix-tui/src/buffer.rs
+++ b/helix-tui/src/buffer.rs
@@ -18,6 +18,14 @@ pub struct Cell {
 }
 
 impl Cell {
+    #[must_use]
+    pub fn new(symbol: &str) -> Self {
+        Self {
+            symbol: symbol.to_owned(),
+            ..Default::default()
+        }
+    }
+
     /// Set the cell's grapheme
     pub fn set_symbol(&mut self, symbol: &str) -> &mut Cell {
         self.symbol.clear();
@@ -707,8 +715,8 @@ impl Buffer {
     /// Updates: `0: a, 1: コ` (double width symbol at index 1 - skip index 2)
     /// ```
     pub fn diff<'a>(&self, other: &'a Buffer) -> Vec<(u16, u16, &'a Cell)> {
-        let previous_buffer = self.content.as_slice();
-        let next_buffer = other.content.as_slice();
+        let prev = self.content.as_slice();
+        let next = other.content.as_slice();
         let width = self.area.width;
 
         let mut updates: Vec<(u16, u16, &Cell)> = vec![];
@@ -717,11 +725,49 @@ impl Buffer {
         // Cells from the current buffer to skip due to preceding multi-width characters taking their
         // place (the skipped cells should be blank anyway):
         let mut to_skip: usize = 0;
-        for (i, (current, previous)) in next_buffer.iter().zip(previous_buffer.iter()).enumerate() {
+
+        let mut x: u16 = 0;
+        let mut y: u16 = 0;
+
+        let mut i = 0;
+
+        let len = std::cmp::min(next.len(), prev.len());
+
+        while i < len {
+            // PERF: Fast-Path
+            // In typical text-editing scenarios (e.g., typing, cursor navigation, scrolling),
+            // the vast majority of terminal screen cells remain static frame-over-frame.
+            //
+            // This inner loop acts as a filter to prevent doing more expensive operations,
+            // such as potential allocations and calls to `width`, unless absolutely necessary.
+            //
+            // NOTE:
+            // This cuts partial diffing times by ~50% at the cost of a ~30% regression
+            // during total redraws (e.g., changing color themes).
+            while i < len && to_skip == 0 && invalidated == 0 && next[i] == prev[i] {
+                x += 1;
+                if x >= width {
+                    x = 0;
+                    y += 1;
+                }
+                i += 1;
+            }
+
+            if i >= len {
+                break;
+            }
+
+            let current = &next[i];
+            let previous = &prev[i];
+
             if to_skip == 0 && (invalidated > 0 || current != previous) {
-                let x = (i % width as usize) as u16;
-                let y = (i / width as usize) as u16;
-                updates.push((x, y, &next_buffer[i]));
+                updates.push((x, y, current));
+            }
+
+            x += 1;
+            if x >= width {
+                x = 0;
+                y += 1;
             }
 
             let current_width = current.symbol.width();
@@ -729,7 +775,10 @@ impl Buffer {
 
             let affected_width = std::cmp::max(current_width, previous.symbol.width());
             invalidated = std::cmp::max(affected_width, invalidated).saturating_sub(1);
+
+            i += 1;
         }
+
         updates
     }
 }


### PR DESCRIPTION
This builds on #15821 and includes whatever performance that gives along with the changes here.

Unlike that PR, this one is more nuanced in that there are optimizations at the cost of pessimizations, as seen below: 

```shell
buffer/empty/16         time:   [4.8199 µs 4.8419 µs 4.8679 µs]
                        change: [−2.6809% −2.2238% −1.8155%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
buffer/empty/64         time:   [82.337 µs 82.534 µs 82.766 µs]
                        change: [−3.8595% −3.4773% −3.1145%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe
buffer/empty/255        time:   [1.3223 ms 1.3253 ms 1.3282 ms]
                        change: [−2.3087% −1.4884% −0.4783%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high severe

buffer/filled/16        time:   [5.2871 µs 5.2954 µs 5.3052 µs]
                        change: [+1.0383% +1.4895% +1.9577%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
buffer/filled/64        time:   [80.679 µs 80.877 µs 81.142 µs]
                        change: [−4.5287% −3.6825% −2.4996%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
buffer/filled/255       time:   [1.3097 ms 1.3126 ms 1.3152 ms]
                        change: [−4.3921% −3.7152% −2.7140%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

buffer/diff_no_change/16
                        time:   [929.16 ns 930.77 ns 933.06 ns]
                        change: [−58.761% −58.651% −58.544%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
buffer/diff_no_change/64
                        time:   [14.944 µs 14.976 µs 15.014 µs]
                        change: [−58.339% −58.001% −57.461%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
buffer/diff_no_change/128
                        time:   [59.914 µs 60.090 µs 60.312 µs]
                        change: [−59.424% −58.820% −58.034%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  1 (1.00%) high mild
  18 (18.00%) high severe

buffer/diff_partial_change/16
                        time:   [1.3396 µs 1.3416 µs 1.3445 µs]
                        change: [−47.910% −47.719% −47.545%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
buffer/diff_partial_change/64
                        time:   [19.823 µs 19.859 µs 19.901 µs]
                        change: [−52.726% −52.202% −51.492%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
buffer/diff_partial_change/128
                        time:   [77.342 µs 77.634 µs 77.998 µs]
                        change: [−50.844% −50.178% −49.277%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

buffer/diff_full_change/16
                        time:   [3.5487 µs 3.5601 µs 3.5761 µs]
                        change: [+34.221% +34.928% +35.630%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe
buffer/diff_full_change/64
                        time:   [53.487 µs 53.678 µs 53.885 µs]
                        change: [+36.189% +37.786% +39.878%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe
buffer/diff_full_change/128
                        time:   [210.06 µs 210.36 µs 210.68 µs]
                        change: [+39.831% +40.929% +43.144%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

buffer/diff_multi_width/16
                        time:   [2.5109 µs 2.5135 µs 2.5164 µs]
                        change: [+5.0914% +6.3047% +8.1144%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
buffer/diff_multi_width/64
                        time:   [37.204 µs 37.251 µs 37.299 µs]
                        change: [−0.3551% +0.7205% +2.1961%] (p = 0.36 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

buffer/diff_emoji/16    time:   [2.8508 µs 2.8554 µs 2.8598 µs]
                        change: [−5.8161% −5.4131% −4.9896%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
buffer/diff_emoji/64    time:   [40.363 µs 40.593 µs 40.855 µs]
                        change: [−13.541% −12.040% −10.341%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  6 (6.00%) high mild
  9 (9.00%) high severe
```

The main idea is that we optimize for the expected use case of editing actions, at the expense of less performance for things that are not, like changing themes.

before:
<img width="1889" height="362" alt="image" src="https://github.com/user-attachments/assets/dba0b813-2efe-4332-b1c5-bf2bca8341bf" />

after:
<img width="1889" height="362" alt="image" src="https://github.com/user-attachments/assets/76df1ebf-e424-40d7-82ef-b8ca96a4a847" />
