### PR TITLE
Bump tree house to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3095,9 +3095,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tree-house"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00ea55222392f171ae004dd13b62edd09d995633abf0c13406a8df3547fb999"
+checksum = "333476442882205ab249a8ced263ae53db3d0797c727cc3424836a6fb221d7b1"
 dependencies = [
  "arc-swap",
  "hashbrown 0.15.5",
@@ -3112,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "tree-house-bindings"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbcbb59cca301d903c11b48b722b7c85f0e0001be2f65655cd417d98c6f3121"
+checksum = "58e4bee70ada3fca497abeb498c4919a192ce84eb8b747145277240494454372"
 dependencies = [
  "cc",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ package.helix-tui.opt-level = 2
 package.helix-term.opt-level = 2
 
 [workspace.dependencies]
-tree-house = { version = "0.3.0", default-features = false }
+tree-house = { version = "0.4", default-features = false }
 nucleo = "0.5.0"
 slotmap = "1.1.1"
 thiserror = "2.0"

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [Languages](./languages.md)
 - [Guides](./guides/README.md)
   - [Adding languages](./guides/adding_languages.md)
+  - [Adding locals queries](./guides/locals.md)
   - [Adding textobject queries](./guides/textobject.md)
   - [Adding indent queries](./guides/indent.md)
   - [Adding injection queries](./guides/injection.md)

--- a/book/src/guides/locals.md
+++ b/book/src/guides/locals.md
@@ -1,0 +1,92 @@
+## Adding Locals Queries
+
+`locals.scm` queries teach Helix about variable scopes and definitions so that
+local variables can be highlighted distinctly from global ones. When a
+`@local.reference` identifier is resolved to a `@local.definition`, it inherits
+the highlight class of that definition rather than the class assigned by
+`highlights.scm`.
+
+Query files should be placed in `runtime/queries/{language}/locals.scm` when
+contributing to Helix.
+
+## Captures
+
+### `@local.scope`
+
+Marks a node as a scope boundary. Definitions are only visible to references
+that appear inside the same scope or a nested one. Typical scope nodes are
+function bodies and blocks.
+
+```scm
+[
+  (function_definition)
+  (block)
+] @local.scope
+```
+
+### `@local.definition.*`
+
+Marks a name node as introducing a local symbol. The suffix after
+`@local.definition.` becomes the highlight class applied to any reference that
+resolves to this definition. For example, `@local.definition.variable.parameter`
+causes matching references to be highlighted as `variable.parameter`.
+
+```scm
+(function_item
+  (parameters
+    (parameter
+      pattern: (identifier) @local.definition.variable.parameter)))
+```
+
+Common suffixes mirror the highlight classes in `highlights.scm`:
+`variable`, `variable.parameter`, `variable.builtin`, `variable.mutable`,
+`function`, `namespace`, `type`, `constant`, etc.
+
+### `@local.reference`
+
+Marks an identifier node as a potential reference to a local definition.
+Helix searches enclosing scopes for a matching definition and, if found,
+highlights the reference with that definition's class instead.
+
+```scm
+(identifier) @local.reference
+```
+
+## Discard captures
+
+Any capture in `locals.scm` that is not `@local.scope`, `@local.reference`, or
+`@local.definition.*` acts as a discard. It prevents a `@local.reference` from
+being resolved at that node without affecting the `highlights.scm` result. This
+is useful for identifier nodes that look like references but should not be
+treated as variable references, for example keyword argument names or struct
+field names in struct literals.
+
+```scm
+; Keyword argument names in a call are not variable references.
+(keyword_argument
+  name: (identifier) @_)
+```
+
+Later patterns in a query file have higher precedence than earlier ones. A
+discard pattern must appear after the `@local.reference` pattern it is intended
+to override. Placing it later ensures it takes precedence and cancels the
+reference resolution for nodes it matches.
+
+The convention is to use a capture name beginning with an underscore (e.g. `@_`,
+`@_keyword`) to make the discard intent clear, but any non-`@local.*` name works.
+
+## How definitions and references are matched
+
+Helix matches references to definitions by comparing the text of the reference
+node against the text of definitions visible from the current scope. Definitions
+in inner scopes shadow those in outer scopes. If no definition is found the
+reference is left with its `highlights.scm` highlight.
+
+## Relationship with `highlights.scm`
+
+The locals system runs alongside `highlights.scm`, not instead of it.
+`highlights.scm` always determines the baseline highlight for a node.
+`locals.scm` can override that highlight only when a `@local.reference`
+successfully resolves to a `@local.definition`, and only for that specific
+resolution. Non-`@local.*` captures in `locals.scm` (i.e. discards) have no
+effect on `highlights.scm` results.

--- a/book/src/guides/tags.md
+++ b/book/src/guides/tags.md
@@ -13,7 +13,12 @@ when contributing to Helix. You may place these under your local runtime
 directory (`~/.config/helix/runtime` in Linux for example) for the sake of
 testing.
 
-The following [captures][tree-sitter-captures] are recognized:
+## Captures
+
+### `@definition.*`
+
+Marks a node as a symbol definition. The following definition captures are
+recognized:
 
 | Capture name           |
 |---                     |
@@ -29,9 +34,28 @@ The following [captures][tree-sitter-captures] are recognized:
 | `definition.struct`    |
 | `definition.type`      |
 
+### `@name`
+
+Marks the name identifier node within a match. `@definition.*` should capture
+the entire definition node, and `@name` should capture the name identifier
+within that same match:
+
+```scm
+(function_definition
+  name: (identifier) @name) @definition.function
+
+(class_definition
+  name: (identifier) @name) @definition.class
+```
+
+### `@reference.*`
+
+Marks a node as a call site or type reference. These are used by workspace
+symbol search to locate usages. `@reference.call` and `@reference.class` are
+the common variants.
+
 [Example query files][example-queries] can be found in the Helix GitHub
 repository.
 
 [Code Navigation Systems]: https://tree-sitter.github.io/tree-sitter/4-code-navigation.html
-[tree-sitter-captures]: https://tree-sitter.github.io/tree-sitter/using-parsers/queries/index.html
 [example-queries]: https://github.com/search?q=repo%3Ahelix-editor%2Fhelix+path%3A%2A%2A/tags.scm&type=Code

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -32,7 +32,7 @@ use crate::{indent::IndentQuery, tree_sitter, ChangeSet, Language};
 
 pub use tree_house::{
     highlighter::{Highlight, HighlightEvent},
-    query_iter::QueryIterEvent,
+    query_iter::{CapturedMatch, QueryIterEvent, QueryMatchIter, QueryMatchIterEvent},
     Error as HighlighterError, LanguageLoader, TreeCursor, TREE_SITTER_MATCH_LIMIT,
 };
 
@@ -618,8 +618,9 @@ impl Syntax {
         source: RopeSlice<'a>,
         loader: &'a Loader,
         range: impl RangeBounds<u32>,
-    ) -> QueryIter<'a, 'a, impl FnMut(Language) -> Option<&'a Query> + 'a, ()> {
-        self.query_iter(
+    ) -> QueryMatchIter<'a, 'a, impl FnMut(Language) -> Option<&'a Query> + 'a, ()> {
+        QueryMatchIter::new(
+            &self.inner,
             source,
             |lang| loader.tag_query(lang).map(|q| &q.query),
             range,

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -10,7 +10,7 @@ use futures_util::FutureExt;
 use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
 use helix_core::{
-    syntax::{Loader, QueryIterEvent},
+    syntax::{Loader, QueryMatchIterEvent},
     Rope, RopeSlice, Selection, Syntax, Uri,
 };
 use helix_stdx::{
@@ -122,35 +122,58 @@ fn tags_iter<'a>(
     let mut tags_iter = syntax.tags(text, loader, ..);
 
     iter::from_fn(move || loop {
-        let QueryIterEvent::Match(mat) = tags_iter.next()? else {
+        let QueryMatchIterEvent::Match(mat) = tags_iter.next()? else {
             continue;
         };
         let query = &loader
             .tag_query(tags_iter.current_language())
             .expect("must have a tags query to emit matches")
             .query;
-        let Some(kind) = query
-            .capture_name(mat.capture)
-            .strip_prefix("definition.")
-            .and_then(TagKind::from_name)
-        else {
+
+        // Find the @definition.* and optional @name captures in this match.
+        let mut def_capture = None::<(TagKind, std::ops::Range<u32>)>;
+        let mut name_range = None::<std::ops::Range<u32>>;
+        let name_capture = query.get_capture("name");
+
+        for node in mat.nodes.iter() {
+            let capture_name = query.capture_name(node.capture);
+            if let Some(kind) = capture_name
+                .strip_prefix("definition.")
+                .and_then(TagKind::from_name)
+            {
+                def_capture = Some((kind, node.node.byte_range()));
+            } else if name_capture == Some(node.capture) {
+                name_range = Some(node.node.byte_range());
+            }
+        }
+
+        let Some((kind, def_byte_range)) = def_capture else {
             continue;
         };
-        let range = mat.node.byte_range();
-        if pattern.is_some_and(|pattern| {
-            !pattern.is_match(text.regex_input_at_bytes(range.start as usize..range.end as usize))
+        let name_byte_range = name_range.unwrap_or_else(|| def_byte_range.clone());
+
+        if pattern.is_some_and(|re| {
+            !re.is_match(
+                text.regex_input_at_bytes(
+                    name_byte_range.start as usize..name_byte_range.end as usize,
+                ),
+            )
         }) {
             continue;
         }
-        let start = text.byte_to_char(range.start as usize);
-        let end = text.byte_to_char(range.end as usize);
+
+        let name_start = text.byte_to_char(name_byte_range.start as usize);
+        let name_end = text.byte_to_char(name_byte_range.end as usize);
+        let def_start = text.byte_to_char(def_byte_range.start as usize);
+        let def_end = text.byte_to_char(def_byte_range.end as usize);
+
         return Some(Tag {
             kind,
-            name: text.slice(start..end).to_string(),
-            start,
-            end,
-            start_line: text.char_to_line(start),
-            end_line: text.char_to_line(end),
+            name: text.slice(name_start..name_end).to_string(),
+            start: def_start,
+            end: def_end,
+            start_line: text.char_to_line(def_start),
+            end_line: text.char_to_line(def_end),
             doc: doc.clone(),
         });
     })

--- a/runtime/queries/erlang/locals.scm
+++ b/runtime/queries/erlang/locals.scm
@@ -7,12 +7,12 @@
 
 ; parametric `-type`s
 ((attribute
-    name: (atom) @keyword
+    name: (atom) @_keyword
     (arguments
       (binary_operator
         left: (call (arguments (variable) @local.definition.variable.parameter))
         operator: "::") @local.scope))
- (#any-of? @keyword "type" "opaque" "nominal"))
+ (#any-of? @_keyword "type" "opaque" "nominal"))
 
 ; `fun`s
 (anonymous_function (stab_clause pattern: (arguments (variable) @local.definition.variable.parameter))) @local.scope

--- a/runtime/queries/erlang/tags.scm
+++ b/runtime/queries/erlang/tags.scm
@@ -1,18 +1,19 @@
 ; Modules
-(attribute
+((attribute
   name: (atom) @_attr
-  (arguments (atom) @definition.module)
+  (arguments (atom) @name)) @definition.module
  (#eq? @_attr "module"))
 
 ; Constants
 ((attribute
     name: (atom) @_attr
-    (arguments
-      .
-      [
-        (atom) @definition.constant
-        (call function: [(variable) (atom)] @definition.macro)
-      ]))
+    (arguments . (atom) @name)) @definition.constant
+ (#eq? @_attr "define"))
+
+; Macros (with arguments)
+((attribute
+    name: (atom) @_attr
+    (arguments . (call function: [(variable) (atom)] @name))) @definition.macro
  (#eq? @_attr "define"))
 
 ; Record definitions
@@ -20,37 +21,37 @@
    name: (atom) @_attr
    (arguments
      .
-     (atom) @definition.struct))
+     (atom) @name)) @definition.struct
  (#eq? @_attr "record"))
 
-(attribute
+((attribute
   name: (atom) @_attr
   (arguments
     .
     [(atom) (macro)] ; Record name
     [
       ; Just the field name:
-      (tuple (atom)? @definition.field)
+      (tuple (atom)? @name)
       ; Field name, type OR default:
       (tuple
         (binary_operator
-          left: (atom) @definition.field
+          left: (atom) @name
           operator: ["=" "::"]))
       ; Field name, type AND default:
       (tuple
         (binary_operator
           left:
             (binary_operator
-              left: (atom) @definition.field
+              left: (atom) @name
               operator: "=")
           operator: "::"))
-    ])
+    ])) @definition.field
  (#eq? @_attr "record"))
 
 ; Function specs
 ((attribute
     name: (atom) @_attr
-    (stab_clause name: (atom) @definition.interface))
+    (stab_clause name: (atom) @name)) @definition.interface
  (#any-of? @_attr "spec" "callback"))
 
 ; Types
@@ -59,11 +60,11 @@
     (arguments
       (binary_operator
         left: [
-          (atom) @definition.type
-          (call function: (atom) @definition.type)
+          (atom) @name
+          (call function: (atom) @name)
         ]
-        operator: "::")))
+        operator: "::"))) @definition.type
  (#any-of? @_attr "type" "opaque"))
 
 ; Functions
-(function_clause name: (atom) @definition.function)
+(function_clause name: (atom) @name) @definition.function

--- a/runtime/queries/go/locals.scm
+++ b/runtime/queries/go/locals.scm
@@ -22,4 +22,4 @@
 
 ; Field names in struct literals are identifier rather than field_identifier,
 ; these cannot be locals.
-(keyed_element . (literal_element (identifier) @variable.other.member))
+(keyed_element . (literal_element (identifier) @_))

--- a/runtime/queries/julia/textobjects.scm
+++ b/runtime/queries/julia/textobjects.scm
@@ -26,7 +26,7 @@
 
 (block_comment)+ @comment.around
 
-(_expression (macro_identifier
+(macrocall_expression (macro_identifier
     (identifier) @_name
     (#match? @_name "^(test|test_throws|test_logs|inferred|test_deprecated|test_warn|test_nowarn|test_broken|test_skip)$")
   )

--- a/runtime/queries/markdown/tags.scm
+++ b/runtime/queries/markdown/tags.scm
@@ -1,1 +1,1 @@
-(atx_heading) @definition.section
+(atx_heading (inline) @name) @definition.section

--- a/runtime/queries/python/locals.scm
+++ b/runtime/queries/python/locals.scm
@@ -47,4 +47,4 @@
 
 ; don't make the name of kwargs locals
 (keyword_argument
-  name: (identifier) @variable.parameter)
+  name: (identifier) @_)

--- a/runtime/queries/rust/locals.scm
+++ b/runtime/queries/rust/locals.scm
@@ -43,23 +43,22 @@
 (identifier) @local.reference
 
 ; lifetimes / labels
-(lifetime (identifier) @label)
-(label (identifier) @label)
+(lifetime (identifier) @_)
+(label (identifier) @_)
 
 ; == scoped function calls and function defs ==
 ; avoid coloring functions as variables
-; taken from highlights.scm
 (call_expression
   function: (scoped_identifier
-    name: (identifier) @function))
+    name: (identifier) @_))
 (generic_function
   function: (scoped_identifier
-    name: (identifier) @function))
+    name: (identifier) @_))
 
 (function_item
-  name: (identifier) @function)
+  name: (identifier) @_)
 (function_signature_item
-  name: (identifier) @function)
+  name: (identifier) @_)
 
 ; == other ==
-(enum_variant (identifier) @type.enum.variant)
+(enum_variant (identifier) @_)

--- a/runtime/queries/rust/tags.scm
+++ b/runtime/queries/rust/tags.scm
@@ -1,29 +1,29 @@
 (struct_item
-  name: (type_identifier) @definition.struct)
+  name: (type_identifier) @name) @definition.struct
 
 (const_item
-  name: (identifier) @definition.constant)
+  name: (identifier) @name) @definition.constant
 
 (trait_item
-  name: (type_identifier) @definition.interface)
+  name: (type_identifier) @name) @definition.interface
 
 (function_item
-  name: (identifier) @definition.function)
+  name: (identifier) @name) @definition.function
 
 (function_signature_item
-  name: (identifier) @definition.function)
+  name: (identifier) @name) @definition.function
 
 (enum_item
-  name: (type_identifier) @definition.enum)
+  name: (type_identifier) @name) @definition.enum
 
 (enum_variant
-  name: (identifier) @definition.struct)
+  name: (identifier) @name) @definition.struct
 
 (type_item
-  name: (type_identifier) @definition.type)
+  name: (type_identifier) @name) @definition.type
 
 (mod_item
-  name: (identifier) @definition.module)
+  name: (identifier) @name) @definition.module
 
 (macro_definition
-  name: (identifier) @definition.macro)
+  name: (identifier) @name) @definition.macro


### PR DESCRIPTION
I cut a new release of tree-house with a bunch of fixes.

* Locals queries now have their own precedence. Previously they mixed together with highlights unintentionally and we had to work around this by writing highlights queries in the locals.scm file. Now we can use discards like `@_keyword` to cancel a `@local.reference` capture.
* Use `@name` capture in `tags.scm` queries to capture the definition's name. The `@definition.*` captures then capture the entire item. The `@name` is shown in the symbol picker and can be used for goto-definition / goto-references in the future.
* Add a guide to the book for writing `locals.scm` queries.
* Fix some panics and issues with highlighting. Fixes https://github.com/helix-editor/helix/issues/14751.