### PR TITLE
fix: move line number with the code

### DIFF
--- a/helix-term/src/ui/document.rs
+++ b/helix-term/src/ui/document.rs
@@ -434,6 +434,8 @@ impl<'a> TextRenderer<'a> {
         if (y as usize) < self.offset.row {
             return;
         }
+        // The substraction and the cast are safe, because `self.offset.row` is less than y
+        let y = y - self.offset.row as u16;
         self.surface
             .set_stringn(x, y + self.viewport.y, string, width, style);
     }


### PR DESCRIPTION
In a `helix-term::ui::document::TextRenderer`, account for inline diagnostics offset when styling a gutter.

**Before:**
[![Before](https://asciinema.org/a/1168484.svg)](https://asciinema.org/a/1168484)

**After:**
[![After](https://asciinema.org/a/1168482.svg)](https://asciinema.org/a/1168482)


May require a review from @pascalkuthe before merging.

Fixes #14110