### PR TITLE
Improve the Adwaita themes' cursor color

### DIFF
--- a/runtime/themes/adwaita-dark.toml
+++ b/runtime/themes/adwaita-dark.toml
@@ -64,21 +64,22 @@
 
 "ui.background" = { fg = "light_4", bg = "libadwaita_dark" }
 "ui.background.separator" = { fg = "split_and_borders", bg = "libadwaita_dark" }
-"ui.cursor" = { fg = "libadwaita_dark", bg = "light_5" }
-"ui.cursor.insert" = { fg = "libadwaita_dark", bg = "light_5" }
-"ui.cursor.select" = { fg = "libadwaita_dark", bg = "light_5" }
-"ui.cursor.match" = { fg = "libadwaita_dark", bg = "blue_2" }
-"ui.cursor.primary" = { fg = "libadwaita_dark", bg = "light_7" }
-"ui.cursor.primary.normal" = { fg = "libadwaita_dark", bg = "light_7" }
-"ui.cursor.primary.insert" = { fg = "libadwaita_dark", bg = "teal_4" }
-"ui.cursor.primary.select" = { fg = "libadwaita_dark", bg = "blue_4" }
+"ui.cursor" = { fg = "libadwaita_dark", bg = "light_7" }
+"ui.cursor.normal" = { fg = "libadwaita_dark", bg = "light_7" }
+"ui.cursor.insert" = { fg = "libadwaita_dark", bg = "blue_5" }
+"ui.cursor.select" = { fg = "libadwaita_dark", bg = "orange_5" }
+"ui.cursor.match" = { bg = "dark_3" }
+"ui.cursor.primary" = { fg = "libadwaita_dark", bg = "light_1" }
+"ui.cursor.primary.normal" = { fg = "libadwaita_dark", bg = "light_1" }
+"ui.cursor.primary.insert" = { fg = "libadwaita_dark", bg = "blue_1" }
+"ui.cursor.primary.select" = { fg = "libadwaita_dark", bg = "orange_1" }
 "ui.linenr" = "dark_2"
 "ui.linenr.selected" = { fg = "light_7", modifiers = ["bold"] }
 "ui.statusline" = { fg = "light_4", bg = "libadwaita_dark_alt" }
 "ui.statusline.inactive" = { fg = "light_7", bg = "libadwaita_dark_alt" }
-"ui.statusline.normal" = { fg = "libadwaita_dark", bg = "light_7" }
-"ui.statusline.insert" = { fg = "libadwaita_dark", bg = "teal_4" }
-"ui.statusline.select" = { fg = "libadwaita_dark", bg = "blue_4" }
+"ui.statusline.normal" = { fg = "libadwaita_dark", bg = "light_1" }
+"ui.statusline.insert" = { fg = "libadwaita_dark", bg = "blue_1" }
+"ui.statusline.select" = { fg = "libadwaita_dark", bg = "orange_1" }
 "ui.popup" = { fg = "light_4", bg = "libadwaita_popup" }
 "ui.window" = "split_and_borders"
 "ui.help" = { fg = "light_4", bg = "libadwaita_dark_alt" }

--- a/runtime/themes/adwaita-light.toml
+++ b/runtime/themes/adwaita-light.toml
@@ -63,21 +63,22 @@ inherits="adwaita-dark"
 
 "ui.background" = { fg = "dark_4", bg = "light_1" }
 "ui.background.separator" = { fg = "split_and_borders", bg = "light_2" }
-"ui.cursor" = { fg = "light_2", bg = "dark_5" }
-"ui.cursor.insert" = { fg = "light_2", bg = "dark_4" }
-"ui.cursor.select" = { fg = "light_2", bg = "dark_5" }
-"ui.cursor.match" = { fg = "light_2", bg = "blue_1" }
+"ui.cursor" = { fg = "light_2", bg = "light_7" }
+"ui.cursor.normal" = { fg = "light_2", bg = "light_7" }
+"ui.cursor.insert" = { fg = "light_2", bg = "blue_1" }
+"ui.cursor.select" = { fg = "light_2", bg = "orange_1" }
+"ui.cursor.match" = { bg = "light_4" }
 "ui.cursor.primary" = { fg = "light_2", bg = "dark_6" }
 "ui.cursor.primary.normal" = { fg = "light_2", bg = "dark_6" }
-"ui.cursor.primary.insert" = { fg = "light_2", bg = "teal_4" }
-"ui.cursor.primary.select" = { fg = "light_2", bg = "blue_4" }
+"ui.cursor.primary.insert" = { fg = "light_2", bg = "blue_5" }
+"ui.cursor.primary.select" = { fg = "light_2", bg = "orange_5" }
 "ui.linenr" = "light_5"
 "ui.linenr.selected" = { fg = "dark_2", modifiers = ["bold"] }
 "ui.statusline" = { fg = "dark_4", bg = "light_4" }
 "ui.statusline.inactive" = { fg = "light_7", bg = "light_4" }
 "ui.statusline.normal" = { fg = "light_2", bg = "dark_6" }
-"ui.statusline.insert" = { fg = "light_2", bg = "teal_4" }
-"ui.statusline.select" = { fg = "light_2", bg = "blue_4" }
+"ui.statusline.insert" = { fg = "light_2", bg = "blue_5" }
+"ui.statusline.select" = { fg = "light_2", bg = "orange_5" }
 "ui.popup" = { fg = "dark_4", bg = "light_3" }
 "ui.window" = "split_and_borders"
 "ui.help" = { fg = "dark_4", bg = "light_3" }


### PR DESCRIPTION
This PR changes the colors of the cursor in the Adwaita themes. I previously did some slight changes on the themes in https://github.com/helix-editor/helix/pull/15112, but after having daily driven this for a couple of months now, I've gotten irritated over some of the decisions related to the cursor/statusline mode indicator that were made in that PR.

About the changes themselves:

Firstly, I changed the color of the cursor in the normal mode in both themes to match those of GNOME Console, which are `#FFFFFF` and `#000000`.

I also added `ui.cursor.normal` to both themes by copying the value from `ui.cursor`. I'm not sure if this makes a difference, but I figured it would make sense when taking into account that we already had both `ui.cursor.primary` and `ui.cursor.primary.normal` for the primary cursor.

The biggest reason for making this PR was the match color, which was way too contrasty compared to the background/default color. To make matters worse, since the insert cursor color was blue as well, it was pretty much impossible to determine which one was the cursor and which one was the highlighted matching character (or string).

Previously the color of the non-primary cursor didn't change at all regardless of the mode. Now the non-primary cursors are colored with a darker variant of the same base color as the primary cursor.

Additionally I decided to use a lighter color for the insert/selection colors, since I found them too distracting. In the last PR I decided not to touch these colors.

I've attached a screenshot visualizing these changes below. You can see the adwaita-dark theme on the left-hand side and adwaita-light on the right-hand side. From top to bottom there are: the selection, the insertion and the normal mode. Color-modes is enabled for each screenshot. For each theme, you can see the new version on the left side and the old one on the right side. The primary cursor is positioned on the left curly bracket, with the non-primary cursor positioned right on top of the primary cursor.

<img width="7508" height="2499" alt="New Project" src="https://github.com/user-attachments/assets/288ef9a5-c9db-4a12-a31a-80097193770c" />