### PR TITLE
pod: highlight E<> escapes via escape_sequence node

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1954,7 +1954,7 @@ file-types = ["pod"]
 
 [[grammar]]
 name = "pod"
-source = { git = "https://github.com/tree-sitter-perl/tree-sitter-pod", rev = "0bf8387987c21bf2f8ed41d2575a8f22b139687f" }
+source = { git = "https://github.com/tree-sitter-perl/tree-sitter-pod", rev = "cd1931314beafeebc957964c65802961e283411e" }
 
 [[language]]
 name = "racket"

--- a/runtime/queries/pod/highlights.scm
+++ b/runtime/queries/pod/highlights.scm
@@ -91,7 +91,7 @@
   (#eq? @character "X")
   (content) @markup.reference)
 
-(interior_sequence
+(escape_sequence
   (sequence_letter) @character
-  (#eq? @character "E")
+  ["<" ">"] @punctuation.delimiter
   (content) @string.special.escape)


### PR DESCRIPTION
tree-sitter-pod 1.1.0 parses E<...> escapes as a dedicated escape_sequence node rather than a generic interior_sequence, so the old (#eq? @character "E") rule no longer matches. Retarget it and bump the pinned grammar rev to a release-branch commit that has the node.