### PR TITLE
feat(contrib): add completions for `--strict`

### DIFF
--- a/contrib/completion/hx.bash
+++ b/contrib/completion/hx.bash
@@ -21,7 +21,7 @@ _hx() {
 
     case "$2" in
     -*)
-        mapfile -t COMPREPLY < <(compgen -W "-h --help --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2""")
+        mapfile -t COMPREPLY < <(compgen -W "-h --help --strict --tutor -V --version -v -vv -vvv --health -g --grammar --vsplit --hsplit -c --config --log" -- """$2""")
         return 0
         ;;
     *)

--- a/contrib/completion/hx.elv
+++ b/contrib/completion/hx.elv
@@ -3,7 +3,7 @@
 # Be sure to replace `$REPOS` with something that makes sense for you!
 
 ### Renders a pretty completion candidate
-var candidate = { | _stem  _desc | 
+var candidate = { | _stem  _desc |
   edit:complex-candidate $_stem &display=(styled $_stem bold)(styled " "$_desc dim)
 }
 
@@ -24,26 +24,27 @@ set edit:completion:arg-completer[hx] = {|@args|
     # and invalidate further input
     if (has-value $skips $args[-2]) {
       return
-    } 
+    }
     # If the previous arg == --grammar, then only suggest:
     if (has-value $grammar $args[-2]) {
       $candidate "fetch" "Fetch the tree-sitter grammars"
       $candidate "build" "Build the tree-sitter grammars"
       return
-    } 
+    }
     # When we have --config, we need a file
     if (has-values $config $args[-2]) {
       edit:complete-filename $args[-1] | each { |v| put $v[stem] }
       return
-    } 
+    }
     # When we have --log, we need a file
     if (has-values "log" $args[-2]) {
       edit:complete-filename $args[-1] | each { |v| put $v[stem] }
       return
-    } 
-  } 
+    }
+  }
   edit:complete-filename $args[-1] | each { |v| put $v[stem]}
   $candidate "--help" "(Prints help information)"
+  $candidate "--strict" "(Bail on error for commands that can fail)"
   $candidate "--version" "(Prints version information)"
   $candidate "--tutor" "(Loads the tutorial)"
   $candidate "--health" "(Checks for errors in editor setup)"

--- a/contrib/completion/hx.fish
+++ b/contrib/completion/hx.fish
@@ -2,6 +2,7 @@
 # Fish completion script for Helix editor
 
 complete -c hx -s h -l help -d "Prints help information"
+complete -c hx -l strict -d "Bail on error for commands that can fail"
 complete -c hx -l tutor -d "Loads the tutorial"
 complete -c hx -l health -xa "(__hx_langs_ops)" -d "Checks for errors"
 complete -c hx -l health -xka all -d "Prints all diagnostic informations"

--- a/contrib/completion/hx.nu
+++ b/contrib/completion/hx.nu
@@ -15,6 +15,7 @@ def grammar_categories [] { ["fetch", "build"] }
 # A post-modern text editor.
 export extern hx [
     --help(-h),                                 # Prints help information
+    --strict,                                   # Bail on error for commands that can fail
     --tutor,                                    # Loads the tutorial
     --health: string@health_categories,         # Checks for potential errors in editor setup
     --grammar(-g): string@grammar_categories,   # Fetches or builds tree-sitter grammars listed in `languages.toml`

--- a/contrib/completion/hx.zsh
+++ b/contrib/completion/hx.zsh
@@ -5,6 +5,7 @@ _hx() {
 	_arguments -C \
 		"-h[Prints help information]" \
 		"--help[Prints help information]" \
+		"--strict[Bail on error for commands that can fail]" \
 		"-v[Increase logging verbosity]" \
 		"-vv[Increase logging verbosity]" \
 		"-vvv[Increase logging verbosity]" \


### PR DESCRIPTION
Follow-up for #15548 which added the `--strict` flag.

I don't use completions myself, and not very familiar with some of these shells, but just added where it looked like it should go. 