### PR TITLE
Make tokyonight primary and secondary cursor visually differentiable

### DIFF
--- a/runtime/themes/tokyonight.toml
+++ b/runtime/themes/tokyonight.toml
@@ -70,7 +70,11 @@ hint = { fg = "hint" }
 "diagnostic.deprecated" = { modifiers = ["crossed_out"] }
 
 "ui.background" = { bg = "bg", fg = "fg" }
-"ui.cursor" = { modifiers = ["reversed"] }
+"ui.cursor" = { fg = "bg", bg = "gray" }
+"ui.cursor.primary" = { fg = "bg", bg = "fg" }
+"ui.cursor.primary.normal" = { fg = "bg", bg = "blue" }
+"ui.cursor.primary.insert" = { fg = "bg", bg = "light-green" }
+"ui.cursor.primary.select" = { fg = "bg", bg = "magenta" }
 "ui.cursor.match" = { fg = "orange", modifiers = ["bold"] }
 "ui.cursorline.primary" = { bg = "bg-menu" }
 "ui.help" = { bg = "bg-menu", fg = "fg" }


### PR DESCRIPTION
The secondary cursor look the same as the primary cursors, making it
difficult to use `,` or `alt-,` features.
With this change the primary cursor is now colored as the current mode
and the secondary cursors are always gray, making them visually
differentiable.

With this change:

<img width="1021" height="367" alt="image" src="https://github.com/user-attachments/assets/dddd5108-a248-4281-9910-d2a56547888d" />

Before this change:

<img width="1021" height="367" alt="image" src="https://github.com/user-attachments/assets/7d6d1d75-c14c-4b6c-907a-eade6d94f4a2" />

The primary cursor is on the first line in both cases.