### PR TITLE
Add three more simple expansions

### DIFF
--- a/book/src/command-line.md
+++ b/book/src/command-line.md
@@ -50,10 +50,12 @@ The following variables are supported:
 | `line_ending` | A string containing the line ending of the currently focused document. For example on Unix systems this is usually a line-feed character (`\n`) but on Windows systems this may be a carriage-return plus a line-feed (`\r\n`). The line ending kind of the currently focused document can be inspected with the `:line-ending` command. |
 | `current_working_directory` | Current working directory |
 | `workspace_directory` | Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix` |
+| `workspace_path` | The path of the current file, relative to the current workspace directory (see above). If not in the workspace directory, returns the absolute path. |
 | `language` | A string containing the language name of the currently focused document.|
 | `selection` | A string containing the contents of the primary selection of the currently focused document. |
 | `selection_line_start` | The line number of the start of the primary selection in the currently focused document, starting at 1. |
 | `selection_line_end` | The line number of the end of the primary selection in the currently focused document, starting at 1. |
+| `clipboard` | The clipboard content (content of the `+` register) as is, with no escaping. |
 
 Aside from editor variables, the following expansions may be used:
 

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -40,6 +40,8 @@ pub enum Variable {
     CurrentWorkingDirectory,
     /// Nearest ancestor directory of the current working directory that contains `.git`, `.svn`, `jj` or `.helix`
     WorkspaceDirectory,
+    // Current filename, relative to the nearest ancestor that contains `.git`, `.svn`, `jj` or `.helix`, similar to WorkSpaceDirectory
+    WorkspacePath,
     // The name of current buffers language as set in `languages.toml`
     Language,
     // Primary selection
@@ -50,10 +52,6 @@ pub enum Variable {
     SelectionLineEnd,
     // Clipboard content
     Clipboard,
-    // Current filename
-    Filename,
-    // Current filename, relative
-    FilenameRelative,
 }
 
 impl Variable {
@@ -65,13 +63,12 @@ impl Variable {
         Self::LineEnding,
         Self::CurrentWorkingDirectory,
         Self::WorkspaceDirectory,
+        Self::WorkspacePath,
         Self::Language,
         Self::Selection,
         Self::SelectionLineStart,
         Self::SelectionLineEnd,
         Self::Clipboard,
-        Self::Filename,
-        Self::FilenameRelative,
     ];
 
     pub const fn as_str(&self) -> &'static str {
@@ -83,13 +80,12 @@ impl Variable {
             Self::LineEnding => "line_ending",
             Self::CurrentWorkingDirectory => "current_working_directory",
             Self::WorkspaceDirectory => "workspace_directory",
+            Self::WorkspacePath => "workspace_path",
             Self::Language => "language",
             Self::Selection => "selection",
             Self::SelectionLineStart => "selection_line_start",
             Self::SelectionLineEnd => "selection_line_end",
             Self::Clipboard => "clipboard",
-            Self::Filename => "filename",
-            Self::FilenameRelative => "relfilename",
         }
     }
 
@@ -101,14 +97,13 @@ impl Variable {
             "file_path_absolute" => Some(Self::FilePathAbsolute),
             "line_ending" => Some(Self::LineEnding),
             "workspace_directory" => Some(Self::WorkspaceDirectory),
+            "workspace_path" => Some(Self::WorkspacePath),
             "current_working_directory" => Some(Self::CurrentWorkingDirectory),
             "language" => Some(Self::Language),
             "selection" => Some(Self::Selection),
             "selection_line_start" => Some(Self::SelectionLineStart),
             "selection_line_end" => Some(Self::SelectionLineEnd),
             "clipboard" => Some(Self::Clipboard),
-            "filename" => Some(Self::Filename),
-            "relfilename" => Some(Self::FilenameRelative),
             _ => None,
         }
     }
@@ -303,6 +298,28 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
                 .to_string_lossy()
                 .to_string(),
         )),
+        Variable::WorkspacePath => {
+            let workspace_path = helix_loader::find_workspace()
+                .0
+                .to_string_lossy()
+                .to_string();
+            let abs_path = match doc.path() {
+                Some(path) => path.to_owned(),
+                None => helix_stdx::env::current_working_dir(),
+            }
+            .to_string_lossy()
+            .to_string();
+
+            // check the workspace path is actually a valid prefix for the absolute path
+            // otherwise we might get weird results for files not in our CWD tree
+            if abs_path[..workspace_path.len()] == workspace_path {
+                return Ok(std::borrow::Cow::Owned(
+                    abs_path[workspace_path.len() + 1..].into(), // if we're in-tree, cut off workspace dir plus an extra slash
+                ));
+            } else {
+                return Ok(std::borrow::Cow::Owned(abs_path)); // otherwise return abs path
+            }
+        }
         Variable::Language => Ok(match doc.language_name() {
             Some(lang) => Cow::Owned(lang.to_owned()),
             None => Cow::Borrowed("text"),
@@ -328,19 +345,5 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             };
             Ok(Cow::Owned(content))
         }
-        Variable::Filename => Ok(Cow::Owned(match editor.documents().next() {
-            Some(doc) => match doc.path() {
-                Some(path) => path.to_string_lossy().into_owned(),
-                None => "".to_string(),
-            },
-            None => "".to_string(),
-        })),
-        Variable::FilenameRelative => Ok(Cow::Owned(match editor.documents().next() {
-            Some(doc) => match doc.relative_path() {
-                Some(path) => path.to_string_lossy().into_owned(),
-                None => "".to_string(),
-            },
-            None => "".to_string(),
-        })),
     }
 }

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -71,6 +71,7 @@ impl Variable {
         Self::SelectionLineEnd,
         Self::Clipboard,
         Self::Filename,
+        Self::FilenameRelative,
     ];
 
     pub const fn as_str(&self) -> &'static str {

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -48,6 +48,12 @@ pub enum Variable {
     SelectionLineStart,
     // The one-indexed line number of the end of the primary selection in the currently focused document.
     SelectionLineEnd,
+    // Clipboard content
+    Clipboard,
+    // Current filename
+    Filename,
+    // Current filename, relative
+    FilenameRelative,
 }
 
 impl Variable {
@@ -63,6 +69,8 @@ impl Variable {
         Self::Selection,
         Self::SelectionLineStart,
         Self::SelectionLineEnd,
+        Self::Clipboard,
+        Self::Filename,
     ];
 
     pub const fn as_str(&self) -> &'static str {
@@ -78,6 +86,9 @@ impl Variable {
             Self::Selection => "selection",
             Self::SelectionLineStart => "selection_line_start",
             Self::SelectionLineEnd => "selection_line_end",
+            Self::Clipboard => "clipboard",
+            Self::Filename => "filename",
+            Self::FilenameRelative => "relfilename",
         }
     }
 
@@ -94,6 +105,9 @@ impl Variable {
             "selection" => Some(Self::Selection),
             "selection_line_start" => Some(Self::SelectionLineStart),
             "selection_line_end" => Some(Self::SelectionLineEnd),
+            "clipboard" => Some(Self::Clipboard),
+            "filename" => Some(Self::Filename),
+            "relfilename" => Some(Self::FilenameRelative),
             _ => None,
         }
     }
@@ -303,5 +317,29 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             let end_line = doc.selection(view.id).primary().line_range(text).1;
             Ok(Cow::Owned((end_line + 1).to_string()))
         }
+        Variable::Clipboard => {
+            let content = match editor.registers.read('+', editor) {
+                Some(mut values) if values.len() > 0 => values
+                    .next()
+                    .unwrap_or(Cow::Owned("".to_string()))
+                    .into_owned(),
+                _ => "".to_string(),
+            };
+            Ok(Cow::Owned(content))
+        }
+        Variable::Filename => Ok(Cow::Owned(match editor.documents().next() {
+            Some(doc) => match doc.path() {
+                Some(path) => path.to_string_lossy().into_owned(),
+                None => "".to_string(),
+            },
+            None => "".to_string(),
+        })),
+        Variable::FilenameRelative => Ok(Cow::Owned(match editor.documents().next() {
+            Some(doc) => match doc.relative_path() {
+                Some(path) => path.to_string_lossy().into_owned(),
+                None => "".to_string(),
+            },
+            None => "".to_string(),
+        })),
     }
 }

--- a/helix-view/src/expansion.rs
+++ b/helix-view/src/expansion.rs
@@ -313,11 +313,11 @@ fn expand_variable(editor: &Editor, variable: Variable) -> Result<Cow<'static, s
             // check the workspace path is actually a valid prefix for the absolute path
             // otherwise we might get weird results for files not in our CWD tree
             if abs_path[..workspace_path.len()] == workspace_path {
-                return Ok(std::borrow::Cow::Owned(
+                Ok(std::borrow::Cow::Owned(
                     abs_path[workspace_path.len() + 1..].into(), // if we're in-tree, cut off workspace dir plus an extra slash
-                ));
+                ))
             } else {
-                return Ok(std::borrow::Cow::Owned(abs_path)); // otherwise return abs path
+                Ok(std::borrow::Cow::Owned(abs_path)) // otherwise return abs path
             }
         }
         Variable::Language => Ok(match doc.language_name() {


### PR DESCRIPTION
Hi there :wave: :blush: 

Long time user of Helix here. I use it as my daily driver for security auditing, and for quicker access to files and for quicker communication with others I've added the following two expansions:
- `workspace_path`: the path of the currently focused file, relative to the working directory. Implementation is a combination of the `workspace_directory` and `file_path_absolute` implementations, with some extra logic for files outside the workspace (for these it returns the absolute path).
- `clipboard`: simply expands into the clipboard (`+` register)

Example usage for both:
```toml
C-A-o = ":o %{clipboard}"
```
I have a separate TUI tool that provides a file tree and to open files in Helix I simply use the clipboard. This allows me to fill the clipboard with the absolute path from the external tool, and simply hit `Ctrl + Alt + o` in Helix to quickly open the file.

```toml
[keys.normal."minus"]
c = ":sh echo -n '%{workspace_path}:%{selection_line_start}' | wl-copy"
```
I use this to copy relevant file locations for communication with others. Because we often audit multiple repositories at a time, I usually have Helix open in a subdir containing the repository (these have their `.git` dirs stripped). The `workspace_path` expansion includes the containing folders, regardless of where my actual Helix CWD is and saves me a few steps.

Changes are contained in the `expansion.rs` file, as you can see from the commits. Documentation in the `command-line.md` page of the Docs book is also added.