### PR TITLE
feat: Code Actions on save

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -173,7 +173,7 @@ The following statusline elements can be configured:
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 | `snippets`      | Enables snippet completions. Requires a server restart (`:lsp-restart`) to take effect after `:config-reload`/`:set`. | `true`  |
 | `goto-reference-include-declaration` | Include declaration in the goto references popup. | `true`  |
-| `code_actions_on_save` | Which code actions should be ran on save | `["source.organizeImports"]` |
+| `code-actions-on-save` | Which code actions should be executed before saving | `["source.organizeImports"]` |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 

--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -173,6 +173,7 @@ The following statusline elements can be configured:
 | `display-signature-help-docs` | Display docs under signature help popup             | `true`  |
 | `snippets`      | Enables snippet completions. Requires a server restart (`:lsp-restart`) to take effect after `:config-reload`/`:set`. | `true`  |
 | `goto-reference-include-declaration` | Include declaration in the goto references popup. | `true`  |
+| `code_actions_on_save` | Which code actions should be ran on save | `["source.organizeImports"]` |
 
 [^1]: By default, a progress spinner is shown in the statusline beside the file path.
 

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4,9 +4,9 @@ pub(crate) mod syntax;
 pub(crate) mod typed;
 
 pub use dap::*;
-use futures_util::{stream::FuturesOrdered, FutureExt, StreamExt};
+use futures_util::{stream::FuturesUnordered, FutureExt, StreamExt};
 use helix_event::status;
-use helix_lsp::{lsp::CodeActionKind, LanguageServerId};
+use helix_lsp::{lsp::CodeAction, LanguageServerId};
 use helix_stdx::{
     path::{self, find_paths},
     rope::{self, RopeSliceExt},
@@ -3806,35 +3806,43 @@ async fn make_format_callback(
     Ok(call)
 }
 
-async fn make_caos_callback(
+struct CodeActionItem {
+    code_action: CodeAction,
+    language_server_id: LanguageServerId,
+}
+
+async fn make_code_action_callback(
     doc_id: DocumentId,
     doc_version: i32,
     view_id: ViewId,
-    mut lsps: FuturesOrdered<
-        impl Future<Output = helix_lsp::Result<Option<Vec<helix_lsp::lsp::CodeActionOrCommand>>>>,
+    mut ls_responses: FuturesUnordered<
+        impl Future<
+            Output = (
+                LanguageServerId,
+                helix_lsp::Result<Option<Vec<helix_lsp::lsp::CodeActionOrCommand>>>,
+            ),
+        >,
     >,
-    ids: Vec<LanguageServerId>,
 ) -> anyhow::Result<job::Callback> {
-    let mut actions = vec![];
-    let mut ids = ids.into_iter();
-    while let Some(lsp) = lsps.next().await {
-        let id = ids.next().unwrap();
-        if let Ok(Some(code_actions)) = lsp {
+    let mut available_code_actions = vec![];
+    while let Some((language_server_id, code_actions)) = ls_responses.next().await {
+        if let Ok(Some(code_actions)) = code_actions {
             for a in code_actions {
-                actions.push((id, a));
+                match a {
+                    helix_lsp::lsp::CodeActionOrCommand::CodeAction(code_action)
+                        if code_action.disabled.is_none() =>
+                    {
+                        available_code_actions.push(CodeActionItem {
+                            code_action,
+                            language_server_id,
+                        });
+                    }
+                    helix_lsp::lsp::CodeActionOrCommand::CodeAction(_)
+                    | helix_lsp::lsp::CodeActionOrCommand::Command(_) => {}
+                }
             }
         }
     }
-
-    let actions = actions
-        .into_iter()
-        .filter_map(|(id, a)| match a {
-            helix_lsp::lsp::CodeActionOrCommand::CodeAction(a) => {
-                a.disabled.is_none().then(|| (id, a))
-            }
-            helix_lsp::lsp::CodeActionOrCommand::Command(_) => None,
-        })
-        .collect::<Vec<_>>();
 
     let cb: job::Callback = Callback::Editor(Box::new(move |editor| {
         if !editor.documents.contains_key(&doc_id) || !editor.tree.contains(view_id) {
@@ -3843,7 +3851,7 @@ async fn make_caos_callback(
 
         let doc = doc_mut!(editor, &doc_id);
 
-        if actions.is_empty() {
+        if available_code_actions.is_empty() {
             return;
         }
 
@@ -3854,30 +3862,41 @@ async fn make_caos_callback(
 
         let enabled_code_actions = &editor.config.load().lsp.code_actions_on_save;
 
-        for (ls_id, action) in actions {
-            if action
+        for CodeActionItem {
+            code_action,
+            language_server_id,
+        } in available_code_actions
+        {
+            if code_action
                 .kind
                 .as_ref()
                 .is_none_or(|k| !enabled_code_actions.iter().any(|a| k.as_str() == a))
             {
-                log::debug!("Skipping disabled code action");
+                log::debug!(
+                    "Skipping disabled code action {}",
+                    code_action
+                        .kind
+                        .as_ref()
+                        .map(|ca| ca.as_str())
+                        .unwrap_or("[unknown]")
+                );
                 continue;
             }
 
-            let Some(language_server) = editor.language_server_by_id(ls_id) else {
+            let Some(language_server) = editor.language_server_by_id(language_server_id) else {
                 editor.set_error("Language Server disappeared");
                 continue;
             };
 
             let mut resolved_code_action = None;
-            if action.edit.is_none() || action.command.is_none() {
-                if let Some(future) = language_server.resolve_code_action(&action) {
+            if code_action.edit.is_none() || code_action.command.is_none() {
+                if let Some(future) = language_server.resolve_code_action(&code_action) {
                     if let Ok(action) = helix_lsp::block_on(future) {
                         resolved_code_action = Some(action);
                     }
                 }
             }
-            let resolved_code_action = resolved_code_action.as_ref().unwrap_or(&action);
+            let resolved_code_action = resolved_code_action.as_ref().unwrap_or(&code_action);
 
             if let Some(ref workspace_edit) = resolved_code_action.edit {
                 let _ =
@@ -3886,8 +3905,8 @@ async fn make_caos_callback(
 
             // if code action provides both edit and command first the edit
             // should be applied and then the command
-            if let Some(command) = &action.command {
-                editor.execute_lsp_command(command.clone(), ls_id);
+            if let Some(command) = &code_action.command {
+                editor.execute_lsp_command(command.clone(), language_server_id);
             }
         }
     }));

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3752,6 +3752,13 @@ fn insert_with_indent(cx: &mut Context, cursor_fallback: IndentFallbackPos) {
     doc.apply(&transaction, view.id);
 }
 
+fn apply_format(doc: &mut Document, view: &mut View, scrolloff: usize, format: &Transaction) {
+    doc.apply(format, view.id);
+    doc.append_changes_to_history(view);
+    doc.detect_indent_and_line_ending();
+    view.ensure_cursor_in_view(doc, scrolloff);
+}
+
 // Creates an LspCallback that waits for formatting changes to be computed. When they're done,
 // it applies them, but only if the doc hasn't changed.
 //
@@ -3778,10 +3785,7 @@ async fn make_format_callback(
         match format {
             Ok(format) => {
                 if doc.version() == doc_version {
-                    doc.apply(&format, view.id);
-                    doc.append_changes_to_history(view);
-                    doc.detect_indent_and_line_ending();
-                    view.ensure_cursor_in_view(doc, scrolloff);
+                    apply_format(doc, view, scrolloff, &format);
                 } else {
                     log::info!("discarded formatting changes because the document changed");
                 }
@@ -3811,10 +3815,44 @@ struct CodeActionItem {
     language_server_id: LanguageServerId,
 }
 
+fn apply_code_actions(editor: &mut Editor, code_actions: Vec<CodeActionItem>) {
+    for CodeActionItem {
+        code_action,
+        language_server_id,
+    } in code_actions
+    {
+        let Some(language_server) = editor.language_server_by_id(language_server_id) else {
+            editor.set_error("Language Server disappeared");
+            continue;
+        };
+
+        let mut resolved_code_action = None;
+        if code_action.edit.is_none() || code_action.command.is_none() {
+            if let Some(future) = language_server.resolve_code_action(&code_action) {
+                if let Ok(action) = helix_lsp::block_on(future) {
+                    resolved_code_action = Some(action);
+                }
+            }
+        }
+        let resolved_code_action = resolved_code_action.as_ref().unwrap_or(&code_action);
+
+        if let Some(ref workspace_edit) = resolved_code_action.edit {
+            let _ = editor.apply_workspace_edit(language_server.offset_encoding(), workspace_edit);
+        }
+
+        // if code action provides both edit and command first the edit
+        // should be applied and then the command
+        if let Some(command) = &code_action.command {
+            editor.execute_lsp_command(command.clone(), language_server_id);
+        }
+    }
+}
 async fn make_code_action_callback(
     doc_id: DocumentId,
     doc_version: i32,
     view_id: ViewId,
+    path: Option<PathBuf>,
+    options: WriteOptions,
     mut ls_responses: FuturesUnordered<
         impl Future<
             Output = (
@@ -3844,56 +3882,47 @@ async fn make_code_action_callback(
         }
     }
 
-    let cb: job::Callback = Callback::Editor(Box::new(move |editor| {
+    let call: job::Callback = Callback::Editor(Box::new(move |editor| {
         if !editor.documents.contains_key(&doc_id) || !editor.tree.contains(view_id) {
             return;
         }
 
-        let doc = doc_mut!(editor, &doc_id);
+        if doc!(editor, &doc_id).version() == doc_version {
+            apply_code_actions(editor, available_code_actions);
 
-        if available_code_actions.is_empty() {
-            return;
-        }
+            let auto_format = editor.config().auto_format;
+            let scrolloff = editor.config().scrolloff;
 
-        if doc.version() != doc_version {
-            log::info!("Aborting applying code actions on save because the document changed");
-            return;
-        }
-
-        for CodeActionItem {
-            code_action,
-            language_server_id,
-        } in available_code_actions
-        {
-            let Some(language_server) = editor.language_server_by_id(language_server_id) else {
-                editor.set_error("Language Server disappeared");
-                continue;
+            let fmt = if auto_format && options.auto_format {
+                let doc = doc!(editor, &doc_id);
+                doc.format(editor)
+                    .map(|fmt| match helix_lsp::block_on(fmt) {
+                        Ok(fmt) => Some(fmt),
+                        Err(err) => {
+                            log::info!("failed to format '{}': {err}", doc.display_name());
+                            None
+                        }
+                    })
+            } else {
+                None
             };
 
-            let mut resolved_code_action = None;
-            if code_action.edit.is_none() || code_action.command.is_none() {
-                if let Some(future) = language_server.resolve_code_action(&code_action) {
-                    if let Ok(action) = helix_lsp::block_on(future) {
-                        resolved_code_action = Some(action);
-                    }
-                }
-            }
-            let resolved_code_action = resolved_code_action.as_ref().unwrap_or(&code_action);
+            if let Some(fmt) = fmt.flatten() {
+                let doc = doc_mut!(editor, &doc_id);
+                let view = view_mut!(editor, view_id);
 
-            if let Some(ref workspace_edit) = resolved_code_action.edit {
-                let _ =
-                    editor.apply_workspace_edit(language_server.offset_encoding(), workspace_edit);
+                apply_format(doc, view, scrolloff, &fmt);
             }
+        } else {
+            log::info!("Aborting applying code actions and formatting on save because the document changed");
+        }
 
-            // if code action provides both edit and command first the edit
-            // should be applied and then the command
-            if let Some(command) = &code_action.command {
-                editor.execute_lsp_command(command.clone(), language_server_id);
-            }
+        if let Err(err) = editor.save(doc_id, path, options.force) {
+            editor.set_error(format!("Error saving: {}", err));
         }
     }));
 
-    Ok(cb)
+    Ok(call)
 }
 
 #[derive(PartialEq, Eq)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3834,11 +3834,6 @@ async fn make_caos_callback(
             }
             helix_lsp::lsp::CodeActionOrCommand::Command(_) => None,
         })
-        .filter(|(_, a)| {
-            a.kind
-                .as_ref()
-                .is_some_and(|k| k == &CodeActionKind::SOURCE_ORGANIZE_IMPORTS)
-        })
         .collect::<Vec<_>>();
 
     let cb: job::Callback = Callback::Editor(Box::new(move |editor| {
@@ -3857,7 +3852,18 @@ async fn make_caos_callback(
             return;
         }
 
+        let enabled_code_actions = &editor.config.load().lsp.code_actions_on_save;
+
         for (ls_id, action) in actions {
+            if action
+                .kind
+                .as_ref()
+                .is_none_or(|k| !enabled_code_actions.iter().any(|a| k.as_str() == a))
+            {
+                log::debug!("Skipping disabled code action");
+                continue;
+            }
+
             let Some(language_server) = editor.language_server_by_id(ls_id) else {
                 editor.set_error("Language Server disappeared");
                 continue;

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4,8 +4,9 @@ pub(crate) mod syntax;
 pub(crate) mod typed;
 
 pub use dap::*;
-use futures_util::FutureExt;
+use futures_util::{stream::FuturesOrdered, FutureExt, StreamExt};
 use helix_event::status;
+use helix_lsp::{lsp::CodeActionKind, LanguageServerId};
 use helix_stdx::{
     path::{self, find_paths},
     rope::{self, RopeSliceExt},
@@ -3803,6 +3804,89 @@ async fn make_format_callback(
     }));
 
     Ok(call)
+}
+
+async fn make_caos_callback(
+    doc_id: DocumentId,
+    doc_version: i32,
+    view_id: ViewId,
+    mut lsps: FuturesOrdered<
+        impl Future<Output = helix_lsp::Result<Option<Vec<helix_lsp::lsp::CodeActionOrCommand>>>>,
+    >,
+    ids: Vec<LanguageServerId>,
+) -> anyhow::Result<job::Callback> {
+    let mut actions = vec![];
+    let mut ids = ids.into_iter();
+    while let Some(lsp) = lsps.next().await {
+        let id = ids.next().unwrap();
+        if let Ok(Some(code_actions)) = lsp {
+            for a in code_actions {
+                actions.push((id, a));
+            }
+        }
+    }
+
+    let actions = actions
+        .into_iter()
+        .filter_map(|(id, a)| match a {
+            helix_lsp::lsp::CodeActionOrCommand::CodeAction(a) => {
+                a.disabled.is_none().then(|| (id, a))
+            }
+            helix_lsp::lsp::CodeActionOrCommand::Command(_) => None,
+        })
+        .filter(|(_, a)| {
+            a.kind
+                .as_ref()
+                .is_some_and(|k| k == &CodeActionKind::SOURCE_ORGANIZE_IMPORTS)
+        })
+        .collect::<Vec<_>>();
+
+    let cb: job::Callback = Callback::Editor(Box::new(move |editor| {
+        if !editor.documents.contains_key(&doc_id) || !editor.tree.contains(view_id) {
+            return;
+        }
+
+        let doc = doc_mut!(editor, &doc_id);
+
+        if actions.is_empty() {
+            return;
+        }
+
+        if doc.version() != doc_version {
+            log::info!("Aborting applying code actions on save because the document changed");
+            return;
+        }
+
+        for (ls_id, action) in actions {
+            let Some(language_server) = editor.language_server_by_id(ls_id) else {
+                editor.set_error("Language Server disappeared");
+                continue;
+            };
+
+            let mut resolved_code_action = None;
+            if action.edit.is_none() || action.command.is_none() {
+                if let Some(future) = language_server.resolve_code_action(&action) {
+                    if let Ok(action) = helix_lsp::block_on(future) {
+                        resolved_code_action = Some(action);
+                    }
+                }
+            }
+            let resolved_code_action = resolved_code_action.as_ref().unwrap_or(&action);
+
+            if let Some(ref workspace_edit) = resolved_code_action.edit {
+                let _ =
+                    editor.apply_workspace_edit(language_server.offset_encoding(), workspace_edit);
+            }
+
+            // if code action provides both edit and command first the edit
+            // should be applied and then the command
+            if let Some(command) = &action.command {
+                editor.execute_lsp_command(command.clone(), ls_id);
+            }
+        }
+    }));
+
+    Ok(cb)
 }
 
 #[derive(PartialEq, Eq)]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3860,29 +3860,11 @@ async fn make_code_action_callback(
             return;
         }
 
-        let enabled_code_actions = &editor.config.load().lsp.code_actions_on_save;
-
         for CodeActionItem {
             code_action,
             language_server_id,
         } in available_code_actions
         {
-            if code_action
-                .kind
-                .as_ref()
-                .is_none_or(|k| !enabled_code_actions.iter().any(|a| k.as_str() == a))
-            {
-                log::debug!(
-                    "Skipping disabled code action {}",
-                    code_action
-                        .kind
-                        .as_ref()
-                        .map(|ca| ca.as_str())
-                        .unwrap_or("[unknown]")
-                );
-                continue;
-            }
-
             let Some(language_server) = editor.language_server_by_id(language_server_id) else {
                 editor.set_error("Language Server disappeared");
                 continue;

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -10,6 +10,9 @@ use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
 use helix_core::line_ending;
+use helix_lsp::lsp::{CodeActionContext, CodeActionTriggerKind, Range};
+use helix_lsp::util::diagnostic_to_lsp_diagnostic;
+use helix_lsp::Position;
 use helix_stdx::path::home_dir;
 use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
@@ -398,6 +401,55 @@ fn write_impl(
     doc.append_changes_to_history(view);
 
     let (view, doc) = current_ref!(cx.editor);
+
+    // TODO: cleanup
+
+    let mut seen_language_servers = HashSet::new();
+
+    let mut ids = vec![];
+    let mut lsps = FuturesOrdered::new();
+
+    for c in doc
+        .language_servers_with_feature(LanguageServerFeature::CodeAction)
+        .filter(|c| seen_language_servers.insert(c.id()))
+    {
+        let Some(res) = c.code_actions(
+            doc.identifier(),
+            Range::new(
+                Position::new(0, 0),
+                doc.position(view.id, c.offset_encoding()),
+            ),
+            CodeActionContext {
+                diagnostics: doc
+                    .diagnostics()
+                    .iter()
+                    .map(|diag| diagnostic_to_lsp_diagnostic(doc.text(), diag, c.offset_encoding()))
+                    .collect(),
+                only: None,
+                trigger_kind: Some(CodeActionTriggerKind::AUTOMATIC),
+            },
+        ) else {
+            continue;
+        };
+
+        ids.push(c.id());
+        lsps.push_back(res);
+    }
+
+    if !lsps.is_empty() {
+        jobs.add(
+            Job::with_callback(make_caos_callback(
+                doc.id(),
+                doc.version(),
+                view.id,
+                lsps,
+                ids,
+            ))
+            .wait_before_exiting(),
+        );
+        log::info!("Job added");
+    }
+
     let fmt = if config.auto_format && options.auto_format {
         doc.auto_format(cx.editor).map(|fmt| {
             let callback = make_format_callback(

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -6,6 +6,7 @@ use crate::job::Job;
 
 use super::*;
 
+use futures_util::stream::FuturesUnordered;
 use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
@@ -378,6 +379,45 @@ fn buffer_previous(
     Ok(())
 }
 
+fn available_code_actions(
+    doc: &Document,
+) -> FuturesUnordered<
+    impl Future<
+        Output = (
+            LanguageServerId,
+            helix_lsp::Result<Option<Vec<helix_lsp::lsp::CodeActionOrCommand>>>,
+        ),
+    >,
+> {
+    let mut seen = HashSet::new();
+
+    doc.language_servers_with_feature(LanguageServerFeature::CodeAction)
+        .filter(|x| seen.insert(x.id()))
+        .filter_map(|client| {
+            let encoding = client.offset_encoding();
+            let res = client.code_actions(
+                doc.identifier(),
+                Range::new(
+                    Position::new(0, 0),
+                    Position::new(doc.text().len_lines() as u32 + 1, 0),
+                ),
+                CodeActionContext {
+                    diagnostics: doc
+                        .diagnostics()
+                        .iter()
+                        .map(|diag| diagnostic_to_lsp_diagnostic(doc.text(), diag, encoding))
+                        .collect(),
+                    only: None,
+                    trigger_kind: Some(CodeActionTriggerKind::AUTOMATIC),
+                },
+            )?;
+
+            Some((client.id(), res))
+        })
+        .map(|(id, f)| async move { (id, f.await) })
+        .collect()
+}
+
 fn write_impl(
     cx: &mut compositor::Context,
     path: Option<&str>,
@@ -402,52 +442,10 @@ fn write_impl(
 
     let (view, doc) = current_ref!(cx.editor);
 
-    // TODO: cleanup
-
-    let mut seen_language_servers = HashSet::new();
-
-    let mut ids = vec![];
-    let mut lsps = FuturesOrdered::new();
-
-    for c in doc
-        .language_servers_with_feature(LanguageServerFeature::CodeAction)
-        .filter(|c| seen_language_servers.insert(c.id()))
-    {
-        let Some(res) = c.code_actions(
-            doc.identifier(),
-            Range::new(
-                Position::new(0, 0),
-                doc.position(view.id, c.offset_encoding()),
-            ),
-            CodeActionContext {
-                diagnostics: doc
-                    .diagnostics()
-                    .iter()
-                    .map(|diag| diagnostic_to_lsp_diagnostic(doc.text(), diag, c.offset_encoding()))
-                    .collect(),
-                only: None,
-                trigger_kind: Some(CodeActionTriggerKind::AUTOMATIC),
-            },
-        ) else {
-            continue;
-        };
-
-        ids.push(c.id());
-        lsps.push_back(res);
-    }
-
-    if !lsps.is_empty() {
-        jobs.add(
-            Job::with_callback(make_caos_callback(
-                doc.id(),
-                doc.version(),
-                view.id,
-                lsps,
-                ids,
-            ))
-            .wait_before_exiting(),
-        );
-        log::info!("Job added");
+    let code_actions = available_code_actions(doc);
+    if !code_actions.is_empty() {
+        let callback = make_code_action_callback(doc.id(), doc.version(), view.id, code_actions);
+        jobs.add(Job::with_callback(callback).wait_before_exiting());
     }
 
     let fmt = if config.auto_format && options.auto_format {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -444,12 +444,21 @@ fn write_impl(
     let (view, doc) = current_ref!(cx.editor);
 
     let code_actions = available_code_actions(doc);
-    if !code_actions.is_empty() {
-        let callback = make_code_action_callback(doc.id(), doc.version(), view.id, code_actions);
-        jobs.add(Job::with_callback(callback).wait_before_exiting());
-    }
 
-    let fmt = if config.auto_format && options.auto_format {
+    let job_scheduled = if !code_actions.is_empty() {
+        let callback = make_code_action_callback(
+            doc.id(),
+            doc.version(),
+            view.id,
+            path.map(Into::into),
+            options,
+            code_actions,
+        );
+
+        jobs.add(Job::with_callback(callback).wait_before_exiting());
+
+        Some(())
+    } else if config.auto_format && options.auto_format {
         doc.auto_format(cx.editor).map(|fmt| {
             let callback = make_format_callback(
                 doc.id(),
@@ -465,7 +474,7 @@ fn write_impl(
         None
     };
 
-    if fmt.is_none() {
+    if job_scheduled.is_none() {
         let id = doc.id();
         cx.editor.save(id, path, options.force)?;
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -394,7 +394,6 @@ fn available_code_actions(
     doc.language_servers_with_feature(LanguageServerFeature::CodeAction)
         .filter(|x| seen.insert(x.id()))
         .filter_map(|client| {
-            let encoding = client.offset_encoding();
             let res = client.code_actions(
                 doc.identifier(),
                 Range::new(
@@ -405,9 +404,11 @@ fn available_code_actions(
                     diagnostics: doc
                         .diagnostics()
                         .iter()
-                        .map(|diag| diagnostic_to_lsp_diagnostic(doc.text(), diag, encoding))
+                        .map(|diag| {
+                            diagnostic_to_lsp_diagnostic(doc.text(), diag, client.offset_encoding())
+                        })
                         .collect(),
-                    only: None,
+                    only: Some(doc.config.load().lsp.code_actions_on_save.clone()),
                     trigger_kind: Some(CodeActionTriggerKind::AUTOMATIC),
                 },
             )?;

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -20,7 +20,7 @@ use helix_vcs::DiffProviderRegistry;
 
 use futures_util::stream::select_all::SelectAll;
 use futures_util::{future, StreamExt};
-use helix_lsp::{Call, LanguageServerId};
+use helix_lsp::{lsp::CodeActionKind, Call, LanguageServerId};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use std::{
@@ -566,6 +566,8 @@ pub struct LspConfig {
     pub snippets: bool,
     /// Whether to include declaration in the goto reference query
     pub goto_reference_include_declaration: bool,
+    /// Which code actions should be ran on save
+    pub code_actions_on_save: Vec<String>,
 }
 
 impl Default for LspConfig {
@@ -582,6 +584,9 @@ impl Default for LspConfig {
             snippets: true,
             goto_reference_include_declaration: true,
             display_color_swatches: true,
+            code_actions_on_save: vec![CodeActionKind::SOURCE_ORGANIZE_IMPORTS
+                .as_str()
+                .to_string()],
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -566,8 +566,8 @@ pub struct LspConfig {
     pub snippets: bool,
     /// Whether to include declaration in the goto reference query
     pub goto_reference_include_declaration: bool,
-    /// Which code actions should be ran on save
-    pub code_actions_on_save: Vec<String>,
+    /// Which code actions should be executed before saving
+    pub code_actions_on_save: Vec<CodeActionKind>,
 }
 
 impl Default for LspConfig {
@@ -584,9 +584,7 @@ impl Default for LspConfig {
             snippets: true,
             goto_reference_include_declaration: true,
             display_color_swatches: true,
-            code_actions_on_save: vec![CodeActionKind::SOURCE_ORGANIZE_IMPORTS
-                .as_str()
-                .to_string()],
+            code_actions_on_save: vec![CodeActionKind::SOURCE_ORGANIZE_IMPORTS],
         }
     }
 }


### PR DESCRIPTION
Add support for executing code actions before saving, while respecting format on save.

There's new configuration option `editor.lsp.code-actions-on-save` for controlling which code actions are ran.

I'll add tests for this, but I couldn't find any for auto-formatting (which is really close to this code path), so it'll take me some time

## Demo
https://github.com/user-attachments/assets/4d2ee7b1-ab01-4fb9-a49c-2d97cf2caae5

## Caveats
VSCode allows overriding for each language which code actions are executed, this PR does not include that. 

Closes #1565 