### PR TITLE
syntax: support `nix-shell -i` interpreters for the shebang detector

### DIFF
--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -391,19 +391,16 @@ impl Loader {
     pub fn language_for_shebang(&self, text: RopeSlice) -> Option<Language> {
         // NOTE: this is slightly different than the one for injection markers in tree-house. It
         // is anchored at the beginning.
-        use helix_stdx::rope::Regex;
-        use once_cell::sync::Lazy;
-        const SHEBANG: &str = r"^#!\s*(?:\S*[/\\](?:env\s+(?:\-\S+\s+)*)?)?([^\s\.\d]+)";
-        static SHEBANG_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(SHEBANG).unwrap());
-
-        let marker = SHEBANG_REGEX
-            .captures_iter(regex_cursor::Input::new(text))
-            .map(|cap| text.byte_slice(cap.get_group(1).unwrap().range()))
-            .next()?;
+        let marker = shebang_interpreter(text)?;
         self.language_for_shebang_marker(marker)
     }
 
     fn language_for_shebang_marker(&self, marker: RopeSlice) -> Option<Language> {
+        // Injection markers are usually plain interpreter names such as `bash` or `nu`, but some tree-sitter queries
+        // capture a larger source range as `@injection.shebang`, which can include shebang lines and script text.
+        // Re-parse those larger captures so `nix-shell -i` works for injections too, then fall back to the original
+        // marker for the normal lookup path.
+        let marker = shebang_interpreter(marker).unwrap_or(marker);
         let shebang: Cow<str> = marker.into();
         self.languages_by_shebang.get(shebang.as_ref()).copied()
     }
@@ -458,6 +455,28 @@ impl LanguageLoader for Loader {
     fn get_config(&self, lang: Language) -> Option<&SyntaxConfig> {
         self.languages[lang.idx()].syntax_config(self)
     }
+}
+
+fn shebang_interpreter(text: RopeSlice) -> Option<RopeSlice> {
+    use helix_stdx::rope::Regex;
+    use once_cell::sync::Lazy;
+
+    const NIX_SHELL: &str =
+        r"(?m)^#!\s*(?:\S*[/\\](?:env\s+(?:\-\S+\s+)*)?)?nix-shell(?:\s+[^\n]*)?\s-i\s+([^\s]+)";
+    const SHEBANG: &str = r"^#!\s*(?:\S*[/\\](?:env\s+(?:\-\S+\s+)*)?)?([^\s\.\d]+)";
+
+    static NIX_SHELL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(NIX_SHELL).unwrap());
+    static SHEBANG_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(SHEBANG).unwrap());
+
+    NIX_SHELL_REGEX
+        .captures_iter(regex_cursor::Input::new(text))
+        .next()
+        .or_else(|| {
+            SHEBANG_REGEX
+                .captures_iter(regex_cursor::Input::new(text))
+                .next()
+        })
+        .map(|cap| text.byte_slice(cap.get_group(1).unwrap().range()))
 }
 
 #[derive(Debug)]
@@ -1220,6 +1239,20 @@ mod test {
         assert_shebang_interpreter("#! /usr/bin/python3\n", Some("python"));
         assert_shebang_interpreter("def main [] {}\n", None);
     }
+
+    #[test]
+    fn test_nix_shell_shebang_interpreter() {
+        assert_shebang_interpreter(
+            "#!/usr/bin/env nix-shell\n#!nix-shell -i nu -p nushell nh\n",
+            Some("nu"),
+        );
+        assert_shebang_interpreter(
+            "#!/usr/bin/env nix-shell\n#!nix-shell -p nushell nh -i nu\n",
+            Some("nu"),
+        );
+        assert_shebang_interpreter("#!nix-shell -p bash -i bash\n", Some("bash"));
+    }
+
     #[test]
     fn test_textobject_queries() {
         let query_str = r#"

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -461,8 +461,7 @@ fn shebang_interpreter(text: RopeSlice) -> Option<RopeSlice> {
     use helix_stdx::rope::Regex;
     use once_cell::sync::Lazy;
 
-    const NIX_SHELL: &str =
-        r"(?m)^#!\s*(?:\S*[/\\](?:env\s+(?:\-\S+\s+)*)?)?nix-shell(?:\s+[^\n]*)?\s-i\s+([^\s]+)";
+    const NIX_SHELL: &str = r"(?m)^#!\s*(?:\S*[/\\](?:env\s+(?:\-\S+\s+)*)?)?(?:nix-shell(?:\s+[^\n]*)?\s-i|nix(?:\s+[^\n]*)?\s(?:--command|-c))\s+([^\s]+)";
     const SHEBANG: &str = r"^#!\s*(?:\S*[/\\](?:env\s+(?:\-\S+\s+)*)?)?([^\s\.\d]+)";
 
     static NIX_SHELL_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(NIX_SHELL).unwrap());
@@ -1251,6 +1250,18 @@ mod test {
             Some("nu"),
         );
         assert_shebang_interpreter("#!nix-shell -p bash -i bash\n", Some("bash"));
+        assert_shebang_interpreter(
+            "#!/usr/bin/env nix\n#! nix shell github:tomberek/-#python3With.prettytable --command python\n",
+            Some("python"),
+        );
+        assert_shebang_interpreter(
+            "#!/usr/bin/env nix\n#! nix shell github:tomberek/-#perlWith.HTMLTokeParserSimple.LWP -c perl -x\n",
+            Some("perl"),
+        );
+        assert_shebang_interpreter(
+            "#!/usr/bin/env nix\n#! nix shell --impure --expr ``\n#! nix with (import (builtins.getFlake ''nixpkgs'') {});\n#! nix terraform.withPlugins (plugins: [ plugins.openstack ])\n#! nix ``\n#! nix --command bash\n",
+            Some("bash"),
+        );
     }
 
     #[test]

--- a/helix-core/src/syntax.rs
+++ b/helix-core/src/syntax.rs
@@ -1205,6 +1205,21 @@ mod test {
 
     static LOADER: Lazy<Loader> = Lazy::new(crate::config::default_lang_loader);
 
+    fn assert_shebang_interpreter(source: &str, expected: Option<&str>) {
+        let source = Rope::from(source);
+        let interpreter = shebang_interpreter(source.slice(..)).map(Cow::<str>::from);
+        assert_eq!(interpreter.as_deref(), expected);
+    }
+
+    #[test]
+    fn test_shebang_interpreter() {
+        assert_shebang_interpreter("#!nu\n", Some("nu"));
+        assert_shebang_interpreter("#!/usr/bin/env nu\n", Some("nu"));
+        assert_shebang_interpreter("#!/usr/bin/env -S uv run python\n", Some("uv"));
+        assert_shebang_interpreter("#!/bin/bash\n", Some("bash"));
+        assert_shebang_interpreter("#! /usr/bin/python3\n", Some("python"));
+        assert_shebang_interpreter("def main [] {}\n", None);
+    }
     #[test]
     fn test_textobject_queries() {
         let query_str = r#"


### PR DESCRIPTION
An interesting ability that `nix-shell` has is that it can be used as a shebang interpreter to delegate the "real" interpretation to a nixpkgs package. See the [docs](https://nix.dev/manual/nix/2.18/command-ref/nix-shell#use-as-a--interpreter) for this, it's pretty cool.

Anyways, this PR extends the existing shebang language detection code with support for `nix-shell -i` by using Even More Cursed Regex!

Tested on the following sample:
```
#!/usr/bin/env nix-shell
#!nix-shell -i nu -p nushell

def main [...$args] {
  print hi!
}
```

And in the new unit tests, of course.
