### PR TITLE
lang: update gas

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3666,7 +3666,7 @@ language-servers = ["asm-lsp"]
 
 [[grammar]]
 name = "gas"
-source = { git = "https://github.com/sirius94/tree-sitter-gas", rev = "60f443646b20edee3b7bf18f3a4fb91dc214259a" }
+source = { git = "https://github.com/sirius94/tree-sitter-gas", rev = "5d6c0a0b4d7b6f35913906ba922fe38064a9bede" }
 
 [[language]]
 name = "rst"


### PR DESCRIPTION
Hi ! 

This PR just uses the latest commit of the dev branch of the gas tree-sitter.

https://github.com/sirius94/tree-sitter-gas/pull/3 (dev->master) never has been merged but fixes QOL things like local labels