### PR TITLE
Fix stray separator when incrementing negative numbers across a digit boundary

### DIFF
--- a/helix-core/src/increment/integer.rs
+++ b/helix-core/src/increment/integer.rs
@@ -83,11 +83,20 @@ pub fn increment(selected_text: &str, amount: i64) -> Option<String> {
         }
     };
 
+    // Separators must only be inserted between digits, never within the sign or
+    // base prefix. Otherwise a negative number that loses a digit (e.g. -1_000
+    // incrementing to -999) would place a separator right after the `-`.
+    let digit_start = if radix == 10 {
+        usize::from(new_text.starts_with('-'))
+    } else {
+        2
+    };
+
     // Add separators from original number.
     for &rtl_index in &separator_rtl_indexes {
         if rtl_index < new_text.len() {
             let new_index = new_text.len().saturating_sub(rtl_index);
-            if new_index > 0 {
+            if new_index > digit_start {
                 new_text.insert(new_index, SEPARATOR);
             }
         }
@@ -219,6 +228,23 @@ mod test {
             ("0x0000_0000_0000", -1, "0x0000_0000_0000"),
             ("0b01111111_11111111", 1, "0b10000000_00000000"),
             ("0b11111111_11111111", 1, "0b1_00000000_00000000"),
+        ];
+
+        for (original, amount, expected) in tests {
+            assert_eq!(increment(original, amount).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn test_increment_negative_with_separators_shrinking() {
+        // A negative number that loses a digit must not gain a stray separator
+        // directly after the minus sign.
+        let tests = [
+            ("-1_000", 1, "-999"),
+            ("-1_000", 2, "-998"),
+            ("-1_000_000", 1, "-999_999"),
+            ("-1_0", 1, "-9"),
+            ("999_999", -1_000_000, "-1"),
         ];
 
         for (original, amount, expected) in tests {


### PR DESCRIPTION
Incrementing a negative number that contains digit separators can produce malformed output when the result loses a digit. For example, with `-1_000` selected and pressing increment:

```
-1_000  ->  -_999
```

The expected result is `-999`.

Root cause: after building the new number string, `increment` re-inserts separators by mapping the original number's right-to-left separator positions onto the new string (`new_index = new_text.len() - rtl_index`), guarded only by `new_index > 0`. When the value is negative the leading `-` adds one to `new_text.len()`, so a separator whose original position no longer corresponds to a digit boundary gets placed immediately after the minus sign.

The fix restricts separator insertion to positions strictly past the sign (decimal) or the base prefix (binary/octal/hex), so separators only ever land between digits. The positive-number behavior is unchanged: for base 10 without a sign the new bound is 0, identical to the previous `> 0` check.

Added a regression test covering negative decimals that shrink across a power-of-ten boundary (`-1_000`, `-1_000_000`, `-1_0`) and a positive value decremented past zero (`999_999` - `1_000_000` = `-1`). Existing increment tests continue to pass; `cargo fmt --check` and `cargo clippy -p helix-core` are clean.
