### PR TITLE
Fix Svelte `<script>` and `<style>` injections

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1652,7 +1652,7 @@ language-servers = [ "svelteserver" ]
 
 [[grammar]]
 name = "svelte"
-source = { git = "https://github.com/themixednuts/tree-sitter-htmlx", rev = "80c3e698ec7379772c7f2aecb9b4b4c4ac52ff0b", subpath = "crates/tree-sitter-svelte" }
+source = { git = "https://github.com/themixednuts/tree-sitter-htmlx", rev = "c9b9cc35709fff494a3a9e41cd9471b633649e45", subpath = "crates/tree-sitter-svelte" }
 
 [[language]]
 name = "vue"

--- a/runtime/queries/svelte/injections.scm
+++ b/runtime/queries/svelte/injections.scm
@@ -1,72 +1,18 @@
-; Script elements with TypeScript aliases
-((element
-  (start_tag
-    (tag_name) @_tag
-    (attribute
-      (quoted_attribute_value
-        (attribute_value) @_value)))
-  (raw_text) @injection.content)
-  (#match? @_tag "^[Ss][Cc][Rr][Ii][Pp][Tt]$")
-  (#any-of? @_value "ts" "typescript" "text/typescript")
-  (#set! injection.language "typescript"))
-
-; Script elements with explicit language
-((element
-  (start_tag
-    (tag_name) @_tag
-    (attribute
-      (attribute_name) @_lang
-      (quoted_attribute_value
-        (attribute_value) @injection.language)))
-  (raw_text) @injection.content)
-  (#eq? @_tag "script")
-  (#eq? @_lang "lang")
-  (#not-any-of? @injection.language "ts" "typescript" "text/typescript"))
-
-; Script content defaults to JavaScript
+; <script> content defaults to JavaScript
 ((element
   (start_tag (tag_name) @_tag)
   (raw_text) @injection.content)
   (#eq? @_tag "script")
   (#set! injection.language "javascript"))
 
-; Style with lang="scss"
+; <style> content defaults to CSS
 ((element
-  (start_tag
-    (tag_name) @_tag
-    (attribute
-      (quoted_attribute_value
-        (attribute_value) @_scss)))
+  (start_tag (tag_name) @_tag)
   (raw_text) @injection.content)
   (#eq? @_tag "style")
-  (#eq? @_scss "scss")
-  (#set! injection.language "scss"))
+  (#set! injection.language "css"))
 
-; Style with lang="sass"
-((element
-  (start_tag
-    (tag_name) @_tag
-    (attribute
-      (quoted_attribute_value
-        (attribute_value) @_sass)))
-  (raw_text) @injection.content)
-  (#eq? @_tag "style")
-  (#eq? @_sass "sass")
-  (#set! injection.language "sass"))
-
-; Style with lang="less"
-((element
-  (start_tag
-    (tag_name) @_tag
-    (attribute
-      (quoted_attribute_value
-        (attribute_value) @_less)))
-  (raw_text) @injection.content)
-  (#eq? @_tag "style")
-  (#eq? @_less "less")
-  (#set! injection.language "less"))
-
-; Style with explicit language
+; <script> or <style> with "lang" attribute
 ((element
   (start_tag
     (tag_name) @_tag
@@ -75,20 +21,8 @@
       (quoted_attribute_value
         (attribute_value) @injection.language)))
   (raw_text) @injection.content)
-  (#eq? @_tag "style")
-  (#eq? @_lang "lang")
-  (#not-any-of? @injection.language "scss" "sass" "less"))
-
-; Style content defaults to CSS when no lang attribute is present
-((element
-  (start_tag
-    (tag_name) @_tag
-    (attribute
-      (attribute_name) @_style_attr)*)
-  (raw_text) @injection.content)
-  (#eq? @_tag "style")
-  (#not-any-of? @_style_attr "lang")
-  (#set! injection.language "css"))
+  (#any-of? @_tag "style" "script")
+  (#eq? @_lang "lang"))
 
 ; Inline style attribute
 ((attribute


### PR DESCRIPTION
Instead of using separate injection queries for each tag and `lang` combination, this combines them. This also moves the fallback queries to the top so that they actually apply.

We also avoid matching the tag name case-insensitively as was done before since unlike HTML, Svelte requires the `<script>` and `<style>` tags to be all lowercase or else it won't compile (e.g. [here](https://svelte.dev/playground/hello-world?version=5.56.2#H4sIAAAAAAAAA22PQU_EIBCF_8pITLaNxrpXhCbGi__B9UDb2UhEIGXY1RD-u0DX7MXjvO_NezOJWfWFjLNXNMbB2a1mgQ4XTbj07J4dtcHA-Fti9OOrrwpFv2w9e_8QTmioapMK-J8-O0toqcQwEV5W7Wk82AMZJKh2kHAbSBF2u1a_65_-8OyipSt_rEQM1wwrPvbjdnmqUflGDEVpRFsfCSZtF35SJqLcHDAULKZI5Cw4Oxs9f8rU9SDHS92dhH1uFzYYOKQGcu3eFgstfxF-E-O0RszvZVLanEsb40dlAuZfgvAoV1oBAAA)). 

Before:
<img width="358" height="185" alt="image" src="https://github.com/user-attachments/assets/0960b0dc-4cd3-4cfd-a256-05ee244eb15f" />

After:
<img width="358" height="185" alt="image" src="https://github.com/user-attachments/assets/cf82219e-98f2-443f-a1cf-b36b6e413de6" />

Also updates @themixednuts's `tree-sitter-htmlx` to the [latest release](https://github.com/themixednuts/tree-sitter-htmlx/commit/c9b9cc35709fff494a3a9e41cd9471b633649e45). (Not needed for the injections fixes to work, but might as well bump it while we're here.)