### PR TITLE
qml: add statement_block to indents.scm

### DIFF
--- a/runtime/queries/qml/indents.scm
+++ b/runtime/queries/qml/indents.scm
@@ -1,6 +1,7 @@
 [
   (enum_body)
   (ui_object_initializer)
+  (statement_block)
 ] @indent
 
 "}" @outdent


### PR DESCRIPTION
QML grammar seems to be JS derived, and the QML indents.scm is missing (statement_block) causing incorrect indentation. adding it corrects indentation.

[Fixes #15847](https://github.com/helix-editor/helix/issues/15847) 