### PR TITLE
lang: Add nginx LSP

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -194,7 +194,7 @@
 | nasm | ✓ | ✓ |  |  |  | `asm-lsp` |
 | nearley | ✓ |  |  |  | ✓ |  |
 | nestedtext | ✓ | ✓ | ✓ |  |  |  |
-| nginx | ✓ |  |  |  |  |  |
+| nginx | ✓ |  |  |  |  | `nginx-language-server` |
 | nickel | ✓ |  | ✓ |  |  | `nls` |
 | nim | ✓ | ✓ | ✓ |  | ✓ | `nimlangserver` |
 | nix | ✓ | ✓ | ✓ | ✓ | ✓ | `nil`, `nixd` |

--- a/languages.toml
+++ b/languages.toml
@@ -90,6 +90,7 @@ mesonlsp = { command = "mesonlsp", args = ["--lsp"] }
 mint = { command = "mint", args = ["tool", "ls"] }
 mojo-lsp-server = { command = "pixi", args = ["run", "mojo-lsp-server"] }
 neocmakelsp = { command = "neocmakelsp", args = ["stdio"] }
+nginx-language-server = { command = "nginx-language-server" }
 nil = { command = "nil" }
 nimlangserver = { command = "nimlangserver" }
 nimlsp = { command = "nimlsp" }
@@ -4754,6 +4755,7 @@ file-types = [
 roots = ["nginx.conf"]
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
+language-servers = [ "nginx-language-server" ]
 
 [[grammar]]
 name = "nginx"


### PR DESCRIPTION
This PR adds support for [nginx-language-server](https://github.com/pappasam/nginx-language-server).

<img width="928" height="554" alt="image" src="https://github.com/user-attachments/assets/a9fb0acb-c671-4efa-aaa3-4db8172da564" />

Previously, nginx files would only have syntax highlighting.

Zed Editor utilizes the same LSP via official [extension](https://github.com/zed-extensions/nginx).