### PR TITLE
feat(picker): add scrollable file preview

### DIFF
--- a/book/src/keymap.md
+++ b/book/src/keymap.md
@@ -472,8 +472,8 @@ See the documentation page on [pickers](./pickers.md) for more info.
 | -----                        | -------------                                              |
 | `Shift-Tab`, `Up`, `Ctrl-p`  | Previous entry                                             |
 | `Tab`, `Down`, `Ctrl-n`      | Next entry                                                 |
-| `PageUp`, `Ctrl-u`           | Page up                                                    |
-| `PageDown`, `Ctrl-d`         | Page down                                                  |
+| `Ctrl-u`                     | Page up the list                                          |
+| `Ctrl-d`                     | Page down the list                                        |
 | `Home`                       | Go to first entry                                          |
 | `End`                        | Go to last entry                                           |
 | `Enter`                      | Open selected                                              |
@@ -481,6 +481,10 @@ See the documentation page on [pickers](./pickers.md) for more info.
 | `Ctrl-s`                     | Open horizontally                                          |
 | `Ctrl-v`                     | Open vertically                                            |
 | `Ctrl-t`                     | Toggle preview                                             |
+| `PageUp`                     | Scroll the preview up a page (page up the list when no preview is shown)   |
+| `PageDown`                   | Scroll the preview down a page (page down the list when no preview is shown) |
+| `Alt-k`, `Shift-Up`          | Scroll the preview up a line                              |
+| `Alt-j`, `Shift-Down`        | Scroll the preview down a line                            |
 | `Escape`, `Ctrl-c`           | Close picker                                               |
 
 ## Prompt

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -42,7 +42,8 @@ use std::{
 use crate::ui::{Prompt, PromptEvent};
 use helix_core::{
     char_idx_at_visual_offset, fuzzy::MATCHER, movement::Direction,
-    text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation, Position,
+    text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation,
+    visual_offset_from_anchor, Position,
 };
 use helix_view::{
     editor::Action,
@@ -269,6 +270,15 @@ pub struct Picker<T: 'static + Send + Sync, D: 'static> {
     /// An event handler for syntax highlighting the currently previewed file.
     preview_highlight_handler: Sender<Arc<Path>>,
     dynamic_query_handler: Option<Sender<DynamicQueryChange>>,
+
+    /// Vertical scroll of the file preview, in visual (soft-wrapped) rows relative to
+    /// the natural top of the preview. Positive scrolls down, negative scrolls up.
+    preview_scroll_offset: isize,
+    /// Height in rows of the preview pane's inner text area, used for page scrolling.
+    preview_height: u16,
+    /// Selected item the current `preview_scroll_offset` applies to; the scroll resets
+    /// to the top when the selection changes.
+    preview_scroll_cursor: u32,
 }
 
 impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
@@ -394,6 +404,9 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
             file_fn: None,
             preview_highlight_handler: PreviewHighlightHandler::<T, D>::default().spawn(),
             dynamic_query_handler: None,
+            preview_scroll_offset: 0,
+            preview_height: 0,
+            preview_scroll_cursor: 0,
         }
     }
 
@@ -453,6 +466,23 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
     pub fn with_default_action(mut self, action: Action) -> Self {
         self.default_action = action;
         self
+    }
+
+    /// Scrolls the file preview by `amount` visual lines, down for a positive amount and
+    /// up for a negative one.
+    ///
+    /// The offset is counted in visual (soft-wrapped) rows so a file with long lines can
+    /// be scrolled to its end one wrapped row at a time. It is clamped against the file
+    /// bounds later, when the preview is rendered and the soft-wrap layout is known.
+    fn scroll_preview(&mut self, amount: isize) {
+        self.preview_scroll_offset = self.preview_scroll_offset.saturating_add(amount);
+    }
+
+    /// Whether a scrollable file preview is currently shown. Pickers without a preview
+    /// callback (no `file_fn`) or with the preview toggled off route preview-scroll keys
+    /// back to result-list navigation.
+    fn preview_shown(&self) -> bool {
+        self.show_preview && self.file_fn.is_some()
     }
 
     /// Move the cursor by a number of lines, either down (`Forward`) or up (`Backward`)
@@ -897,6 +927,16 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
         let inner = inner.inner(margin);
         BLOCK.render(area, surface);
 
+        // Reset the preview scroll on a selection change, before the `get_preview` borrow.
+        if self.cursor != self.preview_scroll_cursor {
+            self.preview_scroll_offset = 0;
+            self.preview_scroll_cursor = self.cursor;
+        }
+
+        // `get_preview` borrows `self` for the block below, so the offset is read into a
+        // local here, clamped against the soft-wrap layout inside, then written back after.
+        let mut scroll = self.preview_scroll_offset;
+
         if let Some((preview, range)) = self.get_preview(cx.editor) {
             let doc = match preview.document() {
                 Some(doc)
@@ -930,6 +970,7 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                     return;
                 }
             };
+            let doc_height = doc.text().len_lines();
 
             let mut offset = ViewPosition::default();
             if let Some((start_line, end_line)) = range {
@@ -955,6 +996,82 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                     }
                 } else {
                     offset.anchor = start;
+                }
+            }
+
+            // Apply the preview scroll by moving the anchor by whole visual lines, so
+            // soft-wrapped lines scroll one wrapped row at a time. `offset.anchor` is the
+            // natural top of the preview (line 0, or the centred match for range previews)
+            // and is left untouched when there is no scroll, keeping that centring. An
+            // upward scroll is clamped to the start of the file by `char_idx_at_visual_offset`.
+            let mut at_bottom = false;
+            if scroll != 0 {
+                let text = doc.text().slice(..);
+                let text_fmt = doc.text_format(inner.width, None);
+                let annotations = TextAnnotations::default();
+                let natural_anchor = offset.anchor;
+
+                let (anchor, vertical_offset) = char_idx_at_visual_offset(
+                    text,
+                    natural_anchor,
+                    scroll,
+                    0,
+                    &text_fmt,
+                    &annotations,
+                );
+
+                // The anchor that keeps the file's last visual line on the bottom row, so a
+                // downward scroll can't run past the end into empty space. Found by walking
+                // up one viewport from the end: a screenful of rows at most.
+                let (max_anchor, _) = char_idx_at_visual_offset(
+                    text,
+                    text.len_chars().saturating_sub(1),
+                    -(inner.height as isize - 1),
+                    0,
+                    &text_fmt,
+                    &annotations,
+                );
+
+                if anchor >= max_anchor {
+                    at_bottom = true;
+                    offset.anchor = max_anchor;
+                    offset.vertical_offset = 0;
+
+                    // Scrolled past the bottom: clamp the stored offset to the scroll that
+                    // exactly reaches it, so the offset can't accumulate and the next upward
+                    // scroll responds at once. Measured between the in-range natural and
+                    // bottom anchors (not the applied anchor, which may sit past EOF where it
+                    // can't be measured), capped at the current offset.
+                    if anchor > max_anchor {
+                        let max_scroll = visual_offset_from_anchor(
+                            text,
+                            natural_anchor,
+                            max_anchor,
+                            &text_fmt,
+                            &annotations,
+                            scroll.unsigned_abs(),
+                        )
+                        .map_or(scroll, |(pos, _)| pos.row as isize);
+                        scroll = scroll.min(max_scroll);
+                    }
+                } else {
+                    offset.anchor = anchor;
+                    offset.vertical_offset = vertical_offset;
+
+                    // Past the top: `char_idx_at_visual_offset` already pinned the anchor to
+                    // the start, so normalise a negative offset to the rows actually
+                    // scrolled, keeping it from accumulating above the top.
+                    if scroll < 0 && anchor <= natural_anchor {
+                        scroll = visual_offset_from_anchor(
+                            text,
+                            anchor,
+                            natural_anchor,
+                            &text_fmt,
+                            &annotations,
+                            scroll.unsigned_abs(),
+                        )
+                        .map_or(scroll, |(pos, _)| -(pos.row as isize));
+                    }
                 }
             }
 
@@ -1008,6 +1125,8 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 decorations.add_decoration(draw_highlight);
             }
 
+            let current_line = doc.text().slice(..).char_to_line(offset.anchor);
+
             render_document(
                 surface,
                 inner,
@@ -1020,7 +1139,41 @@ impl<T: 'static + Send + Sync, D: 'static + Send + Sync> Picker<T, D> {
                 &cx.editor.theme,
                 decorations,
             );
+
+            // Scroll indicator on the right edge. The thumb is placed from document lines,
+            // which is approximate when lines soft-wrap, so it is pinned to the end once the
+            // preview is scrolled to the bottom and otherwise clamped within the track.
+            let win_height = inner.height as usize;
+            let scroll_style = cx.editor.theme.get("ui.menu.scroll");
+
+            if doc_height > win_height {
+                let scroll_height = win_height.pow(2).div_ceil(doc_height).min(win_height);
+                let track = win_height - scroll_height;
+                let scroll_line = if at_bottom {
+                    track
+                } else {
+                    (track * current_line / std::cmp::max(1, doc_height.saturating_sub(win_height)))
+                        .min(track)
+                };
+
+                let mut cell;
+                for i in 0..win_height {
+                    cell = &mut surface[(inner.right() - 1, inner.top() + i as u16)];
+                    cell.set_symbol("▐");
+
+                    if scroll_line <= i && i < scroll_line + scroll_height {
+                        // thumb
+                        cell.set_fg(scroll_style.fg.unwrap_or(helix_view::theme::Color::Reset));
+                    } else {
+                        // track
+                        cell.set_fg(scroll_style.bg.unwrap_or(helix_view::theme::Color::Reset));
+                    }
+                }
+            }
         }
+
+        // Persist the offset clamped against the soft-wrap layout above.
+        self.preview_scroll_offset = scroll;
     }
 }
 
@@ -1094,10 +1247,24 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             key!(Tab) | key!(Down) | ctrl!('n') => {
                 self.move_by(1, Direction::Forward);
             }
-            key!(PageDown) | ctrl!('d') => {
+            // Ctrl-d/Ctrl-u always page the result list. PageDown/PageUp scroll the
+            // preview a full page when one is shown, and otherwise page the list.
+            ctrl!('d') => {
                 self.page_down();
             }
-            key!(PageUp) | ctrl!('u') => {
+            ctrl!('u') => {
+                self.page_up();
+            }
+            key!(PageDown) if self.preview_shown() => {
+                self.scroll_preview(self.preview_height as isize);
+            }
+            key!(PageUp) if self.preview_shown() => {
+                self.scroll_preview(-(self.preview_height as isize));
+            }
+            key!(PageDown) => {
+                self.page_down();
+            }
+            key!(PageUp) => {
                 self.page_up();
             }
             key!(Home) => {
@@ -1162,6 +1329,17 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
             ctrl!('t') => {
                 self.toggle_preview();
             }
+            // Preview line scrolling. Alt-d/f/b are intentionally avoided here: the prompt
+            // keybinds (which also apply in pickers) use them for word editing in the
+            // query, and full-page preview scrolling is already on PageUp/PageDown.
+            alt!('k') | shift!(Up) if self.preview_shown() => {
+                let lines = ctx.editor.config().scroll_lines.unsigned_abs() as isize;
+                self.scroll_preview(-lines);
+            }
+            alt!('j') | shift!(Down) if self.preview_shown() => {
+                let lines = ctx.editor.config().scroll_lines.unsigned_abs() as isize;
+                self.scroll_preview(lines);
+            }
             _ => {
                 self.prompt_handle_event(event, ctx);
             }
@@ -1191,6 +1369,8 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
 
     fn required_size(&mut self, (width, height): (u16, u16)) -> Option<(u16, u16)> {
         self.completion_height = height.saturating_sub(4 + self.header_height());
+        self.preview_height = height.saturating_sub(2);
+
         Some((width, height))
     }
 


### PR DESCRIPTION
Continues #11441 (a revival of #4189) on current master, with the maintainer
review applied. Makes the picker's file preview scrollable and soft-wrap aware,
without taking over the result-list keys.

Scrolling is by visual lines, so a file with long soft-wrapped lines can be read
to the bottom, the [soft-wrap blocker](https://github.com/helix-editor/helix/pull/11441#pullrequestreview-3185459679) raised in review on #11441. The offset is 
clamped at both edges,  so overscrolling can't accumulate and the opposite 
direction responds on the first press.

**Keys** (when a preview is shown):
- `PageUp`/`PageDown`: scroll a page (page the list when there's no preview)
- `Alt-j`/`Alt-k`, `Shift-Down`/`Shift-Up`: scroll a line
- `Ctrl-u`/`Ctrl-d`: unchanged, still page the result list

`Alt-d`/`Alt-f`/`Alt-b` stay with the prompt for word editing. The picker keymap
docs are updated to match.

Covers the keyboard side of #15047; mouse and remappable keys are out of scope.
The #11441 commit no longer compiles on master (`get_preview` now borrows `self`
across the render block), so this is reworked rather than a plain rebase.
