### PR TITLE
Fix multiple `:set-option` commands in keybinding sequences

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -394,35 +394,41 @@ impl Application {
             ConfigEvent::UpdateField(key, value) => {
                 // Update a single field in the editor config
                 let mut app_config = (*self.config.load().clone()).clone();
-                
+
                 // Use serde_json to navigate and update the nested structure
                 let mut config_json: serde_json::Value = serde_json::to_value(&app_config.editor)
                     .map_err(|err| {
-                        self.editor.set_error(format!("Failed to serialize editor config: {}", err));
+                        self.editor
+                            .set_error(format!("Failed to serialize editor config: {}", err));
                     })
                     .unwrap_or(serde_json::json!({}));
-                
+
                 // Build the JSON pointer path
                 let pointer = format!("/{}", key.replace('.', "/"));
-                
+
                 if let Some(field) = config_json.pointer_mut(&pointer) {
                     *field = value;
                     // Deserialize back to helix_view::editor::Config
                     match serde_json::from_value::<helix_view::editor::Config>(config_json) {
                         Ok(editor_config) => {
                             app_config.editor = editor_config;
-                            if let Err(err) = self.terminal.reconfigure((&app_config.editor).into()) {
+                            if let Err(err) = self.terminal.reconfigure((&app_config.editor).into())
+                            {
                                 self.editor.set_error(err.to_string());
                             };
                             self.config.store(Arc::new(app_config));
                         }
                         Err(err) => {
-                            self.editor.set_error(format!("Failed to deserialize editor config after updating {}: {}", key, err));
+                            self.editor.set_error(format!(
+                                "Failed to deserialize editor config after updating {}: {}",
+                                key, err
+                            ));
                             return;
                         }
                     }
                 } else {
-                    self.editor.set_error(format!("Unknown config field: {}", key));
+                    self.editor
+                        .set_error(format!("Unknown config field: {}", key));
                     return;
                 }
             }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -391,6 +391,41 @@ impl Application {
                 };
                 self.config.store(Arc::new(app_config));
             }
+            ConfigEvent::UpdateField(key, value) => {
+                // Update a single field in the editor config
+                let mut app_config = (*self.config.load().clone()).clone();
+                
+                // Use serde_json to navigate and update the nested structure
+                let mut config_json: serde_json::Value = serde_json::to_value(&app_config.editor)
+                    .map_err(|err| {
+                        self.editor.set_error(format!("Failed to serialize editor config: {}", err));
+                    })
+                    .unwrap_or(serde_json::json!({}));
+                
+                // Build the JSON pointer path
+                let pointer = format!("/{}", key.replace('.', "/"));
+                
+                if let Some(field) = config_json.pointer_mut(&pointer) {
+                    *field = value;
+                    // Deserialize back to helix_view::editor::Config
+                    match serde_json::from_value::<helix_view::editor::Config>(config_json) {
+                        Ok(editor_config) => {
+                            app_config.editor = editor_config;
+                            if let Err(err) = self.terminal.reconfigure((&app_config.editor).into()) {
+                                self.editor.set_error(err.to_string());
+                            };
+                            self.config.store(Arc::new(app_config));
+                        }
+                        Err(err) => {
+                            self.editor.set_error(format!("Failed to deserialize editor config after updating {}: {}", key, err));
+                            return;
+                        }
+                    }
+                } else {
+                    self.editor.set_error(format!("Unknown config field: {}", key));
+                    return;
+                }
+            }
             ConfigEvent::ThemeChanged => {
                 let _ = self.terminal.backend_mut().set_background_color(
                     self.editor

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2275,7 +2275,7 @@ fn get_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
 }
 
 /// Change config at runtime. Access nested values by dot syntax, for
-/// example to disable smart case search, use `:set search.smart-case false`.
+/// example to disable smart case search, use `:set-option search.smart-case false`.
 fn set_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
@@ -2283,30 +2283,30 @@ fn set_option(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> a
 
     let (key, arg) = (&args[0].to_lowercase(), args[1].trim());
 
-    let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
-    let field_error = |_| anyhow::anyhow!("Could not parse field `{}`", arg);
-
-    let mut config = serde_json::json!(&cx.editor.config().deref());
+    // Validate that the key exists and determine its type
+    let config_json = serde_json::json!(&cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
-    let value = config.pointer_mut(&pointer).ok_or_else(key_error)?;
+    let existing_value = config_json
+        .pointer(&pointer)
+        .ok_or_else(|| anyhow::anyhow!("Unknown key `{}`", key))?;
 
-    *value = if value.is_string() {
-        // JSON strings require quotes, so we can't .parse() directly
+    // Construct the value to set
+    let field_error = |_| anyhow::anyhow!("Could not parse field `{}`", arg);
+    let value: Value = if existing_value.is_string() {
         Value::String(arg.to_string())
     } else {
         arg.parse().map_err(field_error)?
     };
-    let config = serde_json::from_value(config).map_err(field_error)?;
 
     cx.editor
         .config_events
         .0
-        .send(ConfigEvent::Update(config))?;
+        .send(ConfigEvent::UpdateField(key.clone(), value))?;
     Ok(())
 }
 
 /// Toggle boolean config option at runtime. Access nested values by dot
-/// syntax, for example to toggle smart case search, use `:toggle search.smart-
+/// syntax, for example to toggle smart case search, use `:toggle-option search.smart-
 /// case`.
 fn toggle_option(
     cx: &mut compositor::Context,
@@ -2321,11 +2321,12 @@ fn toggle_option(
 
     let key_error = || anyhow::anyhow!("Unknown key `{}`", key);
 
-    let mut config = serde_json::json!(&cx.editor.config().deref());
+    // Read the current config to get the existing value
+    let config_json = serde_json::json!(&cx.editor.config().deref());
     let pointer = format!("/{}", key.replace('.', "/"));
-    let value = config.pointer_mut(&pointer).ok_or_else(key_error)?;
+    let existing_value = config_json.pointer(&pointer).ok_or_else(key_error)?;
 
-    *value = match value {
+    let new_value = match existing_value {
         Value::Bool(ref value) => {
             ensure!(
                 args.len() == 1,
@@ -2359,7 +2360,7 @@ fn toggle_option(
             ensure!(
                 args.len() == 2,
                 "Bad arguments. For {kind} configurations use: `:toggle {key} val1 val2 ...`",
-                kind = match value {
+                kind = match existing_value {
                     Value::Number(_) => "number",
                     Value::Array(_) => "array",
                     Value::Object(_) => "object",
@@ -2375,28 +2376,26 @@ fn toggle_option(
 
             if let Some(wrongly_typed_value) = values
                 .iter()
-                .find(|v| std::mem::discriminant(*v) != std::mem::discriminant(&*value))
+                .find(|v| std::mem::discriminant(*v) != std::mem::discriminant(existing_value))
             {
-                bail!("value '{wrongly_typed_value}' has a different type than '{value}'");
+                bail!("value '{wrongly_typed_value}' has a different type than '{existing_value}'");
             }
 
             values
                 .iter()
-                .skip_while(|e| *e != value)
+                .skip_while(|e| *e != existing_value)
                 .nth(1)
                 .unwrap_or(&values[0])
                 .clone()
         }
     };
 
-    let status = format!("'{key}' is now set to {value}");
-    let config = serde_json::from_value(config)
-        .map_err(|err| anyhow::anyhow!("Failed to parse config: {err}"))?;
+    let status = format!("'{key}' is now set to {new_value}");
 
     cx.editor
         .config_events
         .0
-        .send(ConfigEvent::Update(config))?;
+        .send(ConfigEvent::UpdateField(key.clone(), new_value))?;
     cx.editor.set_status(status);
     Ok(())
 }

--- a/helix-term/tests/integration.rs
+++ b/helix-term/tests/integration.rs
@@ -18,6 +18,7 @@ mod test {
     mod auto_pairs;
     mod command_line;
     mod commands;
+    mod config;
     mod movement;
     mod splits;
 }

--- a/helix-term/tests/test/config.rs
+++ b/helix-term/tests/test/config.rs
@@ -1,0 +1,114 @@
+use super::helpers::*;
+use helix_term::config::ConfigRaw;
+
+fn build_app(config_toml: toml::Table) -> anyhow::Result<helix_term::application::Application> {
+    let config_raw: ConfigRaw = config_toml.try_into()?;
+
+    let config = helix_term::config::Config {
+        theme: config_raw.theme,
+        keys: config_raw.keys.unwrap(),
+        editor: config_raw.editor.unwrap().try_into()?,
+    };
+
+    let app = AppBuilder::new().with_config(config).build()?;
+
+    Ok(app)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_config_single() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = ":set trim-trailing-whitespace true"
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(!config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_set_config_multi() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = [
+            ":set trim-final-newlines true",
+            ":set trim-trailing-whitespace true",
+        ]
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_toggle_config_single() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = ":toggle trim-trailing-whitespace"
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(!config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_toggle_config_multi() -> anyhow::Result<()> {
+    let mut app = build_app(toml::toml! {
+        editor.trim-final-newlines = false
+        editor.trim-trailing-whitespace = false
+        keys.normal.space.t = [
+            ":toggle trim-final-newlines",
+            ":toggle trim-trailing-whitespace",
+        ]
+    })?;
+
+    test_key_sequence(
+        &mut app,
+        Some("<space>t"),
+        Some(&|app| {
+            let config = app.editor.config.load();
+            assert!(config.trim_final_newlines);
+            assert!(config.trim_trailing_whitespace);
+        }),
+        false,
+    )
+    .await?;
+
+    Ok(())
+}

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1361,6 +1361,7 @@ pub enum EditorEvent {
 pub enum ConfigEvent {
     Refresh,
     Update(Box<Config>),
+    UpdateField(String, serde_json::Value),
     ThemeChanged,
 }
 


### PR DESCRIPTION
Problem: When using a keybinding with multiple `:set-option` commands in a sequence, only the last option takes effect. For example:

```toml
[keys.normal]
space.x = [":set-option end-of-line-diagnostics error", ":set-option inline-diagnostics.cursor-line error"]
```

Only `inline-diagnostics.cursor-line` would be set, while `end-of-line-diagnostics` would retain its previous value.

The issue occurred because all commands in a sequence would read the same initial config state (before any updates were applied), create full config replacements, and send them. The last event would overwrite all previous changes.

## Solution

Adds `ConfigEvent::UpdateField` variant for incremental config field updates. Commands now send individual field updates (key path + value) which the application applies sequentially, allowing them to compose correctly.

## Related

- Fixes #13187
- Similar to closed PR #14629
