### PR TITLE
lang: add `--vanilla` to R LSP arguments to ignore RProfile

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -120,7 +120,7 @@ pylyzer = { command = "pylyzer", args = ["--server"] }
 pytest-language-server = { command = "pytest-language-server" }
 qmlls = { command = "qmlls" }
 quint-language-server = { command = "quint-language-server", args = ["--stdio"] }
-r = { command = "R", args = ["--no-echo", "-e", "languageserver::run()"] }
+r = { command = "R", args = ["--vanilla", "--no-echo", "-e", "languageserver::run()"] }
 racket = { command = "racket", args = ["-l", "racket-langserver"] }
 regols = { command = "regols" }
 rescript-language-server = { command = "rescript-language-server", args = ["--stdio"] }


### PR DESCRIPTION
Starting `languageserver::run()` with `R --vanilla` avoids loading the user/site profile, saved workspace, and environment restore hooks. This keeps the language server startup path small and predictable, which is especially useful when `.Rprofile` is large, slow, project-specific, or performs complex side effects.

This reduces editor/LSP overhead and avoids unrelated user startup logic from affecting diagnostics, completion, and background indexing, or even crashing the LSP when there is a bug within the user's RProfile.