### PR TITLE
languages: add Clean programming language support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5006,6 +5006,19 @@ name = "clarity"
 source = { git = "https://github.com/xlittlerag/tree-sitter-clarity", rev = "1436da3946359fcd7ac2d81917aaa78ef1e01755" }
 
 [[language]]
+name = "clean"
+scope = "source.clean"
+injection-regex = "clean"
+file-types = ["icl", "dcl"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "clean"
+source = { git = "https://github.com/ishaq2321/tree-sitter-clean", rev = "260af40" }
+
+[[language]]
 name = "alloy"
 scope = "source.alloy"
 injection-regex = "alloy"

--- a/runtime/queries/clean/highlights.scm
+++ b/runtime/queries/clean/highlights.scm
@@ -1,0 +1,84 @@
+; Keywords
+"module" @keyword
+"import" @keyword
+"from" @keyword.control.import
+"where" @keyword
+"with" @keyword
+"class" @keyword
+"instance" @keyword
+"let" @keyword
+"in" @keyword
+"case" @keyword.control.conditional
+"of" @keyword
+"if" @keyword.control.conditional
+"then" @keyword.control.conditional
+"else" @keyword.control.conditional
+"implementation" @keyword
+"definition" @keyword
+"system" @keyword
+"infix" @keyword
+"infixl" @keyword
+"infixr" @keyword
+"generic" @keyword
+"derive" @keyword
+
+; Module names
+(module_identifier) @namespace
+(module_name (module_identifier) @namespace)
+
+; Types
+(type_signature name: (signature_name (identifier) @type))
+(type_definition name: (constructor) @type)
+(class_declaration name: (class_name (constructor) @type))
+(class_name (constructor) @type)
+(constructor) @type
+
+; Functions
+(function_declaration name: (identifier) @function)
+(macro_definition name: (identifier) @function.macro)
+
+; Variables and parameters
+(identifier) @variable
+(wildcard) @variable.builtin
+
+; Literals
+(string) @string
+(char) @string.special
+(number) @constant.numeric
+(integer) @constant.numeric
+(float) @constant.float
+(boolean) @constant.builtin.boolean
+
+; Comments
+(line_comment) @comment.line
+(block_comment) @comment.block
+
+; Operators
+(arrow) @operator
+(comprehension_sep) @operator
+(operator) @operator
+(operator_add) @operator
+(operator_mul) @operator
+(operator_compare) @operator
+(operator_cons) @operator
+(operator_and) @operator
+(operator_or) @operator
+(operator_exp) @operator
+(range_operator) @operator
+
+; Patterns
+(lazy_pattern "~" @operator)
+(strict_pattern "!" @operator)
+
+; Punctuation
+"=" @operator
+"," @punctuation.delimiter
+"." @punctuation.delimiter
+"|" @punctuation.delimiter
+"::" @punctuation.delimiter
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+"{" @punctuation.bracket
+"}" @punctuation.bracket

--- a/runtime/queries/clean/injections.scm
+++ b/runtime/queries/clean/injections.scm
@@ -1,0 +1,2 @@
+; Inject ABC code blocks as a separate language if available
+(code_expression (abc_instruction) @content)

--- a/runtime/queries/clean/textobjects.scm
+++ b/runtime/queries/clean/textobjects.scm
@@ -1,0 +1,17 @@
+; Function definitions
+(function_declaration
+  name: (identifier) @function.around) @function.around
+
+; Class definitions
+(class_declaration
+  name: (class_name) @class.around) @class.around
+
+; Instance definitions
+(instance_declaration
+  name: (instance_class) @class.around) @class.around
+
+; Comments
+(line_comment) @comment.inside
+(block_comment) @comment.inside
+(line_comment)+ @comment.around
+(block_comment) @comment.around


### PR DESCRIPTION
## Description

Add tree-sitter grammar support for the [Clean](https://clean-lang.org/) programming language — a general-purpose, purely functional language with uniqueness typing.

### Changes
- Add `[[language]]` block for Clean (scope: `source.clean`, file-types: `.icl`, `.dcl`)
- Add `[[grammar]]` block pointing to [tree-sitter-clean](https://github.com/ishaq2321/tree-sitter-clean) (v1.0.0, published on npm)

### Grammar
- **Repository**: https://github.com/ishaq2321/tree-sitter-clean
- **npm**: https://www.npmjs.com/package/tree-sitter-clean
- **Tests**: 32/32 corpus tests passing, zero parser warnings
- **Features**: types, functions, lambdas, case guards, lazy patterns, where/with blocks, record expressions, list comprehensions

### Checklist
- [x] Grammar is well-maintained and tested
- [x] Published on npm as `tree-sitter-clean`
- [x] Follows the existing languages.toml format