### PR TITLE
feat(lsp): execute `CompletionItem.command` when accepting a completion

### DIFF
--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -214,7 +214,7 @@ impl Completion {
                     doc.append_changes_to_history(view);
 
                     // item always present here
-                    let (transaction, additional_edits, snippet) = match item.clone() {
+                    let (transaction, additional_edits, snippet, command) = match item.clone() {
                         CompletionItem::Lsp(mut item) => {
                             let language_server = language_server!(item);
 
@@ -237,16 +237,18 @@ impl Completion {
                                 trigger_offset,
                                 replace_mode,
                             );
-                            let add_edits = item.item.additional_text_edits;
+                            let add_edits = item.item.additional_text_edits.take();
+                            let command = completion_command(&CompletionItem::Lsp(item));
 
                             (
                                 transaction,
                                 add_edits.map(|edits| (edits, encoding)),
                                 snippet,
+                                command,
                             )
                         }
                         CompletionItem::Other(core::CompletionItem { transaction, .. }) => {
-                            (transaction, None, None)
+                            (transaction, None, None, None)
                         }
                     };
 
@@ -276,6 +278,12 @@ impl Completion {
                             doc.apply(&transaction, view.id);
                         }
                     }
+
+                    // The LSP spec requires the command to be executed after the text edits have been applied.
+                    if let Some((command, server_id)) = command {
+                        editor.execute_lsp_command(command, server_id);
+                    }
+
                     // we could have just inserted a trigger char (like a `crate::` completion for rust
                     // so we want to retrigger immediately when accepting a completion.
                     trigger_auto_completion(editor, true);

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -656,9 +656,76 @@ fn lsp_item_to_transaction(
     }
 }
 
+/// Returns the `command` to execute after accepting a completion item, together with
+/// the language server that should execute it, if the item carries one.
+fn completion_command(
+    item: &CompletionItem,
+) -> Option<(lsp::Command, helix_lsp::LanguageServerId)> {
+    match item {
+        CompletionItem::Lsp(item) => item
+            .item
+            .command
+            .clone()
+            .map(|command| (command, item.provider)),
+        CompletionItem::Other(_) => None,
+    }
+}
+
 fn completion_changes(transaction: &Transaction, trigger_offset: usize) -> Vec<Change> {
     transaction
         .changes_iter()
         .filter(|(start, end, _)| (*start..=*end).contains(&trigger_offset))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use helix_lsp::LanguageServerId;
+
+    fn lsp_item(command: Option<lsp::Command>) -> CompletionItem {
+        CompletionItem::Lsp(LspCompletionItem {
+            item: lsp::CompletionItem {
+                label: "foo".to_string(),
+                command,
+                ..Default::default()
+            },
+            provider: LanguageServerId::default(),
+            resolved: true,
+            provider_priority: 0,
+        })
+    }
+
+    #[test]
+    fn returns_command_and_provider_when_present() {
+        let command = lsp::Command {
+            title: "Do something".to_string(),
+            command: "my-lsp.someAction".to_string(),
+            arguments: Some(vec![serde_json::json!(42)]),
+        };
+        let item = lsp_item(Some(command.clone()));
+
+        assert_eq!(
+            completion_command(&item),
+            Some((command, LanguageServerId::default()))
+        );
+    }
+
+    #[test]
+    fn returns_none_when_command_absent() {
+        let item = lsp_item(None);
+        assert_eq!(completion_command(&item), None);
+    }
+
+    #[test]
+    fn returns_none_for_non_lsp_item() {
+        let item = CompletionItem::Other(core::CompletionItem {
+            transaction: Transaction::new(&helix_core::Rope::new()),
+            label: "foo".into(),
+            kind: "word".into(),
+            documentation: None,
+            provider: helix_core::completion::CompletionProvider::Word,
+        });
+        assert_eq!(completion_command(&item), None);
+    }
 }


### PR DESCRIPTION
The LSP spec defines an optional `command` on a [completion item](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem) that should run after the completion is inserted. Currently Helix doesn't run the command.

The completion accept flow now runs the command after applying the edits, as the spec defines. The command runs against the language server that provided the completion, and is skipped when the server does not advertise command execution support.

Closes #15585