### PR TITLE
Config option to hide diagnostics in insert mode

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -194,9 +194,12 @@ impl EditorView {
         }
         let width = view.inner_width(doc);
         let config = doc.config.load();
-        let enable_cursor_line = view
-            .diagnostics_handler
-            .show_cursorline_diagnostics(doc, view.id);
+        let enable_cursor_line = match (editor.mode, config.hide_diag_when_inserting) {
+            (Mode::Insert, true) => false,
+            (_, _) => view
+                .diagnostics_handler
+                .show_cursorline_diagnostics(doc, view.id),
+        };
         let inline_diagnostic_config = config.inline_diagnostics.prepare(width, enable_cursor_line);
         decorations.add_decoration(InlineDiagnostics::new(
             doc,
@@ -204,6 +207,7 @@ impl EditorView {
             primary_cursor,
             inline_diagnostic_config,
             config.end_of_line_diagnostics,
+            editor.mode,
         ));
         render_document(
             surface,
@@ -231,6 +235,8 @@ impl EditorView {
 
         if config.inline_diagnostics.disabled()
             && config.end_of_line_diagnostics == DiagnosticFilter::Disable
+            && !config.hide_diag_when_inserting
+            && editor.mode != Mode::Insert
         {
             Self::render_diagnostics(doc, view, inner, surface, theme);
         }
@@ -715,7 +721,7 @@ impl EditorView {
     pub fn render_gutter<'d>(
         editor: &'d Editor,
         doc: &'d Document,
-        view: &View,
+        view: &'d View,
         viewport: Rect,
         theme: &Theme,
         is_focused: bool,

--- a/helix-term/src/ui/text_decorations/diagnostics.rs
+++ b/helix-term/src/ui/text_decorations/diagnostics.rs
@@ -5,10 +5,11 @@ use helix_core::doc_formatter::{DocumentFormatter, FormattedGrapheme};
 use helix_core::graphemes::Grapheme;
 use helix_core::text_annotations::TextAnnotations;
 use helix_core::{Diagnostic, Position};
+
 use helix_view::annotations::diagnostics::{
     DiagnosticFilter, InlineDiagnosticAccumulator, InlineDiagnosticsConfig,
 };
-
+use helix_view::document::Mode;
 use helix_view::theme::Style;
 use helix_view::{Document, Theme};
 
@@ -56,7 +57,14 @@ impl<'a> InlineDiagnostics<'a> {
         cursor: usize,
         config: InlineDiagnosticsConfig,
         eol_diagnostics: DiagnosticFilter,
+        editor_mode: Mode,
     ) -> Self {
+        // Shadow the variable here to hide if user doesn't want to show the eol diagnostics.
+        // Value gets moved after this into the inline::new function, so we have to shadow here without a clone.
+        let eol_diagnostics = match (&config.hide_diag_when_inserting, editor_mode) {
+            (true, Mode::Insert) => DiagnosticFilter::Disable,
+            (_, _) => eol_diagnostics,
+        };
         InlineDiagnostics {
             state: InlineDiagnosticAccumulator::new(cursor, doc, config),
             styles: Styles::new(theme),

--- a/helix-view/src/annotations/diagnostics.rs
+++ b/helix-view/src/annotations/diagnostics.rs
@@ -53,6 +53,7 @@ impl Serialize for DiagnosticFilter {
 pub struct InlineDiagnosticsConfig {
     pub cursor_line: DiagnosticFilter,
     pub other_lines: DiagnosticFilter,
+    pub hide_diag_when_inserting: bool,
     pub min_diagnostic_width: u16,
     pub prefix_len: u16,
     pub max_wrap: u16,
@@ -115,6 +116,7 @@ impl Default for InlineDiagnosticsConfig {
             prefix_len: 1,
             max_wrap: 20,
             max_diagnostics: 10,
+            hide_diag_when_inserting: false,
         }
     }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -93,6 +93,8 @@ pub struct GutterConfig {
     pub layout: Vec<GutterType>,
     /// Options specific to the "line-numbers" gutter
     pub line_numbers: GutterLineNumbersConfig,
+    /// Hides the diagnostics dots when in insert mode
+    pub hide_diag_when_inserting: GutterDiagnosticsConfig,
 }
 
 impl Default for GutterConfig {
@@ -106,6 +108,7 @@ impl Default for GutterConfig {
                 GutterType::Diff,
             ],
             line_numbers: GutterLineNumbersConfig::default(),
+            hide_diag_when_inserting: GutterDiagnosticsConfig::default(),
         }
     }
 }
@@ -174,6 +177,13 @@ impl Default for GutterLineNumbersConfig {
     fn default() -> Self {
         Self { min_width: 3 }
     }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct GutterDiagnosticsConfig {
+    /// Hide the diagnostics gutter dots when set to true and in edit mode
+    pub hide_diagnostics_in_insert_mode: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -422,8 +432,10 @@ pub struct Config {
     /// Display diagnostic below the line they occur.
     pub inline_diagnostics: InlineDiagnosticsConfig,
     pub end_of_line_diagnostics: DiagnosticFilter,
-    // Set to override the default clipboard provider
+    /// Set to override the default clipboard provider
     pub clipboard_provider: ClipboardProvider,
+    /// Set to hide diagnostics when in editing mode
+    pub hide_diag_when_inserting: bool,
     /// Whether to read settings from [EditorConfig](https://editorconfig.org) files. Defaults to
     /// `true`.
     pub editor_config: bool,
@@ -1152,6 +1164,7 @@ impl Default for Config {
             inline_diagnostics: InlineDiagnosticsConfig::default(),
             end_of_line_diagnostics: DiagnosticFilter::Enable(Severity::Hint),
             clipboard_provider: ClipboardProvider::default(),
+            hide_diag_when_inserting: false,
             editor_config: true,
             rainbow_brackets: false,
             kitty_keyboard_protocol: Default::default(),

--- a/helix-view/src/gutter.rs
+++ b/helix-view/src/gutter.rs
@@ -3,6 +3,7 @@ use std::fmt::Write;
 use helix_core::syntax::config::LanguageServerFeature;
 
 use crate::{
+    document::Mode,
     editor::GutterType,
     graphics::{Style, UnderlineStyle},
     Document, Editor, Theme, View,
@@ -21,7 +22,7 @@ impl GutterType {
         self,
         editor: &'doc Editor,
         doc: &'doc Document,
-        view: &View,
+        view: &'doc View,
         theme: &Theme,
         is_focused: bool,
     ) -> GutterFn<'doc> {
@@ -46,9 +47,9 @@ impl GutterType {
 }
 
 pub fn diagnostic<'doc>(
-    _editor: &'doc Editor,
+    editor: &'doc Editor,
     doc: &'doc Document,
-    _view: &View,
+    view: &'doc View,
     theme: &Theme,
     _is_focused: bool,
 ) -> GutterFn<'doc> {
@@ -60,7 +61,13 @@ pub fn diagnostic<'doc>(
 
     Box::new(
         move |line: usize, _selected: bool, first_visual_line: bool, out: &mut String| {
-            if !first_visual_line {
+            if !first_visual_line
+                || (view
+                    .gutters
+                    .hide_diag_when_inserting
+                    .hide_diagnostics_in_insert_mode
+                    && editor.mode == Mode::Insert)
+            {
                 return None;
             }
             use helix_core::diagnostic::Severity;
@@ -171,7 +178,7 @@ pub fn line_numbers<'doc>(
                 write!(out, "{:>1$}", '~', width).unwrap();
                 Some(linenr)
             } else {
-                use crate::{document::Mode, editor::LineNumber};
+                use crate::editor::LineNumber;
 
                 let relative = line_number == LineNumber::Relative
                     && mode != Mode::Insert
@@ -310,7 +317,7 @@ fn execution_pause_indicator<'doc>(
 pub fn diagnostics_or_breakpoints<'doc>(
     editor: &'doc Editor,
     doc: &'doc Document,
-    view: &View,
+    view: &'doc View,
     theme: &Theme,
     is_focused: bool,
 ) -> GutterFn<'doc> {
@@ -331,7 +338,7 @@ mod tests {
 
     use super::*;
     use crate::document::Document;
-    use crate::editor::{Config, GutterConfig, GutterLineNumbersConfig};
+    use crate::editor::{Config, GutterConfig, GutterDiagnosticsConfig, GutterLineNumbersConfig};
     use crate::graphics::Rect;
     use crate::DocumentId;
     use arc_swap::ArcSwap;
@@ -382,6 +389,9 @@ mod tests {
         let gutters = GutterConfig {
             layout: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             line_numbers: GutterLineNumbersConfig { min_width: 10 },
+            hide_diag_when_inserting: GutterDiagnosticsConfig {
+                hide_diagnostics_in_insert_mode: false,
+            },
         };
 
         let mut view = View::new(DocumentId::default(), gutters);
@@ -405,6 +415,9 @@ mod tests {
         let gutters = GutterConfig {
             layout: vec![GutterType::Diagnostics, GutterType::LineNumbers],
             line_numbers: GutterLineNumbersConfig { min_width: 1 },
+            hide_diag_when_inserting: GutterDiagnosticsConfig {
+                hide_diagnostics_in_insert_mode: false,
+            },
         };
 
         let mut view = View::new(DocumentId::default(), gutters);

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -725,7 +725,9 @@ mod tests {
     const DEFAULT_GUTTER_OFFSET_ONLY_DIAGNOSTICS: u16 = 3;
 
     use crate::document::Document;
-    use crate::editor::{Config, GutterConfig, GutterLineNumbersConfig, GutterType};
+    use crate::editor::{
+        Config, GutterConfig, GutterDiagnosticsConfig, GutterLineNumbersConfig, GutterType,
+    };
 
     #[test]
     fn test_text_pos_at_screen_coords() {
@@ -904,6 +906,9 @@ mod tests {
             GutterConfig {
                 layout: vec![GutterType::Diagnostics],
                 line_numbers: GutterLineNumbersConfig::default(),
+                hide_diag_when_inserting: GutterDiagnosticsConfig {
+                    hide_diagnostics_in_insert_mode: false,
+                },
             },
         );
         view.area = Rect::new(40, 40, 40, 40);
@@ -935,6 +940,9 @@ mod tests {
             GutterConfig {
                 layout: vec![],
                 line_numbers: GutterLineNumbersConfig::default(),
+                hide_diag_when_inserting: GutterDiagnosticsConfig {
+                    hide_diagnostics_in_insert_mode: false,
+                },
             },
         );
         view.area = Rect::new(40, 40, 40, 40);


### PR DESCRIPTION
# Note
I am reopening this PR as a new one after I deleted my old repos. There is a comment requesting to reopen this, so I do so: https://github.com/helix-editor/helix/pull/12364#issuecomment-3176044098

Please let me know if there will still be any interest in this. Thanks. 

Added an ability to hide diagnostics when in insert mode using the following config options:
```
[editor.inline_diagnostics]
hide-diag-when-insert-mode = true

[editor.gutters]
hide-diag-when-inserting.hide-diagnostics-in-insert-mode = true
```

Modes other than edit:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/319c18ad-b5aa-45ba-a66d-075ac0f23326" />

Same state but in edit mode with config enabled:
<img width="521" alt="image" src="https://github.com/user-attachments/assets/ec976c6f-b698-4549-bfdf-57f9f49c1448" />

