### PR TITLE
fix css tree-sitter highlighting

### DIFF
--- a/runtime/queries/css/highlights.scm
+++ b/runtime/queries/css/highlights.scm
@@ -54,12 +54,10 @@
   "@keyframes"
   "@media"
   "@namespace"
-  "@scope"
   "@supports"
   (at_keyword)
   (from)
   (important)
-  (important_value)
   (to)
   (keyword_query)
   (keyframes_name)


### PR DESCRIPTION
- Closes #15877

- Restores tree-sitter highlighting for css files.

- Removes 2 lines from `runtime/queries/css/highlights.scm`

1. L57: "@scope": the css @scope at rule now appears as an at_keyword token to tree-sitter

2. L61: "(important_value)": not sure what token this represents

