### PR TITLE
feat(highlights/rust) optional public/private function differentiation

### DIFF
--- a/runtime/queries/rust/highlights.scm
+++ b/runtime/queries/rust/highlights.scm
@@ -357,9 +357,15 @@
 
 (function_item
   name: (identifier) @function)
-
 (function_signature_item
   name: (identifier) @function)
+
+(function_item
+  (visibility_modifier) 
+  name: (identifier) @function.public)
+(function_signature_item
+  (visibility_modifier) 
+  name: (identifier) @function.public)
 
 ; -------
 ; Guess Other Types


### PR DESCRIPTION
Follow-up to #5589. 

Add an (optional) differentiation between private and public Rust functions. 

<img width="351" height="177" alt="sample_highlights" src="https://github.com/user-attachments/assets/7a9b0737-1293-41b5-a958-88591c10cd3e" />

