### PR TITLE
fix(just): Fix injection language detection from `set shell`

### DIFF
--- a/runtime/queries/just/injections.scm
+++ b/runtime/queries/just/injections.scm
@@ -45,7 +45,7 @@
 ; See https://github.com/tree-sitter/tree-sitter/issues/880 for more on that.
 
 (file
-  (setting "shell" ":=" "[" (string) @_langstr
+  (setting "shell" ":=" "[" . (string) @_langstr
     (#match? @_langstr ".*(powershell|pwsh|cmd).*")
     (#set! injection.language "powershell"))
   [
@@ -63,7 +63,7 @@
   ])
 
 (file
-  (setting "shell" ":=" "[" (string) @injection.language
+  (setting "shell" ":=" "[" . (string) @injection.language
     (#not-match? @injection.language ".*(powershell|pwsh|cmd).*"))
   [
     (recipe


### PR DESCRIPTION
Currently the query injects the rightmost detected language in the entire array of `set shell := [...]`, usually that's C (due to `-c` or `--command` or similar).

This adds an anchor before the first string node, so only it gets captured in `@injection.language`.

After/before, after running `:tree-sitter-layers`:
<img width="1873" height="303" alt="image" src="https://github.com/user-attachments/assets/a47821db-8cf9-423e-a116-9c8894d72d77" />
<img width="1856" height="298" alt="image" src="https://github.com/user-attachments/assets/e4b3fe2d-f3fb-436f-91f3-4452fada6ee1" />
