### PR TITLE
queries/cpp: fix unescaped c++26 reflection operator

### DIFF
--- a/runtime/queries/cpp/highlights.scm
+++ b/runtime/queries/cpp/highlights.scm
@@ -115,7 +115,7 @@
   "<=>"
   "[]"
   "()"
-  "^^" ; C++26 reflection operator (reflect_expression)
+  "\^\^" ; C++26 reflection operator (reflect_expression)
 ] @operator
 
 ; C++26 splice brackets `[: reflection :]` (splice_specifier / splice_type_specifier).


### PR DESCRIPTION
This makes C++ highlighting work again, which are currently failing to compile:
```
2026-06-15T05:16:29.543 helix_core::syntax [ERROR] Failed to compile highlights for 'cpp': invalid node type ""
--> 327:4
   |
326 |   "()"
327 |   "^^" ; C++26 reflection operator (reflect_expression)
   |    ^
328 | ] @operator
   |
```
