### PR TITLE
languages.toml: Add microcad config, lsp, and grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -189,6 +189,7 @@
 | mermaid | ✓ |  |  |  |  |  |
 | meson | ✓ |  | ✓ |  |  | `mesonlsp` |
 | metamath | ✓ |  |  | ✓ |  | `mm-lsp-server` |
+| microcad | ✓ |  |  | ✓ |  | `microcad-lsp` |
 | mint |  |  |  |  |  | `mint` |
 | miseconfig | ✓ | ✓ | ✓ |  |  | `taplo`, `tombi` |
 | mojo | ✓ | ✓ | ✓ |  |  | `pixi` |

--- a/languages.toml
+++ b/languages.toml
@@ -89,6 +89,7 @@ markdown-oxide = { command = "markdown-oxide" }
 marksman = { command = "marksman", args = ["server"] }
 metals = { command = "metals", config = { "isHttpEnabled" = true, metals = { inlayHints = { typeParameters = {enable = true} , hintsInPatternMatch = {enable = true} }  } } }
 mesonlsp = { command = "mesonlsp", args = ["--lsp"] }
+microcad-lsp = { command = "microcad-lsp", args = [ "--stdio" ] }
 mint = { command = "mint", args = ["tool", "ls"] }
 mojo-lsp-server = { command = "pixi", args = ["run", "mojo-lsp-server"] }
 mm0-rs = { command = "mm0-rs", args = [ "server" ] }
@@ -5447,6 +5448,25 @@ indent = { tab-width = 4, unit = "    " }
 language-servers = ["tilt"]
 formatter = {command = "buildifier"} # Official formatter tool for starlark/bazel
 auto-format = true
+
+[[language]]
+name = "microcad"
+scope = "source.µcad"
+injection-regex = "microcad"
+file-types = ["µcad", "mcad", "ucad"]
+comment-tokens = [ "//", "///", "//!" ]
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+language-servers = [ "microcad-lsp" ]
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+'"' = '"'
+
+[[grammar]]
+name = "microcad"
+source = { git = "https://codeberg.org/microcad/tree-sitter-microcad", rev = "339420b9cfbb9d6e96ed1f881c1632af4c3fcd22" }
 
 [[language]]
 name = "gnuplot"

--- a/runtime/queries/microcad/highlights.scm
+++ b/runtime/queries/microcad/highlights.scm
@@ -1,0 +1,102 @@
+; Variables
+;----------
+
+(identifier) @variable
+(type) @type
+
+; Function and method definitions
+;--------------------------------
+
+(function_definition
+  name: (identifier) @function)
+(parameter (identifier) @variable.parameter)
+
+; Function and method calls
+;--------------------------
+
+(call
+  method: (qualified_name) @function)
+(method_call
+  method: (qualified_name) @function.method)
+
+; Literals
+;---------
+
+[
+  "true"
+  "false"
+] @constant.builtin
+
+(comment) @comment
+(doc_comment) @comment
+(inner_doc_comment) @comment
+
+(string) @string
+
+(number_literal) @number
+
+; Tokens
+;-------
+
+[
+  ";"
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "-"
+  "+"
+  "*"
+  "/"
+  "<"
+  "<="
+  "="
+  "=="
+  "!"
+  "!="
+  ">"
+  ">="
+  "^"
+  "&"
+  "|"
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+(format_expression
+  "{" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  "mod"
+  "part"
+  "sketch"
+  "op"
+  "fn"
+  "if"
+  "else"
+  "use"
+  "as"
+  "return"
+  "const"
+  "prop"
+  "init"
+  "__plugin"
+  "assembly"
+  "material"
+  "unit"
+  "enum"
+  "struct"
+  "match"
+  "type"
+] @keyword
+(visibility) @keyword
+

--- a/runtime/queries/microcad/tags.scm
+++ b/runtime/queries/microcad/tags.scm
@@ -1,0 +1,32 @@
+; function definitions
+(
+  (function_definition
+    doc: (doc_comment)* @doc
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^///\\s*")
+)
+
+; module definitions
+(
+  (module_definition
+    doc: (doc_comment)* @doc
+    name: (identifier) @name) @definition.module
+  (#strip! @doc "^///\\s*")
+)
+
+; workbench definitions
+(
+  (workbench_definition
+    doc: (doc_comment)* @doc
+    name: (identifier) @name) @definition.function
+  (#strip! @doc "^///\\s*")
+)
+
+; references
+
+(call
+    method: (qualified_name) @name) @reference.call
+
+(method_call
+    method: (qualified_name) @name) @reference.call
+


### PR DESCRIPTION
Add microcad language facilities. 

The microcad LSP doesn't work very well with Helix, though my guess is it doesn't work well with any editor that isn't VScode
https://codeberg.org/microcad/microcad/issues/342
Hopefully it gets better though. 

It sometimes sort of works. 