### PR TITLE
feat(languages): syntax highlighting for Metamath

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -186,6 +186,7 @@
 | matlab | ✓ | ✓ | ✓ |  |  |  |
 | mermaid | ✓ |  |  |  |  |  |
 | meson | ✓ |  | ✓ |  |  | `mesonlsp` |
+| metamath | ✓ |  |  | ✓ |  | `mm-lsp-server` |
 | mint |  |  |  |  |  | `mint` |
 | miseconfig | ✓ | ✓ | ✓ |  |  | `taplo`, `tombi` |
 | mojo | ✓ | ✓ | ✓ |  |  | `pixi` |

--- a/languages.toml
+++ b/languages.toml
@@ -90,6 +90,8 @@ metals = { command = "metals", config = { "isHttpEnabled" = true, metals = { inl
 mesonlsp = { command = "mesonlsp", args = ["--lsp"] }
 mint = { command = "mint", args = ["tool", "ls"] }
 mojo-lsp-server = { command = "pixi", args = ["run", "mojo-lsp-server"] }
+mm0-rs = { command = "mm0-rs", args = [ "server" ] }
+mm-lsp-server = { command = "mm-lsp-server" }
 neocmakelsp = { command = "neocmakelsp", args = ["stdio"] }
 nil = { command = "nil" }
 nimlangserver = { command = "nimlangserver" }
@@ -168,6 +170,7 @@ vuels = { command = "vue-language-server", args = ["--stdio"], config = { typesc
 wgsl-analyzer = { command = "wgsl-analyzer" }
 wikitext-lsp = { command = "wikitext-lsp", args = ["--stdio"]}
 yaml-language-server = { command = "yaml-language-server", args = ["--stdio"] }
+yamma-server = { command = "yamma-server" }
 yls = { command = "yls", args = ["-vv"] }
 zls = { command = "zls" }
 zuban = { command = "zuban", args = ["server"] }
@@ -5509,3 +5512,18 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "concerto"
 source = { git = "https://github.com/accordproject/concerto-tree-sitter", rev = "920ba23ea93af56b19dfc38fcddf80b3ddc62685" }
+
+[[language]]
+name = "metamath"
+scope = "source.metamath"
+file-types = [ "mm" ]
+injection-regex = "mm|metamath"
+roots = [ "set.mm" ]
+block-comment-tokens = { start = "$(", end = "$)" }
+indent = { tab-width = 2, unit = "  " }
+text-width = 80
+language-servers = [ "mm-lsp-server" ]
+
+[[grammar]]
+name = "metamath"
+source = { git = "https://github.com/POPeeeDev/tree-sitter-metamath", rev = "TODO" }

--- a/languages.toml
+++ b/languages.toml
@@ -5524,6 +5524,15 @@ indent = { tab-width = 2, unit = "  " }
 text-width = 80
 language-servers = [ "mm-lsp-server" ]
 
+[language.auto-pairs]
+"$" = "$"
+"(" = ")"
+"[" = "]"
+"{" = "}"
+"<" = ">"
+'"' = '"'
+"`" = "`"
+
 [[grammar]]
 name = "metamath"
 source = { git = "https://github.com/POPeeeDev/tree-sitter-metamath", rev = "TODO" }

--- a/languages.toml
+++ b/languages.toml
@@ -5535,4 +5535,4 @@ language-servers = [ "mm-lsp-server" ]
 
 [[grammar]]
 name = "metamath"
-source = { git = "https://github.com/POPeeeDev/tree-sitter-metamath", rev = "TODO" }
+source = { git = "https://git.sr.ht/~m4dh0rs3/tree-sitter-metamath", rev = "d6a57b0ddb4feba4a88f8cbb2f497b718e0c5c1d" }

--- a/runtime/queries/metamath/highlights.scm
+++ b/runtime/queries/metamath/highlights.scm
@@ -1,0 +1,45 @@
+; Keywords and delimiters
+[ "$c" "$v" "$d" "$f" "$e" "$a" "$p" "$=" ] @keyword
+[ "${" "$}" ] @punctuation.bracket
+[ "$[" "$]" ] @keyword.import
+"$." @punctuation.delimiter
+
+; Markup (update grammar.js to support)
+; "####" @markup.heading.1
+; "#*#*" @markup.heading.2
+; "=-=-" @markup.heading.3
+; "-.-." @markup.heading.4
+
+; Builtin typecodes
+[ "|-" "wff" "setvar" "class" ] @type.builtin
+
+; Labels
+(floatingstmt (label) @function)
+(essentialstmt (label) @function)
+(axiomstmt (label) @function.definition)
+(provablestmt (label) @function.definition)
+
+; Types
+(typecode) @type
+
+; Variables and constants in declarations
+(constantstmt (constant) @constant)
+(variablestmt (variable) @variable)
+
+; Math symbols
+(mathsymbol) @variable
+
+; Proofs
+(uncompressedproof (label) @function.call)
+(compressedproof (label) @function.call)
+(compressedproofblock) @string
+
+; Comments
+(comment) @comment.block
+
+; Parentheses in math expressions
+"(" @punctuation.bracket
+")" @punctuation.bracket
+
+; File includes
+(filename) @string.special.path

--- a/runtime/queries/metamath/highlights.scm
+++ b/runtime/queries/metamath/highlights.scm
@@ -14,25 +14,25 @@
 [ "|-" "wff" "setvar" "class" ] @type.builtin
 
 ; Labels
-(floatingstmt (label) @function)
-(essentialstmt (label) @function)
-(axiomstmt (label) @function.definition)
-(provablestmt (label) @function.definition)
+(floating_stmt (label) @function)
+(essential_stmt (label) @function)
+(axiom_stmt (label) @function.definition)
+(provable_stmt (label) @function.definition)
 
 ; Types
 (typecode) @type
 
 ; Variables and constants in declarations
-(constantstmt (constant) @constant)
-(variablestmt (variable) @variable)
+(constant_stmt (constant) @constant)
+(variable_stmt (variable) @variable)
 
 ; Math symbols
 (mathsymbol) @variable
 
 ; Proofs
-(uncompressedproof (label) @function.call)
-(compressedproof (label) @function.call)
-(compressedproofblock) @string
+(uncompressed_proof (label) @function.call)
+(compressed_proof (label) @function.call)
+(compressed_proof_block) @string
 
 ; Comments
 (comment) @comment.block

--- a/runtime/queries/metamath/locals.scm
+++ b/runtime/queries/metamath/locals.scm
@@ -1,0 +1,26 @@
+; Scopes
+(block) @local.scope
+(database) @local.scope
+
+; Definitions
+(floatingstmt
+  (label) @local.definition)
+
+(essentialstmt
+  (label) @local.definition)
+
+(axiomstmt
+  (label) @local.definition)
+
+(provablestmt
+  (label) @local.definition)
+
+(variablestmt
+  (variable) @local.definition)
+
+(constantstmt
+  (constant) @local.definition)
+
+; References in proofs
+(uncompressedproof
+  (label) @local.reference)

--- a/runtime/queries/metamath/locals.scm
+++ b/runtime/queries/metamath/locals.scm
@@ -3,24 +3,24 @@
 (database) @local.scope
 
 ; Definitions
-(floatingstmt
+(floating_stmt
   (label) @local.definition)
 
-(essentialstmt
+(essential_stmt
   (label) @local.definition)
 
-(axiomstmt
+(axiom_stmt
   (label) @local.definition)
 
-(provablestmt
+(provable_stmt
   (label) @local.definition)
 
-(variablestmt
+(variable_stmt
   (variable) @local.definition)
 
-(constantstmt
+(constant_stmt
   (constant) @local.definition)
 
 ; References in proofs
-(uncompressedproof
+(uncompressed_proof
   (label) @local.reference)

--- a/runtime/queries/metamath/tags.scm
+++ b/runtime/queries/metamath/tags.scm
@@ -1,0 +1,19 @@
+; Axioms
+(axiomstmt
+  (label) @name) @definition.function
+
+; Provable theorems
+(provablestmt
+  (label) @name) @definition.function
+
+; Floating hypotheses
+(floatingstmt
+  (label) @name) @definition.variable
+
+; Essential hypotheses
+(essentialstmt
+  (label) @name) @definition.variable
+
+; References in proofs
+(uncompressedproof
+  (label) @name) @reference.call

--- a/runtime/queries/metamath/tags.scm
+++ b/runtime/queries/metamath/tags.scm
@@ -1,19 +1,19 @@
 ; Axioms
-(axiomstmt
+(axiom_stmt
   (label) @name) @definition.function
 
 ; Provable theorems
-(provablestmt
+(provable_stmt
   (label) @name) @definition.function
 
 ; Floating hypotheses
-(floatingstmt
+(floating_stmt
   (label) @name) @definition.variable
 
 ; Essential hypotheses
-(essentialstmt
+(essential_stmt
   (label) @name) @definition.variable
 
 ; References in proofs
-(uncompressedproof
+(uncompressed_proof
   (label) @name) @reference.call


### PR DESCRIPTION
- [Metamath](https://us.metamath.org/)
- [Grammar](https://git.sr.ht/~m4dh0rs3/tree-sitter-metamath/tree/main/item/grammar.js) was tested on `set.mm`, the main Metamath database file and many others
- `cargo xtask query-check metamath`: Query check succeeded
- `hx --health metamath`: Tree-sitter parser: ✓, Highlight queries: ✓
- `cargo xtask docgen`: `| metamath | ✓ |  |  | ✓ |  | mm-lsp-server |`
- Added Metamath-related LSP servers

(I closed the duplicate #15682 as I changed the branch to merge from from `master` to `metamath`. Github wont let you change this within the same PR.)