### PR TITLE
Add new keybinds to navigate popups, pickers, and completions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ helix-term/rustfmt.toml
 result
 runtime/grammars
 .DS_Store
+.helix

--- a/helix-term/src/ui/menu.rs
+++ b/helix-term/src/ui/menu.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alt,
     compositor::{Callback, Component, Compositor, Context, Event, EventResult},
     ctrl, key, shift,
 };
@@ -268,12 +269,12 @@ impl<T: Item + 'static> Component for Menu<T> {
                 return EventResult::Consumed(close_fn);
             }
             // arrow up/ctrl-p/shift-tab prev completion choice (including updating the doc)
-            shift!(Tab) | key!(Up) | ctrl!('p') => {
+            shift!(Tab) | key!(Up) | ctrl!('p') | alt!('k') => {
                 self.move_up();
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);
                 return EventResult::Consumed(None);
             }
-            key!(Tab) | key!(Down) | ctrl!('n') => {
+            key!(Tab) | key!(Down) | ctrl!('n') | alt!('j') => {
                 // arrow down/ctrl-n/tab advances completion choice (including updating the doc)
                 self.move_down();
                 (self.callback_fn)(cx.editor, self.selection(), MenuEvent::Update);

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1087,10 +1087,10 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         };
 
         match key_event {
-            shift!(Tab) | key!(Up) | ctrl!('p') => {
+            shift!(Tab) | key!(Up) | ctrl!('p') | alt!('k') => {
                 self.move_by(1, Direction::Backward);
             }
-            key!(Tab) | key!(Down) | ctrl!('n') => {
+            key!(Tab) | key!(Down) | ctrl!('n') | alt!('j') => {
                 self.move_by(1, Direction::Forward);
             }
             key!(PageDown) | ctrl!('d') => {

--- a/helix-term/src/ui/popup.rs
+++ b/helix-term/src/ui/popup.rs
@@ -1,4 +1,5 @@
 use crate::{
+    alt,
     commands::Open,
     compositor::{Callback, Component, Context, Event, EventResult},
     ctrl, key,
@@ -290,11 +291,11 @@ impl<T: Component> Component for Popup<T> {
                         let _ = self.contents.handle_event(event, cx);
                         EventResult::Consumed(Some(close_fn))
                     }
-                    key!(PageDown) | ctrl!('d') => {
+                    key!(PageDown) | ctrl!('d') | alt!('j') => {
                         self.scroll_half_page_down();
                         EventResult::Consumed(None)
                     }
-                    key!(PageUp) | ctrl!('u') => {
+                    key!(PageUp) | ctrl!('u') | alt!('k') => {
                         self.scroll_half_page_up();
                         EventResult::Consumed(None)
                     }


### PR DESCRIPTION
### Description
added Alt-j and Alt-k to move inside hover popup, going to next and previous entry in the picker and completion.

### reason
it makes sense to have unified keybinds for navigation. in normal mode the cursor moves up and down with j and k respectively. when there is a popup on the screen the user should not think about what key to press.
in the hover popup to move you have to press ctrl-d and ctrl-u. and for the picker and completion it is tab, shift-tab, ctrl-n and ctrl-p. that is too much. _and holding ctrl with the pinky finger is not the most comfortable thing to do. alt is pressed with the thumb which is more easy._ so to move inside a popup the user just presses alt+ j or k. _it is more consistent._