### PR TITLE
workspace trust: Fix ⚠ indicator not showing if LSPs would start

### DIFF
--- a/helix-term/src/handlers/workspace_trust.rs
+++ b/helix-term/src/handlers/workspace_trust.rs
@@ -24,11 +24,7 @@ pub(super) fn register_hooks(_handlers: &Handlers) {
 
         let (workspace, servers_to_load) = {
             let doc = doc!(event.editor, &doc_id);
-            let servers_to_load = doc
-                .language_config()
-                .map(|lang| !lang.language_servers.is_empty() || lang.debugger.is_some())
-                .unwrap_or(false);
-            (doc.workspace_root().to_path_buf(), servers_to_load)
+            (doc.workspace_root().to_path_buf(), doc.servers_to_load())
         };
 
         // Stale: `.helix/` was edited since the user last ran `trust`. LSPs keep

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1175,7 +1175,7 @@ fn workspace_trust_indicator_visible(editor: &Editor) -> bool {
     let (_, doc) = helix_view::current_ref!(editor);
     editor
         .workspace_trust
-        .workspace_restricted(doc.workspace_root())
+        .restricted_for_doc(doc.workspace_root(), doc.servers_to_load())
 }
 
 impl EditorView {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -1971,6 +1971,12 @@ impl Document {
         self.language_servers().any(|l| l.id() == id)
     }
 
+    pub fn servers_to_load(&self) -> bool {
+        self.language_config()
+            .map(|lang| !lang.language_servers.is_empty() || lang.debugger.is_some())
+            .unwrap_or(false)
+    }
+
     pub fn diff_handle(&self) -> Option<&DiffHandle> {
         self.diff_handle.as_ref()
     }


### PR DESCRIPTION
The UI code only checks if trusting the workspace would load local config, but not if it would load any LSP servers like the documentation claims:

> A small [⚠] indicator appears in the bottom-right of the editor (next to the macro-recording [@]) whenever the workspace is in restricted mode and running :workspace-trust would change observable behavior — i.e. when there’s a local config to load or an LSP that would start.

This is relevant for the "Maximum security: never prompt, trust each workspace by hand" recommended setup:

```toml
[editor.workspace-trust]
level = "none"
prompt = false
```

I refactored the `servers_to_load` logic into a method on `Document` but unsure if that's the best way to represent this; feel free to make any changes.