### PR TITLE
Add staticcheck configuration as TOML

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -411,6 +411,7 @@ file-types = [
   { glob = "policy.conf" },
   { glob = "registries.conf" },
   { glob = "storage.conf" },
+  { glob = "staticcheck.conf" },
 ]
 comment-token = "#"
 language-servers = [ "taplo", "tombi" ]


### PR DESCRIPTION
Go's staticcheck configuration files [are TOML](https://staticcheck.dev/docs/configuration/#configuration-format).