### PR TITLE
fix: clear stale code action hints

### DIFF
--- a/helix-term/src/handlers/code_action_hint.rs
+++ b/helix-term/src/handlers/code_action_hint.rs
@@ -127,6 +127,9 @@ pub(super) fn register_hooks(handlers: &Handlers) {
         if event.doc.config.load().code_action_hint() {
             let doc_id = event.doc.id();
             let view_id = event.view;
+
+            // clear stale hints
+            event.doc.clear_code_action_hints(view_id);
             send_blocking(
                 &tx,
                 CodeActionHintEvent {
@@ -187,6 +190,9 @@ pub(super) fn register_hooks(handlers: &Handlers) {
         if event.doc.config.load().code_action_hint() && !event.ghost_transaction {
             let doc_id = event.doc.id();
             let view_id = event.view;
+
+            // clear stale hints
+            event.doc.clear_code_action_hints(view_id);
             send_blocking(
                 &tx,
                 CodeActionHintEvent {


### PR DESCRIPTION
When there is a code action hint and either the selection or document changes, it would stick around until the debounce period ends. Instead it's better to clear it immediately so that it isn't as misleading.

See: https://github.com/helix-editor/helix/pull/15820#issuecomment-4768055579