### PR TITLE
lang: add language server `ghostty-ls`

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -88,7 +88,7 @@
 | gdscript | ✓ | ✓ | ✓ | ✓ | ✓ |  |
 | gemini | ✓ |  |  |  |  |  |
 | gherkin | ✓ |  |  |  |  |  |
-| ghostty | ✓ |  |  |  |  |  |
+| ghostty | ✓ |  |  |  |  | `ghostty-ls` |
 | git-attributes | ✓ |  |  |  |  |  |
 | git-cliff-config | ✓ | ✓ |  |  | ✓ | `taplo`, `tombi` |
 | git-commit | ✓ | ✓ |  |  |  | `commit-lsp` |

--- a/languages.toml
+++ b/languages.toml
@@ -57,6 +57,7 @@ forc = { command = "forc", args = ["lsp"] }
 forth-lsp = { command = "forth-lsp" }
 fortls = { command = "fortls", args = ["--lowercase_intrinsics"] }
 fsharp-ls = { command = "fsautocomplete", config = { AutomaticWorkspaceInit = true } }
+ghostty-ls = { command = "ghostty-ls" } # https://github.com/MKindberg/ghostty-ls
 gitlab-ci-ls = { command = "gitlab-ci-ls" }
 gleam = { command = "gleam", args = ["lsp"] }
 glsl_analyzer = { command = "glsl_analyzer" }
@@ -4806,6 +4807,7 @@ scope = "source.ghostty"
 file-types = ["ghostty", { glob = "ghostty/config" }]
 comment-tokens = "#"
 indent = { tab-width = 2, unit = "  " }
+language-servers = ["ghostty-ls"]
 
 [[grammar]]
 name = "ghostty"


### PR DESCRIPTION
[ghostty-ls](https://github.com/MKindberg/ghostty-ls) is a language server for [ghostty](https://ghostty.org/) config files.