### PR TITLE
lang: add formatter for just

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3831,8 +3831,8 @@ injection-regex = "just"
 comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 language-servers = ["just-lsp"]
-# auto-format = true
-# formatter = { command = "just", args = ["--dump"] } # Please see: https://github.com/helix-editor/helix/issues/9703
+auto-format = true
+formatter = { command="just", args=["--fmt", "--justfile", "-"] }
 
 [[grammar]]
 name = "just"


### PR DESCRIPTION
A new functionality to format justfile from stdin has been added in [`just:1.52`](https://github.com/casey/just/releases/tag/1.52.0) through the patch https://github.com/casey/just/pull/3356.