### PR TITLE
Show language server name in exit status message

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -940,7 +940,9 @@ impl Application {
                         // do nothing
                     }
                     Notification::Exit => {
-                        self.editor.set_status("Language server exited");
+                        let status =
+                            format!("Language server exited: {}", language_server!().name());
+                        self.editor.set_status(status);
 
                         // LSPs may produce diagnostics for files that haven't been opened in helix,
                         // we need to clear those and remove the entries from the list if this leads to


### PR DESCRIPTION
When using multiple language servers for a single file it can be difficult to tell which one is failing or which to try restarting. This adds the name of the language server to the message so that it's clearer

> I just edited this in the GitHub UI, if there are any CI issues/failures I should be able to handle them if needed more robustly