### PR TITLE
accessibility: Add an option to make the terminal cursor follow selected rows in pickers instead of staying in the prompt

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -70,6 +70,7 @@
 | `editor-config` | Whether to read settings from [EditorConfig](https://editorconfig.org) files | `true` |
 | `rainbow-brackets` | Whether to render rainbow colors for matching brackets. Requires tree-sitter `rainbows.scm` queries for the language. | `false` |
 | `kitty-keyboard-protocol` | Whether to enable Kitty Keyboard Protocol. Can be `enabled`, `disabled` or `auto` | `"auto"` |
+| `picker-cursor-follows-selection` | Whether the terminal cursor follows the selected row in pickers instead of staying in the prompt | `false` |
 
 [^3]: In most cases, you also need to enable the `auto-format` setting under `languages.toml`. You can find the reasoning [here](https://github.com/helix-editor/helix/discussions/9043#discussioncomment-7811497).
 

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -45,6 +45,7 @@ use helix_core::{
     text_annotations::TextAnnotations, unicode::segmentation::UnicodeSegmentation, Position,
 };
 use helix_view::{
+    document::Mode,
     editor::Action,
     graphics::{CursorKind, Margin, Modifier, Rect},
     theme::Style,
@@ -1174,18 +1175,44 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
         // calculate the inner area inside the box
         let inner = block.inner(area);
 
-        // prompt area
-        let render_preview =
-            self.show_preview && self.file_fn.is_some() && area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
+        let prompt_cursor = || {
+            // prompt area
+            let render_preview = self.show_preview
+                && self.file_fn.is_some()
+                && area.width > MIN_AREA_WIDTH_FOR_PREVIEW;
 
-        let picker_width = if render_preview {
-            area.width / 2
-        } else {
-            area.width
+            let picker_width = if render_preview {
+                area.width / 2
+            } else {
+                area.width
+            };
+
+            let area = inner.clip_left(1).with_height(1).with_width(picker_width);
+
+            self.prompt.cursor(area, editor)
         };
-        let area = inner.clip_left(1).with_height(1).with_width(picker_width);
 
-        self.prompt.cursor(area, editor)
+        if editor.config().picker_cursor_follows_selection
+            && self.matcher.snapshot().matched_item_count() > 0
+        {
+            let area = inner.clip_top(2);
+            let header_height = self.header_height();
+            let rows = area.height.saturating_sub(header_height) as u32;
+            if rows == 0 {
+                return prompt_cursor();
+            }
+            let offset = self.cursor - (self.cursor % std::cmp::max(1, rows));
+            let cursor = self.cursor.saturating_sub(offset);
+            let y = area.y as usize + header_height as usize + cursor as usize;
+            let x = area.x as usize;
+
+            (
+                Some(Position::new(y, x)),
+                editor.config().cursor_shape.from_mode(Mode::Normal),
+            )
+        } else {
+            prompt_cursor()
+        }
     }
 
     fn required_size(&mut self, (width, height): (u16, u16)) -> Option<(u16, u16)> {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -434,6 +434,8 @@ pub struct Config {
     pub buffer_picker: BufferPickerConfig,
     /// Workspace-trust configuration.
     pub workspace_trust: WorkspaceTrustConfig,
+    /// Whether the terminal cursor follows the selected row in pickers.
+    pub picker_cursor_follows_selection: bool,
 }
 
 /// User-facing configuration for `[editor.workspace-trust]`.
@@ -1240,6 +1242,7 @@ impl Default for Config {
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
             workspace_trust: WorkspaceTrustConfig::default(),
+            picker_cursor_follows_selection: false,
         }
     }
 }


### PR DESCRIPTION
Screen readers commonly use the terminal cursor as the current focus.
The visual picker selection is currently exposed only through highlight
style and the selection marker, which screen readers cannot reliably track
as the selected row changes.

This adds an opt-in setting that moves the terminal cursor to the selected
picker row instead of leaving it in the prompt. The default remains false,
so existing picker behavior is unchanged.
