### PR TITLE
test(editor-config): cover empty alternate brace groups

### DIFF
--- a/helix-core/src/editor_config.rs
+++ b/helix-core/src/editor_config.rs
@@ -331,4 +331,54 @@ mod test {
             }
         );
     }
+
+    #[test]
+    fn empty_alternate_brace_group_test() {
+        // A glob with a brace group followed by a brace group containing an empty
+        // alternate (e.g. `{,.foo}`) must apply to names matching the empty branch.
+        // <https://github.com/helix-editor/helix/issues/15883>
+        let source = r#"
+        [*]
+        indent_size = 4
+
+        [*.{nix,yml}{,.foo}]
+        indent_size = 2
+        "#;
+
+        // The empty alternate branch must match (`flake.nix`, `config.yml`).
+        assert_eq!(
+            editor_config("flake.nix", source),
+            EditorConfig {
+                indent_style: None,
+                tab_width: NonZeroU8::new(2),
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            editor_config("config.yml", source),
+            EditorConfig {
+                indent_style: None,
+                tab_width: NonZeroU8::new(2),
+                ..Default::default()
+            }
+        );
+        // The non-empty alternate branch must also match (`flake.nix.foo`).
+        assert_eq!(
+            editor_config("flake.nix.foo", source),
+            EditorConfig {
+                indent_style: None,
+                tab_width: NonZeroU8::new(2),
+                ..Default::default()
+            }
+        );
+        // A non-matching extension keeps the catch-all `[*]` value.
+        assert_eq!(
+            editor_config("main.rs", source),
+            EditorConfig {
+                indent_style: None,
+                tab_width: NonZeroU8::new(4),
+                ..Default::default()
+            }
+        );
+    }
 }


### PR DESCRIPTION
Closes #15883

EditorConfig glob sections that combine a brace group with a following brace group containing an empty alternate, such as `[*.{nix,yml}{,.foo}]`, were not applied to names that match the empty branch (for example `flake.nix`). That behavior was fixed in #14107 by enabling globset's `empty_alternates`, but the fix landed without a test, so the regression was not guarded.

This adds a focused unit test in `helix-core` that pins the expected matching:

- the empty alternate branch matches plain extensions (`flake.nix`, `config.yml`)
- the non-empty alternate branch still matches (`flake.nix.foo`)
- a non-matching extension falls back to the catch-all `[*]` section

The test fails if `empty_alternates(true)` is removed from the glob builder and passes on `master`, so it locks in the #14107 fix and lets the issue be closed with coverage.

This was written with the assistance of Claude. I have reviewed every line and take full responsibility for the change.
