### PR TITLE
fix(snippets): make the camelCase transform capitalize subsequent words

### DIFF
--- a/helix-core/src/case_conversion.rs
+++ b/helix-core/src/case_conversion.rs
@@ -47,12 +47,19 @@ pub fn to_camel_case(text: impl Iterator<Item = char>) -> Tendril {
     res
 }
 pub fn to_camel_case_with(mut text: impl Iterator<Item = char>, buf: &mut Tendril) {
+    // The first word is kept lowercase. Stop consuming as soon as that word
+    // ends so the loop below can capitalize the remaining words; leading
+    // non-alphanumeric characters are skipped without ending the first word.
+    let mut seen_word_char = false;
     for c in &mut text {
         if c.is_alphanumeric() {
-            buf.extend(c.to_lowercase())
+            seen_word_char = true;
+            buf.extend(c.to_lowercase());
+        } else if seen_word_char {
+            break;
         }
     }
-    let mut at_word_start = false;
+    let mut at_word_start = true;
     for c in text {
         // we don't count _ as a word char here so case conversions work well
         if !c.is_alphanumeric() {
@@ -64,6 +71,65 @@ pub fn to_camel_case_with(mut text: impl Iterator<Item = char>, buf: &mut Tendri
             buf.extend(c.to_uppercase());
         } else {
             buf.push(c)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn camel_case_capitalizes_every_word_after_the_first() {
+        // Regression: the first word used to consume the whole iterator,
+        // leaving the rest un-capitalized, e.g. "foo_bar_baz" -> "foobarbaz".
+        let cases = [
+            ("foo_bar_baz", "fooBarBaz"),
+            ("hello_world", "helloWorld"),
+            ("snake_case_here", "snakeCaseHere"),
+            ("Foo Bar", "fooBar"),
+            // leading, repeated and trailing separators are not words
+            ("_leading_sep", "leadingSep"),
+            ("foo___bar", "fooBar"),
+            ("trailing_", "trailing"),
+            // a single word is just lowercased
+            ("single", "single"),
+            ("alreadyCamel", "alreadycamel"),
+            // empty / separator-only input yields nothing
+            ("", ""),
+            ("___", ""),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                &to_camel_case(input.chars())[..],
+                expected,
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn camel_case_appends_to_an_existing_buffer() {
+        // The snippet elaborator reuses one buffer across format items, so the
+        // first word must be detected independently of what is already in it.
+        let mut buf = Tendril::from("PREFIX_");
+        to_camel_case_with("foo_bar".chars(), &mut buf);
+        assert_eq!(&buf[..], "PREFIX_fooBar");
+    }
+
+    #[test]
+    fn pascal_case_capitalizes_every_word() {
+        let cases = [
+            ("foo_bar_baz", "FooBarBaz"),
+            ("hello world", "HelloWorld"),
+            ("single", "Single"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                &to_pascal_case(input.chars())[..],
+                expected,
+                "input: {input:?}"
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

The `/camelcase` snippet transform produces flatcase instead of camelCase. For example a snippet variable transform that should turn `foo_bar_baz` into `fooBarBaz` instead yields `foobarbaz`.

## Cause

`to_camel_case_with` is built from two loops: the first is meant to emit the leading word in lowercase, and the second capitalizes every following word. The first loop never stops at the end of the first word:

```rust
for c in &mut text {
    if c.is_alphanumeric() {
        buf.extend(c.to_lowercase())
    }
}
```

Because there is no break, it drains the whole iterator (lowercasing every alphanumeric character and dropping the separators), so the second, word-capitalizing loop runs over an already-empty iterator and never executes. The result is the input lowercased with separators stripped.

## Fix

Stop the first loop as soon as the first word ends, while still skipping any leading separators. The first word is tracked with a local flag rather than the buffer's emptiness, because the snippet elaborator (`snippets/elaborate.rs`) reuses a single buffer across format items, so `buf` can already hold earlier output when this function is called.

`to_pascal_case_with` was already correct and is unchanged.

## Tests

The module had no tests. Added coverage for the camelCase helper (the regression, plus leading/repeated/trailing separators, single-word input, the append-to-existing-buffer path, and empty input) and a couple of cases for the PascalCase helper. The new camelCase tests fail on `master` (`foo_bar_baz` -> `foobarbaz`) and pass with this change.
