### PR TITLE
fix(uri): compare the file scheme case-insensitively

### DIFF
--- a/helix-core/src/uri.rs
+++ b/helix-core/src/uri.rs
@@ -84,7 +84,8 @@ impl fmt::Display for UrlConversionError {
 impl std::error::Error for UrlConversionError {}
 
 fn convert_url_to_uri(url: &helix_stdx::Url) -> Result<Uri, UrlConversionErrorKind> {
-    if url.scheme() == "file" {
+    // Schemes are case-insensitive (RFC3986 §3.1).
+    if url.scheme().eq_ignore_ascii_case("file") {
         url.to_file_path()
             .map(|path| Uri::File(helix_stdx::path::normalize(path).into()))
             .map_err(|_| UrlConversionErrorKind::UnableToConvert)
@@ -127,5 +128,14 @@ mod test {
                 ..
             })
         ));
+    }
+
+    // Schemes are case-insensitive (RFC3986 §3.1), so a mixed-case `file` scheme
+    // must still convert to a `File` URI rather than being rejected.
+    #[cfg(not(windows))]
+    #[test]
+    fn uppercase_file_scheme() {
+        let url = Url::parse("FILE:///home/user/Baz.cs").unwrap();
+        assert!(matches!(Uri::try_from(url), Ok(Uri::File(_))));
     }
 }

--- a/helix-stdx/src/uri.rs
+++ b/helix-stdx/src/uri.rs
@@ -133,7 +133,10 @@ impl Url {
     /// Convert a `file://` URI back to a filesystem path.
     #[allow(clippy::result_unit_err)]
     pub fn to_file_path(&self) -> Result<PathBuf, ()> {
-        if self.scheme() != "file" {
+        // Schemes are case-insensitive (RFC3986 §3.1), so accept any casing.
+        // The scheme is `file`, so it is always 5 bytes (`file:`) regardless of
+        // case, which keeps the slice below valid.
+        if !self.scheme().eq_ignore_ascii_case("file") {
             return Err(());
         }
         let rest = self.0["file:".len()..].strip_prefix("//").ok_or(())?;
@@ -330,6 +333,21 @@ mod tests {
     #[test]
     fn non_file_scheme_has_no_path() {
         assert!(Url::parse("untitled:foo").unwrap().to_file_path().is_err());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn to_file_path_accepts_uppercase_scheme() {
+        // Schemes are case-insensitive (RFC3986 §3.1); the `url` crate lowercased
+        // them on parse, so a mixed-case `file` scheme must still resolve.
+        for uri in ["FILE:///home/user/x.rs", "File:///home/user/x.rs"] {
+            let url = Url::parse(uri).unwrap();
+            assert_eq!(
+                url.to_file_path().unwrap(),
+                PathBuf::from("/home/user/x.rs"),
+                "{uri}"
+            );
+        }
     }
 
     #[test]

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -1571,7 +1571,8 @@ fn open_url_in_callback(
 /// only when the target looks like a binary file (a non-textual file that can't
 /// be viewed in helix).
 fn should_open_url_externally(url: &Url) -> bool {
-    if url.scheme() != "file" {
+    // Schemes are case-insensitive (RFC3986 §3.1).
+    if !url.scheme().eq_ignore_ascii_case("file") {
         return true;
     }
 


### PR DESCRIPTION
## Summary

A `file` URI whose scheme is not all-lowercase, such as `FILE:///path` or `File:///path`, is treated as a non-`file` scheme. `Url::to_file_path` and the `Uri` conversion reject it, and `should_open_url_externally` opens it externally instead of in the editor.

## Cause

URI schemes are case-insensitive (RFC3986 §3.1), and the `url` crate that the new RFC3986 wrapper replaced lowercased the scheme on parse, so downstream `scheme() == "file"` checks always saw lowercase. The new wrapper stores the URI verbatim (path conversion is intentionally lazy), but the three sites that check for the file scheme compared it case-sensitively:

- `helix_stdx::Url::to_file_path`
- `helix_core::uri::convert_url_to_uri`
- `should_open_url_externally` in `helix-term`

So any non-lowercase `file` scheme fell through as if it were a foreign scheme.

## Fix

Compare the scheme with `eq_ignore_ascii_case("file")` at those three sites. This keeps the "store the URI verbatim" design (the scheme is not rewritten) and only changes how consumers interpret it, which is what RFC3986 requires. The scheme is still 5 bytes (`file:`) regardless of case, so the existing length-based slice in `to_file_path` stays valid.

## Tests

Added a `helix-stdx` test that a mixed-case `file` scheme round-trips through `to_file_path`, and a `helix-core` test that `Uri::try_from` accepts it. Both fail before this change (the URI is rejected) and pass after.
