### PR TITLE
queries: highlight calling-side of pipe operators as functions

### DIFF
--- a/runtime/queries/nix/highlights.scm
+++ b/runtime/queries/nix/highlights.scm
@@ -88,6 +88,24 @@
       attrpath: (attrpath
         attr: (identifier) @function .))])
 
+; Pipe operators evaluate the side pointed to by the operator as a function:
+; `value |> lib.foo` and `lib.foo <| value`.
+(binary_expression
+  operator: "|>"
+  right: [
+    (variable_expression (identifier) @function)
+    (select_expression
+      attrpath: (attrpath
+        attr: (identifier) @function .))])
+
+(binary_expression
+  left: [
+    (variable_expression (identifier) @function)
+    (select_expression
+      attrpath: (attrpath
+        attr: (identifier) @function .))]
+  operator: "<|")
+
 (binding
   attrpath: (attrpath
     attr: (identifier) @function)

--- a/tests/query/highlights/nix/calls.nix
+++ b/tests/query/highlights/nix/calls.nix
@@ -4,4 +4,8 @@
   y = builtins.length items;
 #     ^ @constant.builtin
 #              ^ @function.builtin
+  z = value |> lib.foo;
+#                  ^ @function
+  w = lib.foo <| value;
+#         ^ @function
 }

--- a/tests/query/highlights/nix/calls.nix
+++ b/tests/query/highlights/nix/calls.nix
@@ -1,7 +1,7 @@
 {
   x = map double items;
-//    ^ @function.builtin
+#     ^ @function.builtin
   y = builtins.length items;
-//    ^ @constant.builtin
-//             ^ @function.builtin
+#     ^ @constant.builtin
+#              ^ @function.builtin
 }


### PR DESCRIPTION
# Summary

The first commit fixes the incorrect pre-existing highlight assertions in the test, which were using `//` for the
comments instead of `#`.

The second commit adds function highlighting to the left side of the `<|` operator and to the right side of the `|>` operator.
