### PR TITLE
fix(jumplist): show line text when the selection preview is only whitespace

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -3411,12 +3411,22 @@ fn jumplist_picker(cx: &mut Context) {
     let new_meta = |view: &View, doc_id: DocumentId, selection: Selection| {
         let doc = doc!(cx.editor, &doc_id);
         let text = doc.text().slice(..);
-        let contents = selection
-            .fragments(text)
-            .map(Cow::into_owned)
-            .collect::<Vec<_>>()
-            .join(" ");
         let line_start = selection.primary().cursor_line(text);
+        let contents = {
+            let fragments = selection
+                .fragments(text)
+                .map(Cow::into_owned)
+                .collect::<Vec<_>>()
+                .join(" ");
+            if fragments.trim().is_empty() {
+                // The selection covers only whitespace (e.g. a bare cursor on a tab or
+                // on indentation), which renders as an empty cell. Fall back to the
+                // line's text so the contents column still shows something meaningful.
+                text.line(line_start).to_string().trim().to_string()
+            } else {
+                fragments
+            }
+        };
 
         JumpMeta {
             id: doc_id,


### PR DESCRIPTION
## Summary

In the jumplist picker the `contents` column is built from the jump's selection fragments. When a jump lands on whitespace — a bare cursor on a tab or on a line's indentation — the fragment is whitespace-only, so the cell renders blank even though the line itself has visible text. This is the case shown in the issue (a tab followed by text). Closes #15937.

## Change

When the joined selection fragments are whitespace-only, fall back to the line's text (trimmed) so the column shows the line the jump points to instead of an empty cell. Non-whitespace selections are unchanged.

## Notes

The issue also floated showing an explicit `(empty)` marker. I went with the line-text fallback since it directly addresses the reported case — a tab followed by code now previews that code rather than an invisible tab. Happy to switch to a marker for genuinely blank lines if you'd prefer.
