### PR TITLE
Update caddyfile tree-sitter grammar

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5057,7 +5057,7 @@ auto-format = true
 
 [[grammar]]
 name = "caddyfile"
-source = { git = "https://github.com/caddyserver/tree-sitter-caddyfile", rev = "683332a6430675abfd9867201ef47b2b99bdb266" }
+source = { git = "https://github.com/caddyserver/tree-sitter-caddyfile", rev = "15437433b7deec0f0431fb4a5bedb64ecae01513" }
 
 [[language]]
 name = "properties"


### PR DESCRIPTION
There have been some nice fixes to the parsing of heredoc: https://github.com/caddyserver/tree-sitter-caddyfile/issues/78