### PR TITLE
Allow command renaming in configuration

### DIFF
--- a/helix-term/src/keymap.rs
+++ b/helix-term/src/keymap.rs
@@ -174,10 +174,46 @@ impl<'de> serde::de::Visitor<'de> for KeyTrieVisitor {
         M: serde::de::MapAccess<'de>,
     {
         let mut mapping = IndexMap::new();
-        while let Some((key, value)) = map.next_entry::<KeyEvent, KeyTrie>()? {
-            mapping.insert(key, value);
+        let mut label = String::new();
+        let mut command: Option<String> = None;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "label" => label = map.next_value::<String>()?,
+                "command" => command = Some(map.next_value::<String>()?),
+                _ => {
+                    let key_event = key.parse::<KeyEvent>().map_err(serde::de::Error::custom)?;
+                    let value = map.next_value::<KeyTrie>()?;
+                    mapping.insert(key_event, value);
+                }
+            }
         }
-        Ok(KeyTrie::Node(KeyTrieNode::new("", mapping)))
+
+        if let Some(cmd_str) = command {
+            let cmd = cmd_str
+                .parse::<MappableCommand>()
+                .map_err(serde::de::Error::custom)?;
+
+            let cmd = if !label.is_empty() {
+                match cmd {
+                    MappableCommand::Typable { name, args, .. } => MappableCommand::Typable {
+                        name,
+                        args,
+                        doc: label,
+                    },
+                    MappableCommand::Macro { keys, .. } => {
+                        MappableCommand::Macro { name: label, keys }
+                    }
+                    other => other,
+                }
+            } else {
+                cmd
+            };
+
+            Ok(KeyTrie::MappableCommand(cmd))
+        } else {
+            Ok(KeyTrie::Node(KeyTrieNode::new(&label, mapping)))
+        }
     }
 }
 


### PR DESCRIPTION
Hey,

I added new configuration fields to allow renaming commands in the tooltip/command picker. The format is:

```toml
[keys.normal]
space.B = { label = "Show blame information", command = ":sh echo \"%sh{git --no-pager show --no-patch --format='%%h %%s [%%an: %%ar]' %sh{git --no-pager blame -p %{buffer_name} -L%{cursor_line},+1 | head -1 | cut -d' ' -f1} || echo Not committed yet}\"" }

# Convert cases
[keys.normal.g.c]
label = "Switch case"
p = { label = "Change to Pascal", command = ":pipe ccase --to pascal" }
```

This is optional and does not interfere with the previous format.

Let me know if this has a chance of getting merged and I'll update the docs.

### Rationale

Love helix, but I was playing around with the configuration. This is what I ended up with:

```toml
[keys.normal]
space.B = ":sh echo \"%sh{git --no-pager show --no-patch --format='%%h %%s [%%an: %%ar]' %sh{git --no-pager blame -p %{buffer_name} -L%{cursor_line},+1 | head -1 | cut -d' ' -f1} || echo Not committed yet}\""

# Convert cases
[keys.normal.space.c]
c = ":pipe ccase --to camel"
C = ":pipe ccase --to uppercamel"
```

This is unsightly on the tooltip pane. The submenu also has nothing so I cannot remember what I put where.
<img width="3402" height="2078" alt="Screenshot 2026-06-30 at 22 32 48" src="https://github.com/user-attachments/assets/641583c4-06ca-4eac-9c44-374527723307" />

For reference this is what the tooltip is supposed to look like:
<img width="3402" height="2078" alt="Screenshot 2026-06-30 at 22 34 25" src="https://github.com/user-attachments/assets/86e15388-0107-43ec-94a7-614b863426c0" />

After a rename with this PR this is the tooltip:
<img width="1230" height="1172" alt="Screenshot 2026-06-30 at 22 43 42" src="https://github.com/user-attachments/assets/2fe23df7-abd0-447a-89d4-01a69e5b6af9" />