### PR TITLE
fix(indent): Python last-line-of-block indentation regression

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -550,8 +550,12 @@ fn get_node_start_line(text: RopeSlice, node: &Node, new_line_byte_pos: Option<u
 }
 fn get_node_end_line(text: RopeSlice, node: &Node, new_line_byte_pos: Option<u32>) -> usize {
     let mut node_line = text.byte_to_line(node.end_byte() as usize);
-    // Adjust for the new line that will be inserted (with a strict inequality since end_byte is exclusive)
-    if new_line_byte_pos.is_some_and(|pos| node.end_byte() > pos) {
+    // When inserting a new line, bump the scope end if the node's exclusive end
+    // byte is at or after the newline position. The `>=` (rather than `>`) is
+    // intentional: in Python (and similar languages) the last token of a block
+    // ends exactly at the newline byte (exclusive end == newline byte), and we
+    // still want the scope to cover the newly inserted line.
+    if new_line_byte_pos.is_some_and(|pos| node.end_byte() >= pos) {
         node_line += 1;
     }
     node_line
@@ -829,6 +833,27 @@ fn init_indent_query<'a, 'b>(
             }
             prec
         });
+
+        // When typing a newline, byte_pos is the newline character itself.
+        // Tree-sitter's exclusive byte ranges place the newline byte outside
+        // all statement nodes (e.g. `function_definition.end_byte()` equals
+        // the newline byte, not one past it), so `descendant_for_byte_range`
+        // bubbles up to the parent (often the module root). Descend into the
+        // last preceding child so that extend-walks and containment-walks
+        // start inside the enclosing scope rather than at the root.
+        if new_line_byte_pos.is_some() {
+            if let Some(ref dp) = deepest_preceding {
+                let mut ancestor = dp.clone();
+                while let Some(parent) = ancestor.parent() {
+                    if parent.id() == node.id() {
+                        node = ancestor;
+                        break;
+                    }
+                    ancestor = parent;
+                }
+            }
+        }
+
         // When typing a newline, the body the new line opens is a sibling past
         // the cursor — extend the query range to cover it so its capture (and
         // in particular its `(#set! "scope" "header")` annotation) is present

--- a/tests/indent/python.py
+++ b/tests/indent/python.py
@@ -89,3 +89,10 @@ first line
     indented in string
 back"""
     return text
+
+
+def last_line_bug():
+    x = 1
+    return x
+def immediate_follower():
+    pass


### PR DESCRIPTION
Hi!
I really like using helix but ran into an issue when I moved from the stable tarball (25.07) to HEAD on master, described below.
I have an apology/disclaimer: when I ran into the issue, I just handed it off to Claude, and it came up with this fix. I read over the contributing guidelines and it seems like this is OK - if you want, I can go back and write some integration tests, too. Running cargo test, everything passed.
Anyway, happy to chat about the issue or the fix. Thanks for the great software :)

Harry

After commit 3013c107d (containment model rewrite), pressing Enter at the last line of a Python function body placed the cursor at column 0 instead of staying indented inside the body.

Root cause: two bugs in the containment engine for the case where `node.end_byte() == byte_pos` (the newline byte):

1. `descendant_for_byte_range(newline_byte, newline_byte)` returns the module root because Python's tree-sitter grammar places the DEDENT at the newline byte, making `function_definition.end_byte()` exactly equal to `byte_pos`. None of module's children contain the byte, so the lookup bubbles to the root. The subsequent upward walk only visits `module` (no @indent captures) and returns indent = 0.

   Fix: in `init_indent_query`, after computing `deepest_preceding`, walk from it up to the current `node` and use the last direct child of `node` on that path as the new start node. This ensures the walk begins inside the enclosing function scope.

2. `get_node_end_line` used a strict `>` check for the scope-end bump: `if node.end_byte() > byte_pos { node_line += 1 }`. When `end_byte == byte_pos`, the bump did not fire, so `scope_end` stayed on the current line and `target_line == scope_end + 1` fell outside the scope, causing containment to return false.

   Fix: change `>` to `>=`.

Adds a corpus test case (adjacent functions with no blank line) that exercises the last-content-line-of-a-block scenario previously untested because the existing corpus always has a blank line after each function.