### PR TITLE
Add GitHub Copilot inline completion support

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -566,3 +566,35 @@ level = "servers"
 # under a matching path. `~` and environment variables are expanded.
 trusted = ["~/src/github.com/me/*"]
 ```
+
+### `[editor.copilot]` Section
+
+Configures the GitHub Copilot inline-suggestion integration. Copilot is driven
+by an external [`copilot-language-server`](https://www.npmjs.com/package/@github/copilot-language-server)
+process, which must be installed separately and reachable on your `PATH` (or
+given an absolute path with `command`).
+
+| Key       | Description                                                                 | Default                      |
+| ---       | ---                                                                         | ---                          |
+| `enable`  | Whether the Copilot integration is enabled.                                 | `false`                      |
+| `command` | The Copilot language server executable.                                     | `"copilot-language-server"`  |
+| `args`    | Arguments passed to the language server.                                    | `["--stdio"]`                |
+| `auto`    | Reserved for automatically requesting suggestions while typing.             | `true`                       |
+
+Example:
+
+```toml
+[editor.copilot]
+enable = true
+command = "copilot-language-server"
+args = ["--stdio"]
+```
+
+Sign in once with `:copilot-signin` (this prints a device code to enter at
+`https://github.com/login/device`), check the connection with `:copilot-status`,
+and toggle suggestions at runtime with `:copilot-toggle`. In insert mode the
+default keys are `Alt-c` to request a suggestion, `Alt-l` to accept it, and
+`Alt-x` to dismiss it; these map to the `copilot_request_completion`,
+`copilot_apply_completion` and `copilot_dismiss_completion` commands and can be
+remapped like any other command.
+

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -313,3 +313,6 @@
 | `goto_prev_tabstop` | Goto next snippet placeholder |  |
 | `rotate_selections_first` | Make the first selection your primary one |  |
 | `rotate_selections_last` | Make the last selection your primary one |  |
+| `copilot_request_completion` | Request a GitHub Copilot inline suggestion | insert: `` <A-c> `` |
+| `copilot_apply_completion` | Accept the active GitHub Copilot suggestion | insert: `` <A-l> `` |
+| `copilot_dismiss_completion` | Dismiss the active GitHub Copilot suggestion | insert: `` <A-x> `` |

--- a/book/src/generated/typable-cmd.md
+++ b/book/src/generated/typable-cmd.md
@@ -100,3 +100,7 @@
 | `:workspace-trust` | Allow language servers and local config for the current workspace. |
 | `:workspace-untrust` | Revoke the current workspace's trust grant or exclusion. |
 | `:workspace-exclude` | Mark the current workspace as never-prompt. Never prompts for trust again. |
+| `:copilot-signin` | Sign in to GitHub Copilot, showing the device code to enter in the browser. |
+| `:copilot-signout` | Sign out of GitHub Copilot. |
+| `:copilot-status` | Show the GitHub Copilot sign-in and enabled status. |
+| `:copilot-toggle` | Toggle GitHub Copilot inline suggestions on or off. |

--- a/helix-lsp/Cargo.toml
+++ b/helix-lsp/Cargo.toml
@@ -16,7 +16,7 @@ homepage.workspace = true
 helix-stdx = { path = "../helix-stdx" }
 helix-core = { path = "../helix-core" }
 helix-loader = { path = "../helix-loader" }
-helix-lsp-types = { path = "../helix-lsp-types" }
+helix-lsp-types = { path = "../helix-lsp-types", features = ["proposed"] }
 
 anyhow = "1.0"
 futures-executor.workspace = true

--- a/helix-lsp/src/copilot.rs
+++ b/helix-lsp/src/copilot.rs
@@ -1,0 +1,487 @@
+//! A dedicated client for the GitHub Copilot language server
+//! (`copilot-language-server`).
+//!
+//! Copilot speaks the Language Server Protocol over stdio with the standard
+//! `Content-Length` framing, so this module reuses Helix's [`Transport`] for
+//! the wire handshake. On top of that it implements the Copilot specific
+//! requests and notifications (`checkStatus`, `signIn`, `signOut`,
+//! `textDocument/inlineCompletion`, ...) which are not part of the regular LSP
+//! surface and therefore do not belong in the general purpose [`crate::Client`].
+//!
+//! The client is intentionally self contained: it answers the handful of
+//! server to client requests Copilot relies on (`workspace/configuration`,
+//! `window/workDoneProgress/create`, `window/showDocument`) from an internal
+//! background task so that the editor never has to route Copilot traffic
+//! through the main language server registry.
+
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::io::{BufReader, BufWriter};
+use tokio::process::{Child, Command};
+use tokio::sync::mpsc::{channel, UnboundedReceiver, UnboundedSender};
+use tokio::sync::Notify;
+use tokio::time::timeout;
+
+use crate::jsonrpc;
+use crate::transport::{Payload, Transport};
+use crate::{lsp, Error, LanguageServerId, Result};
+
+pub use lsp::{InlineCompletionItem, Url};
+
+/// Default timeout (in seconds) for ordinary Copilot requests.
+const REQUEST_TIMEOUT: u64 = 20;
+/// Generous timeout for the interactive device-flow sign-in, which only
+/// resolves once the user authorizes the device code in their browser.
+const SIGN_IN_TIMEOUT: u64 = 1800;
+
+/// The result of a `checkStatus` / `signOut` request.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatusResponse {
+    /// One of `OK`, `MaybeOk`, `NotAuthorized`, `NotSignedIn`.
+    pub status: String,
+    #[serde(default)]
+    pub user: Option<String>,
+}
+
+impl StatusResponse {
+    pub fn signed_in(&self) -> bool {
+        matches!(self.status.as_str(), "OK" | "MaybeOk" | "AlreadySignedIn")
+    }
+}
+
+/// The result of a `signIn` request. When the account is not yet authorized the
+/// server returns a `PromptUserDeviceFlow` payload carrying the device code the
+/// user has to enter at [`Self::verification_uri`].
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SignInResponse {
+    pub status: String,
+    #[serde(default)]
+    pub user_code: Option<String>,
+    #[serde(default)]
+    pub verification_uri: Option<String>,
+    #[serde(default)]
+    pub expires_in: Option<i64>,
+    #[serde(default)]
+    pub interval: Option<i64>,
+    #[serde(default)]
+    pub user: Option<String>,
+    /// The follow-up command (`github.copilot.finishDeviceFlow`) that must be
+    /// executed to wait for the user to complete the device flow.
+    #[serde(default)]
+    pub command: Option<lsp::Command>,
+}
+
+/// Formatting hints sent alongside an inline completion request.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FormattingOptions {
+    pub tab_size: u32,
+    pub insert_spaces: bool,
+}
+
+impl Default for FormattingOptions {
+    fn default() -> Self {
+        Self {
+            tab_size: 4,
+            insert_spaces: true,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct InlineCompletionResult {
+    #[serde(default)]
+    items: Vec<InlineCompletionItem>,
+}
+
+/// A live, initialized connection to a `copilot-language-server` process.
+pub struct Client {
+    name: String,
+    _process: Child,
+    server_tx: UnboundedSender<Payload>,
+    request_counter: AtomicU64,
+    initialize_notify: Arc<Notify>,
+    /// The last sign-in status reported by the server via `didChangeStatus`.
+    status: Arc<Mutex<Option<String>>>,
+}
+
+impl std::fmt::Debug for Client {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("copilot::Client")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Client {
+    /// Spawn the Copilot language server and wire up the transport. The returned
+    /// client still needs to be [`initialize`](Self::initialize)d before any
+    /// other request is issued.
+    pub fn start(cmd: &str, args: &[String]) -> Result<Arc<Self>> {
+        let cmd = helix_stdx::env::which(cmd)?;
+        log::info!("starting copilot language server: {cmd:?}");
+
+        let mut process = Command::new(cmd)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        let writer = BufWriter::new(process.stdin.take().expect("Failed to open stdin"));
+        let reader = BufReader::new(process.stdout.take().expect("Failed to open stdout"));
+        let stderr = BufReader::new(process.stderr.take().expect("Failed to open stderr"));
+
+        let (server_rx, server_tx, initialize_notify, _shutdown_flushed) = Transport::start(
+            reader,
+            writer,
+            stderr,
+            LanguageServerId::default(),
+            "copilot".to_string(),
+        );
+
+        let status = Arc::new(Mutex::new(None));
+
+        // Answer the server-to-client requests Copilot relies on and keep track
+        // of status notifications without involving the editor event loop.
+        tokio::spawn(Self::run_dispatch(
+            server_rx,
+            server_tx.clone(),
+            status.clone(),
+        ));
+
+        Ok(Arc::new(Self {
+            name: "copilot".to_string(),
+            _process: process,
+            server_tx,
+            request_counter: AtomicU64::new(0),
+            initialize_notify,
+            status,
+        }))
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// The last status string the server pushed via `didChangeStatus`, if any.
+    pub fn last_status(&self) -> Option<String> {
+        self.status.lock().clone()
+    }
+
+    fn next_request_id(&self) -> jsonrpc::Id {
+        jsonrpc::Id::Num(self.request_counter.fetch_add(1, Ordering::Relaxed))
+    }
+
+    fn value_into_params(value: Value) -> jsonrpc::Params {
+        match value {
+            Value::Null => jsonrpc::Params::None,
+            Value::Bool(_) | Value::Number(_) | Value::String(_) => {
+                jsonrpc::Params::Array(vec![value])
+            }
+            Value::Array(vec) => jsonrpc::Params::Array(vec),
+            Value::Object(map) => jsonrpc::Params::Map(map),
+        }
+    }
+
+    fn request<R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> impl std::future::Future<Output = Result<R>> {
+        self.request_with_timeout(method, params, REQUEST_TIMEOUT)
+    }
+
+    fn request_with_timeout<R: DeserializeOwned>(
+        &self,
+        method: &str,
+        params: Value,
+        timeout_secs: u64,
+    ) -> impl std::future::Future<Output = Result<R>> {
+        let server_tx = self.server_tx.clone();
+        let id = self.next_request_id();
+        let method = method.to_string();
+
+        // Build and queue the request eagerly so request ordering is preserved
+        // even if the returned future is polled later.
+        let rx = {
+            let (tx, rx) = channel::<Result<Value>>(1);
+            let request = jsonrpc::MethodCall {
+                jsonrpc: Some(jsonrpc::Version::V2),
+                id: id.clone(),
+                method,
+                params: Self::value_into_params(params),
+            };
+            server_tx
+                .send(Payload::Request {
+                    chan: tx,
+                    value: request,
+                })
+                .map_err(|e| Error::Other(e.into()))
+                .map(|_| rx)
+        };
+
+        async move {
+            let mut rx = rx?;
+            let value = timeout(Duration::from_secs(timeout_secs), rx.recv())
+                .await
+                .map_err(|_| Error::Timeout(id))?
+                .ok_or(Error::StreamClosed)??;
+            serde_json::from_value(value).map_err(Into::into)
+        }
+    }
+
+    fn notify(&self, method: &str, params: Value) {
+        let notification = jsonrpc::Notification {
+            jsonrpc: Some(jsonrpc::Version::V2),
+            method: method.to_string(),
+            params: Self::value_into_params(params),
+        };
+        if let Err(err) = self.server_tx.send(Payload::Notification(notification)) {
+            log::error!("failed to send copilot notification '{method}': {err}");
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Lifecycle
+    // ----------------------------------------------------------------------
+
+    /// Run the Copilot `initialize`/`initialized` handshake and return the
+    /// server capabilities (which include `inlineCompletionProvider` when the
+    /// server supports inline completions).
+    pub async fn initialize(
+        &self,
+        editor_name: &str,
+        editor_version: &str,
+        plugin_version: &str,
+        workspace: Option<&Path>,
+    ) -> Result<lsp::ServerCapabilities> {
+        let (root_uri, workspace_folders) =
+            match workspace.and_then(|p| Url::from_file_path(p).ok()) {
+                Some(uri) => {
+                    let name = workspace
+                        .and_then(|p| p.file_name())
+                        .map(|name| name.to_string_lossy().into_owned())
+                        .unwrap_or_default();
+                    (
+                        Value::String(uri.to_string()),
+                        json!([{ "uri": uri.to_string(), "name": name }]),
+                    )
+                }
+                None => (Value::Null, json!([])),
+            };
+
+        let params = json!({
+            "processId": std::process::id(),
+            "clientInfo": { "name": editor_name, "version": editor_version },
+            "rootUri": root_uri,
+            "workspaceFolders": workspace_folders,
+            "capabilities": {
+                "workspace": { "workspaceFolders": true, "configuration": true },
+                "textDocument": { "inlineCompletion": {} },
+                "window": { "workDoneProgress": true, "showDocument": { "support": true } },
+            },
+            "initializationOptions": {
+                "editorInfo": { "name": editor_name, "version": editor_version },
+                "editorPluginInfo": { "name": "helix-copilot", "version": plugin_version },
+            },
+        });
+
+        let result: lsp::InitializeResult = self.request("initialize", params).await?;
+        self.notify("initialized", json!({}));
+        // Release any requests that were queued while initialization was pending.
+        self.initialize_notify.notify_one();
+        Ok(result.capabilities)
+    }
+
+    pub async fn shutdown(&self) -> Result<()> {
+        let _: Value = self.request("shutdown", Value::Null).await?;
+        Ok(())
+    }
+
+    pub fn exit(&self) {
+        self.notify("exit", Value::Null);
+    }
+
+    // ----------------------------------------------------------------------
+    // Authentication
+    // ----------------------------------------------------------------------
+
+    pub async fn check_status(&self) -> Result<StatusResponse> {
+        self.request("checkStatus", json!({})).await
+    }
+
+    pub async fn sign_in(&self) -> Result<SignInResponse> {
+        self.request("signIn", json!({})).await
+    }
+
+    pub async fn sign_out(&self) -> Result<StatusResponse> {
+        self.request("signOut", json!({})).await
+    }
+
+    /// Execute the `github.copilot.finishDeviceFlow` command returned by
+    /// [`sign_in`](Self::sign_in). This future only resolves once the user has
+    /// authorized the device code in their browser (or the code expires), so it
+    /// is given a long timeout.
+    pub async fn finish_device_flow(&self) -> Result<Value> {
+        self.request_with_timeout(
+            "workspace/executeCommand",
+            json!({ "command": "github.copilot.finishDeviceFlow", "arguments": [] }),
+            SIGN_IN_TIMEOUT,
+        )
+        .await
+    }
+
+    // ----------------------------------------------------------------------
+    // Document synchronization (Copilot uses full-text sync)
+    // ----------------------------------------------------------------------
+
+    pub fn did_open(&self, uri: &Url, version: i32, language_id: &str, text: &str) {
+        self.notify(
+            "textDocument/didOpen",
+            json!({
+                "textDocument": {
+                    "uri": uri.to_string(),
+                    "languageId": language_id,
+                    "version": version,
+                    "text": text,
+                }
+            }),
+        );
+    }
+
+    pub fn did_change(&self, uri: &Url, version: i32, text: &str) {
+        self.notify(
+            "textDocument/didChange",
+            json!({
+                "textDocument": { "uri": uri.to_string(), "version": version },
+                "contentChanges": [{ "text": text }],
+            }),
+        );
+    }
+
+    pub fn did_close(&self, uri: &Url) {
+        self.notify(
+            "textDocument/didClose",
+            json!({ "textDocument": { "uri": uri.to_string() } }),
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // Inline completion
+    // ----------------------------------------------------------------------
+
+    pub async fn inline_completion(
+        &self,
+        uri: &Url,
+        version: i32,
+        line: u32,
+        character: u32,
+        formatting: FormattingOptions,
+    ) -> Result<Vec<InlineCompletionItem>> {
+        let params = json!({
+            "textDocument": { "uri": uri.to_string(), "version": version },
+            "position": { "line": line, "character": character },
+            "context": { "triggerKind": 2 },
+            "formattingOptions": formatting,
+        });
+        let result: Option<InlineCompletionResult> = self
+            .request("textDocument/inlineCompletion", params)
+            .await?;
+        Ok(result.map(|r| r.items).unwrap_or_default())
+    }
+
+    /// Telemetry: report that a completion item was shown to the user.
+    pub fn notify_shown(&self, item_id: &str) {
+        self.notify(
+            "textDocument/didShowCompletion",
+            json!({ "item": { "command": { "arguments": [item_id] } } }),
+        );
+    }
+
+    /// Telemetry: report that a completion item was accepted by the user.
+    pub fn notify_accepted(&self, item_id: &str) {
+        self.notify(
+            "workspace/executeCommand",
+            json!({
+                "command": "github.copilot.didAcceptCompletionItem",
+                "arguments": [item_id],
+            }),
+        );
+    }
+
+    // ----------------------------------------------------------------------
+    // Server -> client dispatch
+    // ----------------------------------------------------------------------
+
+    async fn run_dispatch(
+        mut server_rx: UnboundedReceiver<(LanguageServerId, jsonrpc::Call)>,
+        server_tx: UnboundedSender<Payload>,
+        status: Arc<Mutex<Option<String>>>,
+    ) {
+        while let Some((_id, call)) = server_rx.recv().await {
+            match call {
+                jsonrpc::Call::MethodCall(method_call) => {
+                    let result = Self::handle_server_request(&method_call);
+                    let output = jsonrpc::Output::Success(jsonrpc::Success {
+                        jsonrpc: Some(jsonrpc::Version::V2),
+                        id: method_call.id,
+                        result,
+                    });
+                    if server_tx.send(Payload::Response(output)).is_err() {
+                        break;
+                    }
+                }
+                jsonrpc::Call::Notification(notification) => {
+                    Self::handle_server_notification(&notification, &status);
+                }
+                jsonrpc::Call::Invalid { .. } => {}
+            }
+        }
+    }
+
+    fn handle_server_request(method_call: &jsonrpc::MethodCall) -> Value {
+        match method_call.method.as_str() {
+            // Copilot asks for editor configuration; reply with one empty object
+            // per requested item (an empty config is acceptable).
+            "workspace/configuration" => {
+                let len = match &method_call.params {
+                    jsonrpc::Params::Map(map) => map
+                        .get("items")
+                        .and_then(Value::as_array)
+                        .map(|items| items.len())
+                        .unwrap_or(1),
+                    _ => 1,
+                };
+                Value::Array(vec![json!({}); len.max(1)])
+            }
+            "window/workDoneProgress/create" => Value::Null,
+            "window/showDocument" => json!({ "success": true }),
+            _ => Value::Null,
+        }
+    }
+
+    fn handle_server_notification(
+        notification: &jsonrpc::Notification,
+        status: &Arc<Mutex<Option<String>>>,
+    ) {
+        if let "didChangeStatus" | "statusNotification" = notification.method.as_str() {
+            if let jsonrpc::Params::Map(map) = &notification.params {
+                if let Some(kind) = map.get("kind").and_then(Value::as_str) {
+                    *status.lock() = Some(kind.to_string());
+                }
+            }
+        }
+    }
+}

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -1,4 +1,5 @@
 mod client;
+pub mod copilot;
 pub mod file_event;
 mod file_operations;
 pub mod jsonrpc;

--- a/helix-lsp/tests/copilot.rs
+++ b/helix-lsp/tests/copilot.rs
@@ -1,0 +1,88 @@
+//! End-to-end protocol test against a real `copilot-language-server`.
+//!
+//! This test is ignored by default because it spawns an external process. Run
+//! it explicitly with the path to the binary:
+//!
+//! ```sh
+//! HELIX_COPILOT_BIN=/path/to/copilot-language-server \
+//!     cargo test -p helix-lsp --test copilot -- --ignored --nocapture
+//! ```
+//!
+//! It verifies the full unauthenticated handshake but deliberately stops at the
+//! device-flow prompt, so it never completes an irreversible sign-in.
+
+use helix_lsp::copilot::{Client, FormattingOptions};
+use helix_lsp::{lsp, Error};
+
+fn binary() -> Option<String> {
+    std::env::var("HELIX_COPILOT_BIN").ok()
+}
+
+#[tokio::test]
+#[ignore = "spawns the real copilot-language-server; set HELIX_COPILOT_BIN"]
+async fn copilot_protocol_e2e() {
+    let Some(bin) = binary() else {
+        eprintln!("HELIX_COPILOT_BIN not set; skipping");
+        return;
+    };
+
+    let client = Client::start(&bin, &["--stdio".to_string()]).expect("failed to spawn copilot");
+
+    // 1. initialize -> the server advertises an inline completion provider.
+    let caps = client
+        .initialize("Helix", "25.07.0", "0.1.0", None)
+        .await
+        .expect("initialize failed");
+    assert!(
+        caps.inline_completion_provider.is_some(),
+        "expected inlineCompletionProvider in capabilities, got: {caps:?}"
+    );
+    println!(
+        "[e2e] inlineCompletionProvider present: {:?}",
+        caps.inline_completion_provider
+    );
+
+    // 2. checkStatus -> NotSignedIn for a fresh, unauthenticated server.
+    let status = client.check_status().await.expect("checkStatus failed");
+    println!("[e2e] checkStatus -> {status:?}");
+    assert_eq!(status.status, "NotSignedIn");
+
+    // 3. inlineCompletion before sign-in -> JSON-RPC error 1000 (NotSignedIn).
+    let uri = lsp::Url::parse("file:///tmp/helix-copilot-e2e.py").unwrap();
+    client.did_open(&uri, 1, "python", "def add(a, b):\n    ");
+    let err = client
+        .inline_completion(&uri, 1, 1, 4, FormattingOptions::default())
+        .await
+        .expect_err("expected NotSignedIn error before sign-in");
+    match &err {
+        Error::Rpc(rpc) => {
+            println!(
+                "[e2e] inlineCompletion pre-signin -> error {}: {}",
+                rpc.code.code(),
+                rpc.message
+            );
+            assert_eq!(rpc.code.code(), 1000, "expected error code 1000");
+        }
+        other => panic!("expected an RPC error, got: {other:?}"),
+    }
+
+    // 4. signIn -> a real device code the user could enter at the verification
+    //    URI. We stop here and never finish the device flow.
+    let sign_in = client.sign_in().await.expect("signIn failed");
+    println!("[e2e] signIn -> {sign_in:?}");
+    assert_eq!(sign_in.status, "PromptUserDeviceFlow");
+    assert!(sign_in.user_code.is_some(), "expected a device user code");
+    assert!(
+        sign_in.verification_uri.is_some(),
+        "expected a verification URI"
+    );
+    let command = sign_in
+        .command
+        .expect("expected a finishDeviceFlow command");
+    assert_eq!(command.command, "github.copilot.finishDeviceFlow");
+    println!(
+        "[e2e] device code {} at {} (NOT completing sign-in)",
+        sign_in.user_code.unwrap(),
+        sign_in.verification_uri.unwrap()
+    );
+}

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -4,6 +4,8 @@ pub(crate) mod syntax;
 pub(crate) mod typed;
 
 pub use dap::*;
+pub(crate) mod copilot;
+pub use copilot::*;
 use futures_util::FutureExt;
 use helix_event::status;
 use helix_stdx::{
@@ -616,6 +618,9 @@ impl MappableCommand {
         goto_prev_tabstop, "Goto next snippet placeholder",
         rotate_selections_first, "Make the first selection your primary one",
         rotate_selections_last, "Make the last selection your primary one",
+        copilot_request_completion, "Request a GitHub Copilot inline suggestion",
+        copilot_apply_completion, "Accept the active GitHub Copilot suggestion",
+        copilot_dismiss_completion, "Dismiss the active GitHub Copilot suggestion",
     );
 }
 

--- a/helix-term/src/commands/copilot.rs
+++ b/helix-term/src/commands/copilot.rs
@@ -391,12 +391,16 @@ fn store_suggestion(
         // ghost text after the cursor.
         let already_typed = cursor.saturating_sub(range.start);
         let ghost: String = item.insert_text.chars().skip(already_typed).collect();
-        let first_line = ghost.split('\n').next().unwrap_or("").to_string();
+        // The first line is rendered inline after the cursor; every subsequent
+        // line is rendered on its own virtual line below the cursor's line.
+        let mut lines = ghost.split('\n');
+        let first_line = lines.next().unwrap_or("").to_string();
         let display = if first_line.is_empty() {
             Vec::new()
         } else {
             vec![InlineAnnotation::new(cursor, first_line)]
         };
+        let ghost_lines: Vec<String> = lines.map(|line| line.to_string()).collect();
 
         let item_id = item_id(&item);
         doc.set_copilot_completion(CopilotCompletion {
@@ -406,6 +410,7 @@ fn store_suggestion(
             version: requested_version,
             text: item.insert_text,
             display,
+            ghost_lines,
             item_id,
         });
         true

--- a/helix-term/src/commands/copilot.rs
+++ b/helix-term/src/commands/copilot.rs
@@ -1,0 +1,417 @@
+//! Commands for the GitHub Copilot integration.
+//!
+//! Typed commands (`:copilot-signin`, `:copilot-signout`, `:copilot-status`,
+//! `:copilot-toggle`) drive the connection lifecycle. The bindable static
+//! commands (`copilot_request_completion`, `copilot_apply_completion`,
+//! `copilot_dismiss_completion`) request, accept and dismiss the inline ghost
+//! text suggestion stored on the focused [`Document`].
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use helix_core::command_line::Args;
+use helix_core::indent::IndentStyle;
+use helix_core::text_annotations::InlineAnnotation;
+use helix_core::{Selection, Tendril, Transaction};
+use helix_lsp::copilot::{self, FormattingOptions, InlineCompletionItem};
+use helix_lsp::OffsetEncoding;
+use helix_view::document::CopilotCompletion;
+use helix_view::{DocumentId, Editor, ViewId};
+
+use crate::compositor;
+use crate::job::{self, Callback};
+use crate::ui::PromptEvent;
+
+use super::Context;
+
+/// The position encoding Copilot expects (LSP defaults to UTF-16).
+const ENCODING: OffsetEncoding = OffsetEncoding::Utf16;
+
+fn editor_status(message: String) -> Callback {
+    Callback::Editor(Box::new(move |editor: &mut Editor| {
+        editor.set_status(message)
+    }))
+}
+
+/// Spawn (and initialize) the Copilot language server if it is not already
+/// running, returning a handle to the client. The started handle is stored on
+/// the editor so subsequent commands reuse it.
+async fn ensure_client(
+    existing: Option<Arc<copilot::Client>>,
+    command: String,
+    args: Vec<String>,
+    workspace: Option<std::path::PathBuf>,
+) -> Result<Arc<copilot::Client>> {
+    if let Some(client) = existing {
+        return Ok(client);
+    }
+
+    let client = copilot::Client::start(&command, &args)?;
+    client
+        .initialize(
+            "Helix",
+            helix_loader::VERSION_AND_GIT_HASH,
+            env!("CARGO_PKG_VERSION"),
+            workspace.as_deref(),
+        )
+        .await?;
+
+    let stored = client.clone();
+    job::dispatch(move |editor, _| editor.copilot.set_client(stored)).await;
+
+    Ok(client)
+}
+
+/// Snapshot of the editor configuration needed to reach the Copilot client.
+fn client_context(editor: &Editor) -> (Option<Arc<copilot::Client>>, String, Vec<String>) {
+    let config = editor.config();
+    (
+        editor.copilot.client(),
+        config.copilot.command.clone(),
+        config.copilot.args.clone(),
+    )
+}
+
+fn workspace() -> Option<std::path::PathBuf> {
+    Some(helix_loader::find_workspace().0)
+}
+
+// ---------------------------------------------------------------------------
+// Typed commands
+// ---------------------------------------------------------------------------
+
+pub fn copilot_signin(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let (existing, command, args) = client_context(cx.editor);
+    let workspace = workspace();
+
+    cx.jobs.callback(async move {
+        let client = ensure_client(existing, command, args, workspace).await?;
+
+        let status = client.check_status().await?;
+        if status.signed_in() {
+            let user = status.user.unwrap_or_default();
+            return Ok(Callback::Editor(Box::new(move |editor: &mut Editor| {
+                editor.copilot.signed_in = true;
+                editor.set_status(format!("Copilot: already signed in as {user}"));
+            })));
+        }
+
+        let response = client.sign_in().await?;
+        match response.status.as_str() {
+            "PromptUserDeviceFlow" => {
+                let code = response.user_code.unwrap_or_default();
+                let uri = response
+                    .verification_uri
+                    .unwrap_or_else(|| "https://github.com/login/device".to_string());
+
+                // Wait for the user to authorize the device code in the
+                // background; this resolves only once they finish (or it times
+                // out). It is reversible until the user actually authorizes.
+                let waiter = client.clone();
+                tokio::spawn(async move {
+                    match waiter.finish_device_flow().await {
+                        Ok(_) => {
+                            job::dispatch(|editor, _| {
+                                editor.copilot.signed_in = true;
+                                editor.set_status("Copilot: signed in");
+                            })
+                            .await;
+                        }
+                        Err(err) => {
+                            job::dispatch(move |editor, _| {
+                                editor.set_error(format!("Copilot sign-in failed: {err}"));
+                            })
+                            .await;
+                        }
+                    }
+                });
+
+                Ok(editor_status(format!(
+                    "Copilot: open {uri} and enter code {code}"
+                )))
+            }
+            "AlreadySignedIn" => Ok(Callback::Editor(Box::new(|editor: &mut Editor| {
+                editor.copilot.signed_in = true;
+                editor.set_status("Copilot: already signed in");
+            }))),
+            other => Ok(editor_status(format!(
+                "Copilot: unexpected sign-in status '{other}'"
+            ))),
+        }
+    });
+
+    Ok(())
+}
+
+pub fn copilot_signout(
+    cx: &mut compositor::Context,
+    _args: Args,
+    event: PromptEvent,
+) -> Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let (existing, command, args) = client_context(cx.editor);
+    let workspace = workspace();
+
+    cx.jobs.callback(async move {
+        let client = ensure_client(existing, command, args, workspace).await?;
+        client.sign_out().await?;
+        Ok(Callback::Editor(Box::new(|editor: &mut Editor| {
+            editor.copilot.signed_in = false;
+            editor.set_status("Copilot: signed out");
+        })))
+    });
+
+    Ok(())
+}
+
+pub fn copilot_status(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let (existing, command, args) = client_context(cx.editor);
+    let enabled = cx.editor.copilot.enabled;
+    let workspace = workspace();
+
+    cx.jobs.callback(async move {
+        let client = ensure_client(existing, command, args, workspace).await?;
+        let status = client.check_status().await?;
+        let signed_in = status.signed_in();
+        let state = if enabled { "enabled" } else { "disabled" };
+        let message = if signed_in {
+            let user = status.user.unwrap_or_default();
+            format!("Copilot: signed in as {user} ({state})")
+        } else {
+            format!("Copilot: not signed in ({state}, run :copilot-signin)")
+        };
+
+        Ok(Callback::Editor(Box::new(move |editor: &mut Editor| {
+            editor.copilot.signed_in = signed_in;
+            editor.set_status(message);
+        })))
+    });
+
+    Ok(())
+}
+
+pub fn copilot_toggle(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> Result<()> {
+    if event != PromptEvent::Validate {
+        return Ok(());
+    }
+
+    let enabled = !cx.editor.copilot.enabled;
+    cx.editor.copilot.enabled = enabled;
+
+    if !enabled {
+        // Clear any visible suggestion in the focused document.
+        let doc = doc_mut!(cx.editor);
+        doc.clear_copilot_completion();
+        cx.editor.set_status("Copilot: disabled");
+        return Ok(());
+    }
+
+    cx.editor.set_status("Copilot: enabled");
+
+    // Eagerly start the server so the first suggestion is fast.
+    if cx.editor.copilot.client().is_none() {
+        let (existing, command, args) = client_context(cx.editor);
+        let workspace = workspace();
+        cx.jobs.callback(async move {
+            ensure_client(existing, command, args, workspace).await?;
+            Ok(editor_status("Copilot: ready".to_string()))
+        });
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Static (bindable) commands
+// ---------------------------------------------------------------------------
+
+/// Request an inline suggestion for the focused document at the cursor.
+pub fn copilot_request_completion(cx: &mut Context) {
+    if !cx.editor.copilot.enabled {
+        cx.editor
+            .set_status("Copilot is disabled (run :copilot-toggle to enable)");
+        return;
+    }
+
+    let (existing, command, args) = client_context(cx.editor);
+    let workspace = workspace();
+
+    let (view, doc) = current!(cx.editor);
+    let Some(uri) = doc.url() else {
+        cx.editor
+            .set_status("Copilot: the buffer must be saved to disk first");
+        return;
+    };
+
+    let view_id = view.id;
+    let doc_id = doc.id();
+    let version = doc.version();
+    let text = doc.text();
+    let cursor = doc.selection(view_id).primary().cursor(text.slice(..));
+    let lsp_pos = helix_lsp::util::pos_to_lsp_pos(text, cursor, ENCODING);
+    let full_text = text.to_string();
+    let language_id = doc.language_id().unwrap_or("plaintext").to_string();
+    let formatting = FormattingOptions {
+        tab_size: doc.tab_width() as u32,
+        insert_spaces: matches!(doc.indent_style, IndentStyle::Spaces(_)),
+    };
+    let was_open = cx.editor.copilot.is_open(doc_id);
+
+    cx.jobs.callback(async move {
+        let client = ensure_client(existing, command, args, workspace).await?;
+
+        if was_open {
+            client.did_change(&uri, version, &full_text);
+        } else {
+            client.did_open(&uri, version, &language_id, &full_text);
+            job::dispatch(move |editor, _| editor.copilot.mark_open(doc_id)).await;
+        }
+
+        let items = match client
+            .inline_completion(&uri, version, lsp_pos.line, lsp_pos.character, formatting)
+            .await
+        {
+            Ok(items) => items,
+            Err(helix_lsp::Error::Rpc(err)) if err.code.code() == 1000 => {
+                return Ok(editor_status(
+                    "Copilot: not signed in (run :copilot-signin)".to_string(),
+                ));
+            }
+            Err(err) => return Err(err.into()),
+        };
+
+        let Some(item) = items.into_iter().next() else {
+            return Ok(editor_status("Copilot: no suggestion".to_string()));
+        };
+
+        if let Some(id) = item_id(&item) {
+            client.notify_shown(&id);
+        }
+
+        Ok(Callback::Editor(Box::new(move |editor: &mut Editor| {
+            store_suggestion(editor, doc_id, view_id, cursor, version, item);
+        })))
+    });
+}
+
+/// Accept the active inline suggestion, inserting its text.
+pub fn copilot_apply_completion(cx: &mut Context) {
+    let accepted = {
+        let (view, doc) = current!(cx.editor);
+        let Some(completion) = doc.copilot_completion().cloned() else {
+            return;
+        };
+        if completion.view_id != view.id {
+            return;
+        }
+        doc.clear_copilot_completion();
+
+        let new_cursor = completion.range.start + completion.text.chars().count();
+        let transaction = Transaction::change(
+            doc.text(),
+            std::iter::once((
+                completion.range.start,
+                completion.range.end,
+                Some(Tendril::from(completion.text)),
+            )),
+        )
+        .with_selection(Selection::point(new_cursor));
+        doc.apply(&transaction, view.id);
+
+        completion.item_id
+    };
+
+    if let (Some(id), Some(client)) = (accepted, cx.editor.copilot.client()) {
+        client.notify_accepted(&id);
+    }
+}
+
+/// Dismiss the active inline suggestion without inserting it.
+pub fn copilot_dismiss_completion(cx: &mut Context) {
+    let doc = doc_mut!(cx.editor);
+    doc.clear_copilot_completion();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn item_id(item: &InlineCompletionItem) -> Option<String> {
+    item.command
+        .as_ref()
+        .and_then(|command| command.arguments.as_ref())
+        .and_then(|arguments| arguments.first())
+        .and_then(|argument| argument.as_str())
+        .map(|id| id.to_string())
+}
+
+/// Store a returned suggestion as ghost text on the document, provided it is
+/// still up to date.
+fn store_suggestion(
+    editor: &mut Editor,
+    doc_id: DocumentId,
+    view_id: ViewId,
+    cursor: usize,
+    requested_version: i32,
+    item: InlineCompletionItem,
+) {
+    let stored = {
+        let Some(doc) = editor.documents.get_mut(&doc_id) else {
+            return;
+        };
+        // Discard stale suggestions if the buffer changed in the meantime.
+        if doc.version() != requested_version {
+            return;
+        }
+
+        let text = doc.text();
+        let range = match item.range {
+            Some(range) => {
+                let start =
+                    helix_lsp::util::lsp_pos_to_pos(text, range.start, ENCODING).unwrap_or(cursor);
+                let end =
+                    helix_lsp::util::lsp_pos_to_pos(text, range.end, ENCODING).unwrap_or(cursor);
+                start..end
+            }
+            None => cursor..cursor,
+        };
+
+        // The portion of the suggestion that has not been typed yet, shown as
+        // ghost text after the cursor.
+        let already_typed = cursor.saturating_sub(range.start);
+        let ghost: String = item.insert_text.chars().skip(already_typed).collect();
+        let first_line = ghost.split('\n').next().unwrap_or("").to_string();
+        let display = if first_line.is_empty() {
+            Vec::new()
+        } else {
+            vec![InlineAnnotation::new(cursor, first_line)]
+        };
+
+        let item_id = item_id(&item);
+        doc.set_copilot_completion(CopilotCompletion {
+            view_id,
+            anchor: cursor,
+            range,
+            version: requested_version,
+            text: item.insert_text,
+            display,
+            item_id,
+        });
+        true
+    };
+
+    if stored {
+        editor.needs_redraw = true;
+    }
+}

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -4108,6 +4108,38 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
         fun: exclude_workspace,
         completer: CommandCompleter::none(),
         signature: Signature { positionals: (0, None), ..Signature::DEFAULT },
+    },
+    TypableCommand {
+        name: "copilot-signin",
+        aliases: &[],
+        doc: "Sign in to GitHub Copilot, showing the device code to enter in the browser.",
+        fun: copilot_signin,
+        completer: CommandCompleter::none(),
+        signature: Signature { positionals: (0, Some(0)), ..Signature::DEFAULT },
+    },
+    TypableCommand {
+        name: "copilot-signout",
+        aliases: &[],
+        doc: "Sign out of GitHub Copilot.",
+        fun: copilot_signout,
+        completer: CommandCompleter::none(),
+        signature: Signature { positionals: (0, Some(0)), ..Signature::DEFAULT },
+    },
+    TypableCommand {
+        name: "copilot-status",
+        aliases: &[],
+        doc: "Show the GitHub Copilot sign-in and enabled status.",
+        fun: copilot_status,
+        completer: CommandCompleter::none(),
+        signature: Signature { positionals: (0, Some(0)), ..Signature::DEFAULT },
+    },
+    TypableCommand {
+        name: "copilot-toggle",
+        aliases: &[],
+        doc: "Toggle GitHub Copilot inline suggestions on or off.",
+        fun: copilot_toggle,
+        completer: CommandCompleter::none(),
+        signature: Signature { positionals: (0, Some(0)), ..Signature::DEFAULT },
     }
 ];
 

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -395,6 +395,10 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
         "tab" => smart_tab,
         "S-tab" => insert_tab,
 
+        "A-c" => copilot_request_completion,
+        "A-l" => copilot_apply_completion,
+        "A-x" => copilot_dismiss_completion,
+
         "up" => move_visual_line_up,
         "down" => move_visual_line_down,
         "left" => move_char_left,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -205,6 +205,11 @@ impl EditorView {
             inline_diagnostic_config,
             config.end_of_line_diagnostics,
         ));
+        if is_focused {
+            if let Some(copilot) = text_decorations::InlineCopilot::new(doc, theme, view.id) {
+                decorations.add_decoration(copilot);
+            }
+        }
         render_document(
             surface,
             inner,

--- a/helix-term/src/ui/text_decorations.rs
+++ b/helix-term/src/ui/text_decorations.rs
@@ -8,6 +8,9 @@ use crate::ui::document::{LinePos, TextRenderer};
 
 pub use diagnostics::InlineDiagnostics;
 
+pub use copilot::InlineCopilot;
+
+mod copilot;
 mod diagnostics;
 
 /// Decorations are the primary mechanism for extending the text rendering.

--- a/helix-term/src/ui/text_decorations/copilot.rs
+++ b/helix-term/src/ui/text_decorations/copilot.rs
@@ -1,0 +1,111 @@
+use helix_core::doc_formatter::FormattedGrapheme;
+use helix_core::Position;
+
+use helix_view::theme::Style;
+use helix_view::{Document, Theme, ViewId};
+
+use crate::ui::document::{LinePos, TextRenderer};
+use crate::ui::text_decorations::Decoration;
+
+/// Draws the multi-line portion of a Copilot ghost text suggestion.
+///
+/// The first line of the suggestion is rendered inline after the cursor via an
+/// `InlineAnnotation`; this decoration paints every subsequent line onto the
+/// virtual lines reserved by
+/// [`CopilotGhostText`](helix_view::annotations::copilot::CopilotGhostText)
+/// directly below the cursor's document line. Each line is drawn verbatim so its
+/// own leading whitespace/indentation is preserved.
+pub struct InlineCopilot<'a> {
+    cursor: usize,
+    lines: &'a [String],
+    style: Style,
+    anchored: bool,
+}
+
+impl<'a> InlineCopilot<'a> {
+    pub fn new(doc: &'a Document, theme: &Theme, view_id: ViewId) -> Option<Self> {
+        let completion = doc
+            .copilot_completion()
+            .filter(|completion| completion.view_id == view_id)?;
+        if completion.ghost_lines.is_empty() {
+            return None;
+        }
+        let highlight = theme
+            .find_highlight("ui.virtual.copilot")
+            .or_else(|| theme.find_highlight("ui.virtual.inlay-hint"));
+        let style = match highlight {
+            Some(highlight) => theme.get("ui.text").patch(theme.highlight(highlight)),
+            None => theme.get("ui.text"),
+        };
+        Some(InlineCopilot {
+            cursor: completion.anchor,
+            lines: &completion.ghost_lines,
+            style,
+            anchored: false,
+        })
+    }
+}
+
+impl Decoration for InlineCopilot<'_> {
+    fn reset_pos(&mut self, pos: usize) -> usize {
+        self.anchored = false;
+        if self.cursor >= pos {
+            self.cursor
+        } else {
+            usize::MAX
+        }
+    }
+
+    fn skip_concealed_anchor(&mut self, conceal_end_char_idx: usize) -> usize {
+        if self.cursor >= conceal_end_char_idx {
+            self.cursor
+        } else {
+            usize::MAX
+        }
+    }
+
+    fn decorate_grapheme(
+        &mut self,
+        _renderer: &mut TextRenderer,
+        grapheme: &FormattedGrapheme,
+    ) -> usize {
+        if grapheme.char_idx == self.cursor {
+            self.anchored = true;
+        }
+        usize::MAX
+    }
+
+    fn render_virt_lines(
+        &mut self,
+        renderer: &mut TextRenderer,
+        pos: LinePos,
+        virt_off: Position,
+    ) -> Position {
+        if !self.anchored {
+            return Position::new(0, 0);
+        }
+        self.anchored = false;
+
+        let first_row = pos.visual_line as usize + virt_off.row;
+        let width = renderer.viewport.width as usize;
+        let max_row = renderer.offset.row + renderer.viewport.height as usize;
+        for (i, line) in self.lines.iter().enumerate() {
+            let row = first_row + i;
+            // Skip lines that fall outside the visible viewport so very tall
+            // suggestions never draw past the text area (and never overflow).
+            if row < renderer.offset.row || row >= max_row {
+                continue;
+            }
+            renderer.set_string_truncated(
+                renderer.viewport.x,
+                row as u16,
+                line,
+                width,
+                |_| self.style,
+                false,
+                false,
+            );
+        }
+        Position::new(self.lines.len(), 0)
+    }
+}

--- a/helix-view/src/annotations.rs
+++ b/helix-view/src/annotations.rs
@@ -1,1 +1,2 @@
+pub mod copilot;
 pub mod diagnostics;

--- a/helix-view/src/annotations/copilot.rs
+++ b/helix-view/src/annotations/copilot.rs
@@ -1,0 +1,74 @@
+use helix_core::doc_formatter::FormattedGrapheme;
+use helix_core::text_annotations::LineAnnotation;
+use helix_core::Position;
+
+/// Reserves vertical space for the multi-line portion of a Copilot ghost text
+/// suggestion.
+///
+/// The first line of the suggestion is rendered inline after the cursor via an
+/// [`InlineAnnotation`](helix_core::text_annotations::InlineAnnotation); every
+/// subsequent line is drawn on its own virtual line below the cursor's document
+/// line. This `LineAnnotation` only reserves the empty space for those lines;
+/// the matching decoration in `helix-term` fills it in. The two are kept in sync
+/// by anchoring on the same cursor char index.
+pub struct CopilotGhostText {
+    /// The char index the suggestion is anchored at (the cursor at request time).
+    cursor: usize,
+    /// The number of virtual lines to reserve (the suggestion lines after the
+    /// first).
+    lines: usize,
+    /// Whether the cursor anchor has been seen on the visual line currently
+    /// being laid out.
+    anchored: bool,
+}
+
+impl CopilotGhostText {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new<'a>(cursor: usize, lines: usize) -> Box<dyn LineAnnotation + 'a> {
+        Box::new(CopilotGhostText {
+            cursor,
+            lines,
+            anchored: false,
+        })
+    }
+}
+
+impl LineAnnotation for CopilotGhostText {
+    fn reset_pos(&mut self, char_idx: usize) -> usize {
+        self.anchored = false;
+        if self.cursor >= char_idx {
+            self.cursor
+        } else {
+            usize::MAX
+        }
+    }
+
+    fn skip_concealed_anchors(&mut self, conceal_end_char_idx: usize) -> usize {
+        if self.cursor >= conceal_end_char_idx {
+            self.cursor
+        } else {
+            usize::MAX
+        }
+    }
+
+    fn process_anchor(&mut self, grapheme: &FormattedGrapheme) -> usize {
+        if grapheme.char_idx == self.cursor {
+            self.anchored = true;
+        }
+        usize::MAX
+    }
+
+    fn insert_virtual_lines(
+        &mut self,
+        _line_end_char_idx: usize,
+        _line_end_visual_pos: Position,
+        _doc_line: usize,
+    ) -> Position {
+        if self.anchored {
+            self.anchored = false;
+            Position::new(self.lines, 0)
+        } else {
+            Position::new(0, 0)
+        }
+    }
+}

--- a/helix-view/src/copilot.rs
+++ b/helix-view/src/copilot.rs
@@ -1,0 +1,77 @@
+//! Editor-level state for the GitHub Copilot integration.
+//!
+//! The heavy lifting (the protocol) lives in [`helix_lsp::copilot`]. This module
+//! only holds the running client handle and a little bit of session state so the
+//! editor, commands and rendering code can reach it. The active inline
+//! suggestion itself is stored per-[`Document`](crate::Document) as
+//! [`CopilotCompletion`](crate::document::CopilotCompletion) so it can be
+//! rendered as ghost text alongside the other text annotations.
+
+use std::sync::Arc;
+
+use helix_lsp::copilot::Client;
+
+use crate::DocumentId;
+
+/// Tracks the lifecycle of the Copilot connection for the editor.
+#[derive(Default)]
+pub struct Copilot {
+    /// The running, initialized Copilot client, if one has been started.
+    client: Option<Arc<Client>>,
+    /// Runtime on/off toggle (`:copilot-toggle`). Initialized from
+    /// `editor.copilot.enable`.
+    pub enabled: bool,
+    /// Whether the user is known to be signed in. Best-effort: updated after
+    /// `checkStatus`/`signIn` round-trips.
+    pub signed_in: bool,
+    /// Documents that have been `didOpen`ed with the Copilot server, so we can
+    /// send `didChange` afterwards.
+    opened: std::collections::HashSet<DocumentId>,
+}
+
+impl Copilot {
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            client: None,
+            enabled,
+            signed_in: false,
+            opened: std::collections::HashSet::new(),
+        }
+    }
+
+    /// The running client handle, if Copilot has been started.
+    pub fn client(&self) -> Option<Arc<Client>> {
+        self.client.clone()
+    }
+
+    /// Whether a client has been started and initialized.
+    pub fn is_running(&self) -> bool {
+        self.client.is_some()
+    }
+
+    /// Store the started client handle.
+    pub fn set_client(&mut self, client: Arc<Client>) {
+        self.client = Some(client);
+    }
+
+    /// Drop the client handle (e.g. on `:copilot-toggle` off or shutdown).
+    pub fn take_client(&mut self) -> Option<Arc<Client>> {
+        self.opened.clear();
+        self.client.take()
+    }
+
+    /// Whether the given document has already been opened with the server.
+    pub fn is_open(&self, doc: DocumentId) -> bool {
+        self.opened.contains(&doc)
+    }
+
+    /// Record that the given document has been opened with the server.
+    pub fn mark_open(&mut self, doc: DocumentId) {
+        self.opened.insert(doc);
+    }
+
+    /// Forget that a document was opened (e.g. when it is closed).
+    pub fn forget(&mut self, doc: DocumentId) {
+        self.opened.remove(&doc);
+    }
+}

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -331,9 +331,10 @@ pub struct DocumentInlayHintsId {
 /// A GitHub Copilot inline suggestion held by a [`Document`].
 ///
 /// The full multi-line [`text`](Self::text) is what gets inserted (over
-/// [`range`](Self::range)) when the suggestion is accepted, while
-/// [`display`](Self::display) holds the inline annotation(s) used to render the
-/// ghost text after the cursor.
+/// [`range`](Self::range)) when the suggestion is accepted. The preview is split
+/// across [`display`](Self::display), which renders the first line inline after
+/// the cursor, and [`ghost_lines`](Self::ghost_lines), which renders every
+/// subsequent line on its own virtual line below the cursor's document line.
 #[derive(Debug, Clone)]
 pub struct CopilotCompletion {
     /// The view the suggestion was requested for.
@@ -346,8 +347,13 @@ pub struct CopilotCompletion {
     pub version: i32,
     /// The full suggestion text inserted on accept.
     pub text: String,
-    /// Inline annotations used to render the ghost text preview.
+    /// Inline annotations used to render the ghost text preview. This holds the
+    /// first line of the suggestion, shown inline after the cursor.
     pub display: Vec<InlineAnnotation>,
+    /// The remaining ghost lines (everything after the first line), each shown
+    /// on its own virtual line below the cursor's document line. Each entry
+    /// already contains its own leading whitespace/indentation.
+    pub ghost_lines: Vec<String>,
     /// Opaque identifier used for accept/shown telemetry, if provided.
     pub item_id: Option<String>,
 }

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -159,6 +159,9 @@ pub struct Document {
     /// update from the LSP
     pub inlay_hints_oudated: bool,
 
+    /// The active GitHub Copilot inline suggestion (ghost text), if any.
+    pub(crate) copilot: Option<CopilotCompletion>,
+
     path: Option<PathBuf>,
     relative_path: OnceCell<Option<PathBuf>>,
     /// Lazily-computed workspace root for this document (the ancestor that contains a `.git` /
@@ -323,6 +326,30 @@ pub struct DocumentInlayHintsId {
     pub first_line: usize,
     /// Last line for which the inlay hints were requested.
     pub last_line: usize,
+}
+
+/// A GitHub Copilot inline suggestion held by a [`Document`].
+///
+/// The full multi-line [`text`](Self::text) is what gets inserted (over
+/// [`range`](Self::range)) when the suggestion is accepted, while
+/// [`display`](Self::display) holds the inline annotation(s) used to render the
+/// ghost text after the cursor.
+#[derive(Debug, Clone)]
+pub struct CopilotCompletion {
+    /// The view the suggestion was requested for.
+    pub view_id: ViewId,
+    /// The char index of the cursor at request time (where the ghost text is anchored).
+    pub anchor: usize,
+    /// The char range that is replaced when the suggestion is accepted.
+    pub range: std::ops::Range<usize>,
+    /// The document version the suggestion was requested against.
+    pub version: i32,
+    /// The full suggestion text inserted on accept.
+    pub text: String,
+    /// Inline annotations used to render the ghost text preview.
+    pub display: Vec<InlineAnnotation>,
+    /// Opaque identifier used for accept/shown telemetry, if provided.
+    pub item_id: Option<String>,
 }
 
 use std::{fmt, mem};
@@ -742,6 +769,7 @@ impl Document {
             selections: HashMap::default(),
             inlay_hints: HashMap::default(),
             inlay_hints_oudated: false,
+            copilot: None,
             view_data: Default::default(),
             indent_style: DEFAULT_INDENT,
             editor_config: EditorConfig::default(),
@@ -1580,6 +1608,8 @@ impl Document {
         };
 
         self.inlay_hints_oudated = true;
+        // Any edit invalidates the current Copilot suggestion.
+        self.copilot = None;
         for text_annotation in self.inlay_hints.values_mut() {
             let DocumentInlayHints {
                 id: _,
@@ -2486,6 +2516,21 @@ impl Document {
     /// (since it often means inlay hints have been fully deactivated).
     pub fn reset_all_inlay_hints(&mut self) {
         self.inlay_hints = Default::default();
+    }
+
+    /// The active Copilot inline suggestion, if any.
+    pub fn copilot_completion(&self) -> Option<&CopilotCompletion> {
+        self.copilot.as_ref()
+    }
+
+    /// Store a Copilot inline suggestion to be rendered as ghost text.
+    pub fn set_copilot_completion(&mut self, completion: CopilotCompletion) {
+        self.copilot = Some(completion);
+    }
+
+    /// Clear any active Copilot inline suggestion. Returns the removed suggestion.
+    pub fn clear_copilot_completion(&mut self) -> Option<CopilotCompletion> {
+        self.copilot.take()
     }
 
     pub fn has_language_server_with_feature(&self, feature: LanguageServerFeature) -> bool {

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -434,6 +434,8 @@ pub struct Config {
     pub buffer_picker: BufferPickerConfig,
     /// Workspace-trust configuration.
     pub workspace_trust: WorkspaceTrustConfig,
+    /// GitHub Copilot configuration.
+    pub copilot: CopilotConfig,
 }
 
 /// User-facing configuration for `[editor.workspace-trust]`.
@@ -456,6 +458,33 @@ impl Default for WorkspaceTrustConfig {
             level: ImplicitTrustLevelConfig::default(),
             prompt: true,
             trusted: Vec::new(),
+        }
+    }
+}
+
+/// User-facing configuration for `[editor.copilot]`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case", deny_unknown_fields)]
+pub struct CopilotConfig {
+    /// Whether the Copilot integration is enabled. Defaults to `false`.
+    pub enable: bool,
+    /// Command used to launch the Copilot language server. Defaults to
+    /// `copilot-language-server` (resolved on `PATH`).
+    pub command: String,
+    /// Arguments passed to the Copilot language server. Defaults to `["--stdio"]`.
+    pub args: Vec<String>,
+    /// Automatically request a suggestion a short while after typing stops.
+    /// Defaults to `true`.
+    pub auto: bool,
+}
+
+impl Default for CopilotConfig {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            command: "copilot-language-server".to_string(),
+            args: vec!["--stdio".to_string()],
+            auto: true,
         }
     }
 }
@@ -1240,6 +1269,7 @@ impl Default for Config {
             kitty_keyboard_protocol: Default::default(),
             buffer_picker: BufferPickerConfig::default(),
             workspace_trust: WorkspaceTrustConfig::default(),
+            copilot: CopilotConfig::default(),
         }
     }
 }
@@ -1343,6 +1373,8 @@ pub struct Editor {
     pub mouse_down_range: Option<Range>,
     pub cursor_cache: CursorCache,
     pub workspace_trust: WorkspaceTrust,
+    /// GitHub Copilot session state (the running client and toggle).
+    pub copilot: crate::copilot::Copilot,
 }
 
 pub type Motion = Box<dyn Fn(&mut Editor)>;
@@ -1421,6 +1453,7 @@ impl Editor {
         let language_servers = helix_lsp::Registry::new(syn_loader.clone());
         let conf = config.load();
         let auto_pairs = (&conf.auto_pairs).into();
+        let copilot = crate::copilot::Copilot::new(conf.copilot.enable);
 
         // HAXX: offset the render area height by 1 to account for prompt/commandline
         area.height -= 1;
@@ -1468,6 +1501,7 @@ impl Editor {
             cursor_cache: CursorCache::default(),
             dir_stack: VecDeque::with_capacity(DIR_STACK_CAP),
             workspace_trust,
+            copilot,
         }
     }
 

--- a/helix-view/src/lib.rs
+++ b/helix-view/src/lib.rs
@@ -4,6 +4,7 @@ pub mod macros;
 pub mod action;
 pub mod annotations;
 pub mod clipboard;
+pub mod copilot;
 pub mod document;
 pub mod editor;
 pub mod events;

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -491,6 +491,18 @@ impl View {
                 .add_inline_annotations(other_inlay_hints, other_style)
                 .add_inline_annotations(padding_after_inlay_hints, None);
         };
+
+        // Copilot inline suggestion (ghost text) rendered after the cursor.
+        if let Some(copilot) = doc
+            .copilot_completion()
+            .filter(|copilot| copilot.view_id == self.id)
+        {
+            let style = theme.and_then(|t| t.find_highlight("ui.virtual.copilot"));
+            let style =
+                style.or_else(|| theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint")));
+            text_annotations.add_inline_annotations(&copilot.display, style);
+        }
+
         let config = doc.config.load();
 
         if config.lsp.display_color_swatches {

--- a/helix-view/src/view.rs
+++ b/helix-view/src/view.rs
@@ -1,5 +1,6 @@
 use crate::{
     align_view,
+    annotations::copilot::CopilotGhostText,
     annotations::diagnostics::InlineDiagnostics,
     document::{DocumentColorSwatches, DocumentInlayHints},
     editor::{GutterConfig, GutterType},
@@ -501,6 +502,15 @@ impl View {
             let style =
                 style.or_else(|| theme.and_then(|t| t.find_highlight("ui.virtual.inlay-hint")));
             text_annotations.add_inline_annotations(&copilot.display, style);
+
+            // Reserve the virtual lines below the cursor line for the remaining
+            // suggestion lines; the matching decoration draws their contents.
+            if !copilot.ghost_lines.is_empty() {
+                text_annotations.add_line_annotation(CopilotGhostText::new(
+                    copilot.anchor,
+                    copilot.ghost_lines.len(),
+                ));
+            }
         }
 
         let config = doc.config.load();

--- a/theme.toml
+++ b/theme.toml
@@ -63,6 +63,8 @@ tabstop = { modifiers = ["italic"], bg = "bossanova" }
 
 "ui.virtual.indent-guide" = { fg = "comet" }
 
+"ui.virtual.copilot" = { fg = "comet", modifiers = ["italic"] }
+
 "ui.selection" = { bg = "#540099" }
 "ui.selection.primary" = { bg = "#540099" }
 # TODO: namespace ui.cursor as ui.selection.cursor?


### PR DESCRIPTION
## Summary
- add an opt-in GitHub Copilot inline completion client using copilot-language-server
- add commands for sign-in, sign-out, status, toggle, request, accept, and dismiss
- render Copilot suggestions as ghost text, with the first line inline after the cursor and the remaining lines as virtual lines below, so multi-line suggestions are shown in full before they are accepted
- document the configuration and keybindings

## Testing
- cargo fmt --all --check
- cargo build -p helix-term
- cargo test -p helix-lsp --test copilot
- cargo test -p helix-view --lib copilot
- HELIX_COPILOT_BIN=/path/to/copilot-language-server cargo test -p helix-lsp --test copilot -- --ignored --nocapture
- verified end to end against a signed-in copilot-language-server: requesting shows the full multi-line ghost text, accepting inserts exactly what is shown, and dismissing clears it