### PR TITLE
fix(indent): add missing JS block indents to QML query

### DIFF
--- a/helix-core/tests/data/indent/indent.qml
+++ b/helix-core/tests/data/indent/indent.qml
@@ -1,0 +1,24 @@
+import QtQuick
+
+Item {
+    id: root
+
+    property int count: 0
+
+    function compute(a, b) {
+        var result = {
+            sum: a + b,
+            diff: a - b
+        }
+        var { sum, diff } = result
+        return sum + diff
+    }
+
+    Connections {
+        target: Hyprland
+
+        function onRawEvent() {
+            root.count += 1
+        }
+    }
+}

--- a/helix-core/tests/data/indent/languages.toml
+++ b/helix-core/tests/data/indent/languages.toml
@@ -24,3 +24,17 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "cpp"
 source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "2d2c4aee8672af4c7c8edff68e7dd4c07e88d2b1" }
+
+[[language]]
+name = "qml"
+scope = "source.qml"
+injection-regex = "qml"
+file-types = ["qml"]
+roots = []
+comment-token = "//"
+indent = { tab-width = 4, unit = "    " }
+grammar = "qmljs"
+
+[[grammar]]
+name = "qmljs"
+source = { git = "https://github.com/yuja/tree-sitter-qmljs", rev = "0b2b25bcaa7d4925d5f0dda16f6a99c588a437f1" }

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -112,6 +112,12 @@ fn test_treesitter_indent_rust_helix() {
 }
 
 #[test]
+fn test_treesitter_indent_qml() {
+    let doc = Rope::from_str(include_str!("data/indent/indent.qml"));
+    test_treesitter_indent("indent.qml", doc, "source.qml", Vec::new());
+}
+
+#[test]
 fn test_indent_level_for_line_with_spaces() {
     let tab_width: usize = 4;
     let indent_width: usize = 4;

--- a/runtime/queries/qml/indents.scm
+++ b/runtime/queries/qml/indents.scm
@@ -1,6 +1,10 @@
 [
   (enum_body)
   (ui_object_initializer)
+
+  (statement_block)
+  (object)
+  (object_pattern)
 ] @indent
 
 "}" @outdent


### PR DESCRIPTION
The QML indent query only captured \`(enum_body)\` and \`(ui_object_initializer)\`, so JS constructs embedded in QML — function bodies, object literals and object destructuring patterns — were not indented at all.

Typing a newline inside a function body left the body and its closing brace at the wrong column:

```qml
function onRawEvent() {
root.count += 1
}
```

instead of:

```qml
function onRawEvent() {
    root.count += 1
}
```

### Fix

Add `(statement_block)`, `(object)` and `(object_pattern)` to the `@indent` list in `runtime/queries/qml/indents.scm`. All three are `{`…`}` delimited, so the existing `"}" @outdent` already balances them. All three node names exist in the `qmljs` grammar (they are already referenced by the QML `injections.scm` / `textobjects.scm` queries).

I deliberately left the more opinionated JS blocks (`switch_body`, `class_body`) out — switch-case indentation style is contested and not what this issue is about.

### Test

Registered QML in the indent test harness (`helix-core/tests/data/indent/languages.toml` + a fixture) and added `test_treesitter_indent_qml`, which validates a correctly-indented QML file line-by-line against the query. The test fails on the old query (function-body line suggested at column 4 instead of 8) and passes with the fix.

Closes #15847