### PR TITLE
markdown-inline: Highlighting of inline math equations

### DIFF
--- a/runtime/queries/markdown.inline/injections.scm
+++ b/runtime/queries/markdown.inline/injections.scm
@@ -4,4 +4,4 @@
   (#set! injection.include-unnamed-children)
   (#set! injection.combined))
 
-((latex_block) @injection.content (#set! injection.language "latex") (#set! injection.include-unnamed-children))
+((latex_block) @injection.content (#set! injection.language "latex") (#set! injection.include-children))


### PR DESCRIPTION
This PR fixes math equation highlighting in inline markdown as described in #15922. 

Closes #15922 

Test: 
1. `echo 'some text $E=mc^2$ more text' > test.md`
2. the inline math equation should be highlighted (as it is when in a `.tex` file)