### PR TITLE
use the correct comment tokens for svelte

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1648,8 +1648,7 @@ scope = "source.svelte"
 injection-regex = "svelte"
 file-types = ["svelte"]
 indent = { tab-width = 2, unit = "  " }
-comment-token = "//"
-block-comment-tokens = { start = "/*", end = "*/" }
+block-comment-tokens = { start = "<!--", end = "-->" }
 language-servers = [ "svelteserver" ]
 
 [[grammar]]


### PR DESCRIPTION
as svelte is an html dsl, it uses the comment tokens for html (`<!--`, `-->`). since 5590a21a1 it now correctly uses the `//` (and `/*` `*/`) tokens in the javascript body, so it only makes sense to be able to properly comment out the components as well.