### PR TITLE
docs: document desktop integration setup

### DIFF
--- a/book/src/install.md
+++ b/book/src/install.md
@@ -22,3 +22,26 @@ To set up Helix:
 2. Copy the `runtime` directory to a location that `hx` searches for runtime files. A typical location on Linux/macOS is `~/.config/helix/runtime`.
 
 To see the runtime directories that `hx` searches, run `hx --health`. If necessary, you can override the default runtime location by setting the `HELIX_RUNTIME` environment variable.
+
+## Desktop integration
+
+The source tree includes optional desktop menu and shell completion files under
+`contrib/`. To make Helix available from an XDG desktop menu, install
+`contrib/Helix.desktop` and the icon as described in
+[Configure the desktop shortcut](./building-from-source.md#configure-the-desktop-shortcut).
+
+Shell completion scripts are available for Bash, Elvish, Fish, Nushell, and Zsh
+in `contrib/completion/`. For common shell layouts:
+
+```sh
+mkdir -p ~/.local/share/bash-completion/completions
+cp contrib/completion/hx.bash ~/.local/share/bash-completion/completions/hx
+
+mkdir -p ~/.config/fish/completions
+cp contrib/completion/hx.fish ~/.config/fish/completions/hx.fish
+
+mkdir -p ~/.zfunc
+cp contrib/completion/hx.zsh ~/.zfunc/_hx
+```
+
+For Zsh, make sure `~/.zfunc` is included in `fpath` before `compinit` runs.


### PR DESCRIPTION
Closes #3605.

## Summary

- add a desktop integration section to the install page
- link the existing desktop shortcut instructions
- show common shell completion install paths for Bash, Fish, and Zsh

## Validation

- `git diff --check`
- source guard for the new install-page desktop/completion references
