### PR TITLE
fix(clipboard): prefer Wayland/X11 over termcode in WezTerm

### DIFF
--- a/helix-view/src/clipboard.rs
+++ b/helix-view/src/clipboard.rs
@@ -147,8 +147,6 @@ mod external {
                 Self::Termux
             } else if env_var_is_set("TMUX") && binary_exists("tmux") {
                 Self::Tmux
-            } else if env_var_is_set("WEZTERM_UNIX_SOCKET") && binary_exists("wezterm") {
-                Self::Termcode
             } else if env_var_is_set("WAYLAND_DISPLAY")
                 && binary_exists("wl-copy")
                 && binary_exists("wl-paste")
@@ -164,6 +162,8 @@ mod external {
                 Self::XSel
             } else if binary_exists("win32yank.exe") {
                 Self::Win32Yank
+            } else if env_var_is_set("WEZTERM_UNIX_SOCKET") && binary_exists("wezterm") {
+                Self::Termcode
             } else if cfg!(feature = "term") {
                 Self::Termcode
             } else {


### PR DESCRIPTION
Helix was selecting `termcode` too early whenever it detected WezTerm via `WEZTERM_UNIX_SOCKET`.

  That broke paste from the system clipboard because  `termcode` can write clipboard contents, but it cannot read them. In practice, copying from Helix still worked, while pasting text copied from other apps stopped working. That  matches the reports in #15800 , which started after commit 8cc80c5 from #10605 .

The fix was to prefer real system clipboard backends like Wayland/X11 first, and only fall back to termcode if no readable system clipboard backend is available. It did the trick on my WezTerm + Wayland setup on Arch.