### PR TITLE
fix(dap): configuration done body is not required

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -463,8 +463,10 @@ impl Client {
             return Ok(());
         }
 
-        self.request::<requests::ConfigurationDone>(Some(requests::ConfigurationDoneArguments {}))
-            .await
+        self.call::<requests::ConfigurationDone>(Some(requests::ConfigurationDoneArguments {}))
+            .await?;
+
+        Ok(())
     }
 
     pub fn continue_thread(&self, thread_id: ThreadId) -> impl Future<Output = Result<Value>> {


### PR DESCRIPTION
Respect the DAP specs where the `body` for `ConfigurationDone` server response **isn't** required.

Fixes: https://github.com/helix-editor/helix/issues/15975
