### PR TITLE
feat(lsp): workspace diagnostics

### DIFF
--- a/helix-lsp/src/client.rs
+++ b/helix-lsp/src/client.rs
@@ -1419,6 +1419,37 @@ impl Client {
         Some(self.call::<lsp::request::DocumentDiagnosticRequest>(params))
     }
 
+    pub fn workspace_diagnostic(
+        &self,
+        previous_result_ids: Vec<lsp::PreviousResultId>,
+    ) -> Option<impl Future<Output = Result<lsp::WorkspaceDiagnosticReportResult>>> {
+        let capabilities = self.capabilities();
+
+        let identifier = match capabilities.diagnostic_provider.as_ref()? {
+            lsp::DiagnosticServerCapabilities::Options(cap) if cap.workspace_diagnostics => {
+                cap.identifier.as_ref().map(ToString::to_string)
+            }
+            lsp::DiagnosticServerCapabilities::RegistrationOptions(cap)
+                if cap.diagnostic_options.workspace_diagnostics =>
+            {
+                cap.diagnostic_options
+                    .identifier
+                    .as_ref()
+                    .map(ToString::to_string)
+            }
+            _ => return None,
+        };
+
+        let params = lsp::WorkspaceDiagnosticParams {
+            identifier,
+            previous_result_ids,
+            work_done_progress_params: lsp::WorkDoneProgressParams::default(),
+            partial_result_params: lsp::PartialResultParams::default(),
+        };
+
+        Some(self.call::<lsp::request::WorkspaceDiagnosticRequest>(params))
+    }
+
     pub fn text_document_document_highlight(
         &self,
         text_document: lsp::TextDocumentIdentifier,

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -892,6 +892,10 @@ impl Application {
                                             &mut self.editor,
                                             server_id,
                                         );
+                                        handlers::diagnostics::request_workspace_diagnostics_for_language_server(
+                                            &mut self.editor,
+                                            server_id,
+                                        );
                                     }
                                     self.editor.clear_status();
 
@@ -940,6 +944,10 @@ impl Application {
                                         &mut self.editor,
                                         server_id,
                                     );
+                                    handlers::diagnostics::request_workspace_diagnostics_for_language_server(
+                                        &mut self.editor,
+                                        server_id,
+                                    );
                                 };
                             }
                         }
@@ -962,6 +970,9 @@ impl Application {
                         }
 
                         self.editor.diagnostics.retain(|_, diags| !diags.is_empty());
+                        self.editor.workspace_diagnostic_ids.retain(
+                            |(diagnostic_server_id, _), _| *diagnostic_server_id != server_id,
+                        );
 
                         // Clear any diagnostics for documents with this server open.
                         for doc in self.editor.documents_mut() {
@@ -1132,6 +1143,10 @@ impl Application {
                     Ok(MethodCall::WorkspaceDiagnosticRefresh) => {
                         let server_id = language_server!().id();
                         handlers::diagnostics::request_all_document_diagnostics_for_language_server(
+                            &mut self.editor,
+                            server_id,
+                        );
+                        handlers::diagnostics::request_workspace_diagnostics_for_language_server(
                             &mut self.editor,
                             server_id,
                         );

--- a/helix-term/src/handlers/diagnostics.rs
+++ b/helix-term/src/handlers/diagnostics.rs
@@ -337,10 +337,7 @@ pub fn request_workspace_diagnostics_for_language_server(
         .iter()
         .filter_map(|((diagnostic_server_id, uri), value)| {
             if *diagnostic_server_id == server_id {
-                let uri = match uri.to_url() {
-                    Ok(uri) => uri,
-                    Err(()) => return None,
-                };
+                let uri = uri.to_url().ok()?;
                 Some(lsp::PreviousResultId {
                     uri,
                     value: value.clone(),

--- a/helix-term/src/handlers/diagnostics.rs
+++ b/helix-term/src/handlers/diagnostics.rs
@@ -9,7 +9,7 @@ use helix_core::diagnostic::DiagnosticProvider;
 use helix_core::syntax::config::LanguageServerFeature;
 use helix_core::Uri;
 use helix_event::{cancelable_future, register_hook, send_blocking};
-use helix_lsp::{lsp, LanguageServerId};
+use helix_lsp::{lsp, Client, LanguageServerId};
 use helix_view::document::Mode;
 use helix_view::events::{
     DiagnosticsDidChange, DocumentDidChange, DocumentDidOpen, LanguageServerInitialized,
@@ -21,6 +21,7 @@ use helix_view::{DocumentId, Editor};
 
 use crate::events::OnModeSwitch;
 use crate::job;
+use std::sync::Arc;
 
 pub(super) fn register_hooks(handlers: &Handlers) {
     register_hook!(move |event: &mut DiagnosticsDidChange<'_>| {
@@ -94,6 +95,7 @@ pub(super) fn register_hooks(handlers: &Handlers) {
         for doc_id in doc_ids {
             request_document_diagnostics(event.editor, doc_id);
         }
+        request_workspace_diagnostics_for_language_server(event.editor, event.server_id);
 
         Ok(())
     });
@@ -146,17 +148,62 @@ impl helix_event::AsyncHook for PullAllDocumentsDiagnosticHandler {
     fn finish_debounce(&mut self) {
         let language_servers = mem::take(&mut self.language_servers);
         job::dispatch_blocking(move |editor, _| {
-            let documents: Vec<_> = editor.documents.keys().copied().collect();
+            let (workspace_language_servers, document_language_servers): (HashSet<_>, HashSet<_>) =
+                language_servers.into_iter().partition(|server_id| {
+                    editor
+                        .language_servers
+                        .get_by_id(*server_id)
+                        .is_some_and(|language_server| {
+                            supports_workspace_diagnostics(language_server)
+                        })
+                });
 
+            for language_server in workspace_language_servers {
+                request_workspace_diagnostics_for_language_server(editor, language_server);
+            }
+
+            // Servers with workspace diagnostics can refresh unopened files in one request.
+            // Servers without that capability still need every open document refreshed.
+            if document_language_servers.is_empty() {
+                return;
+            }
+
+            let documents: Vec<_> = editor.documents.keys().copied().collect();
             for document in documents {
                 request_document_diagnostics_for_language_severs(
                     editor,
                     document,
-                    language_servers.clone(),
+                    document_language_servers.clone(),
                 );
             }
         })
     }
+}
+
+fn supports_workspace_diagnostics(language_server: &Client) -> bool {
+    language_server
+        .capabilities()
+        .diagnostic_provider
+        .as_ref()
+        .is_some_and(|diagnostic_provider| match diagnostic_provider {
+            lsp::DiagnosticServerCapabilities::Options(options) => options.workspace_diagnostics,
+            lsp::DiagnosticServerCapabilities::RegistrationOptions(options) => {
+                options.diagnostic_options.workspace_diagnostics
+            }
+        })
+}
+
+fn diagnostic_identifier(language_server: &Client) -> Option<Arc<str>> {
+    language_server
+        .capabilities()
+        .diagnostic_provider
+        .as_ref()
+        .and_then(|diagnostic_provider| match diagnostic_provider {
+            lsp::DiagnosticServerCapabilities::Options(options) => options.identifier.clone(),
+            lsp::DiagnosticServerCapabilities::RegistrationOptions(options) => {
+                options.diagnostic_options.identifier.clone()
+            }
+        })
 }
 
 fn request_document_diagnostics_for_language_severs(
@@ -273,6 +320,75 @@ pub fn request_all_document_diagnostics_for_language_server(
     }
 }
 
+pub fn request_workspace_diagnostics_for_language_server(
+    editor: &mut Editor,
+    server_id: LanguageServerId,
+) {
+    let Some(language_server) = editor.language_servers.get_by_id(server_id).cloned() else {
+        return;
+    };
+
+    if !supports_workspace_diagnostics(&language_server) {
+        return;
+    }
+
+    let previous_result_ids = editor
+        .workspace_diagnostic_ids
+        .iter()
+        .filter_map(|((diagnostic_server_id, uri), value)| {
+            if *diagnostic_server_id == server_id {
+                let uri = match uri.to_url() {
+                    Ok(uri) => uri,
+                    Err(()) => return None,
+                };
+                Some(lsp::PreviousResultId {
+                    uri,
+                    value: value.clone(),
+                })
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let Some(future) = language_server.workspace_diagnostic(previous_result_ids) else {
+        return;
+    };
+    let provider = DiagnosticProvider::Lsp {
+        server_id,
+        identifier: diagnostic_identifier(&language_server),
+    };
+
+    tokio::spawn(async move {
+        match future.await {
+            Ok(result) => {
+                job::dispatch(move |editor, _| {
+                    handle_workspace_diagnostics_response(editor, result, provider);
+                })
+                .await;
+            }
+            Err(err) => {
+                let parsed_cancellation_data = if let helix_lsp::Error::Rpc(error) = err {
+                    error.data.and_then(|data| {
+                        serde_json::from_value::<lsp::DiagnosticServerCancellationData>(data).ok()
+                    })
+                } else {
+                    log::error!("Workspace diagnostic request failed: {err}");
+                    return;
+                };
+
+                if parsed_cancellation_data.is_some_and(|data| data.retrigger_request) {
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                    job::dispatch(move |editor, _| {
+                        request_workspace_diagnostics_for_language_server(editor, server_id);
+                    })
+                    .await;
+                }
+            }
+        }
+    });
+}
+
 pub fn request_document_diagnostics(editor: &mut Editor, doc_id: DocumentId) {
     let Some(doc) = editor.document(doc_id) else {
         return;
@@ -327,4 +443,70 @@ fn handle_pull_diagnostics_response(
         }
         lsp::DocumentDiagnosticReportResult::Partial(_) => {}
     };
+}
+
+fn handle_workspace_diagnostics_response(
+    editor: &mut Editor,
+    result: lsp::WorkspaceDiagnosticReportResult,
+    provider: DiagnosticProvider,
+) {
+    let server_id = provider
+        .language_server_id()
+        .expect("workspace diagnostics always originate from an LSP");
+    let reports = match result {
+        lsp::WorkspaceDiagnosticReportResult::Report(report) => report.items,
+        lsp::WorkspaceDiagnosticReportResult::Partial(report) => report.items,
+    };
+
+    for report in reports {
+        let (uri, version, result_id, diagnostics) = match report {
+            lsp::WorkspaceDocumentDiagnosticReport::Full(report) => (
+                report.uri,
+                report.version,
+                report.full_document_diagnostic_report.result_id,
+                Some(report.full_document_diagnostic_report.items),
+            ),
+            lsp::WorkspaceDocumentDiagnosticReport::Unchanged(report) => (
+                report.uri,
+                report.version,
+                Some(report.unchanged_document_diagnostic_report.result_id),
+                None,
+            ),
+        };
+
+        let uri = match Uri::try_from(uri) {
+            Ok(uri) => uri,
+            Err(err) => {
+                log::error!("{err}");
+                continue;
+            }
+        };
+
+        match result_id {
+            Some(result_id) => {
+                editor
+                    .workspace_diagnostic_ids
+                    .insert((server_id, uri.clone()), result_id);
+            }
+            None => {
+                editor
+                    .workspace_diagnostic_ids
+                    .remove(&(server_id, uri.clone()));
+            }
+        }
+
+        let Some(diagnostics) = diagnostics else {
+            continue;
+        };
+
+        let version = version.and_then(|version| match i32::try_from(version) {
+            Ok(version) => Some(version),
+            Err(_) => {
+                log::warn!("Workspace diagnostic version {version} is out of range for {uri:?}");
+                None
+            }
+        });
+
+        editor.handle_lsp_diagnostics(&provider, uri, version, diagnostics);
+    }
 }

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -699,6 +699,7 @@ impl Default for StatusLineConfig {
             center: vec![],
             right: vec![
                 E::Diagnostics,
+                E::WorkspaceDiagnostics,
                 E::Selections,
                 E::Register,
                 E::Position,

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1270,6 +1270,10 @@ use futures_util::stream::{Flatten, Once};
 
 type Diagnostics = BTreeMap<Uri, Vec<(lsp::Diagnostic, DiagnosticProvider)>>;
 
+// Workspace diagnostics need to be keyed by LSP ID and URI because result IDs
+// used for deduplication are per-document.
+type WorkspaceDiagnosticIds = BTreeMap<(LanguageServerId, Uri), String>;
+
 pub struct Editor {
     /// Current editing mode.
     pub mode: Mode,
@@ -1290,6 +1294,7 @@ pub struct Editor {
     pub macro_replaying: Vec<char>,
     pub language_servers: helix_lsp::Registry,
     pub diagnostics: Diagnostics,
+    pub workspace_diagnostic_ids: WorkspaceDiagnosticIds,
     pub diff_providers: DiffProviderRegistry,
 
     pub debug_adapters: dap::registry::Registry,
@@ -1440,6 +1445,7 @@ impl Editor {
             theme: theme_loader.default(),
             language_servers,
             diagnostics: Diagnostics::new(),
+            workspace_diagnostic_ids: WorkspaceDiagnosticIds::new(),
             diff_providers: DiffProviderRegistry::default(),
             debug_adapters: dap::registry::Registry::new(),
             breakpoints: HashMap::new(),


### PR DESCRIPTION
Add proper support for workspace diagnostics. Workspace diagnostics are supported by:

- `ty` (Astral's Python type checker) (with a diagnosticMode: "workspace" setting)
- `rust-analyzer` (since 2025-03-03)
- `clangd`
- and others

The workspace diagnostics picker (space+D) and workspace-diagnostics statusline elements now show workspace wide diagnostics for LSPs that support workspace diagnostics instead of just diagnostics for open documents.

The wiring itself is the same as for document diagnostics, i.e. through handlers, debounces, etc. Further deduplication is handled by the LSP itself where workspace diagnostics carry IDs.

Fixes: https://github.com/helix-editor/helix/issues/15963