### PR TITLE
fix(runtime/queries/go): regex string injections

### DIFF
--- a/runtime/queries/go/injections.scm
+++ b/runtime/queries/go/injections.scm
@@ -40,9 +40,9 @@
   (argument_list
     .
     [
-      (raw_string_literal)
-      (interpreted_string_literal)
-    ] @injection.content
+      (raw_string_literal (raw_string_literal_content) @injection.content)
+      (interpreted_string_literal (interpreted_string_literal_content) @injection.content)
+    ]
     (#set! injection.language "regex")))
 
 ; https://pkg.go.dev/fmt#Printf


### PR DESCRIPTION
The Go queries for injecting regex language syntax were taking also the surrounding quotes. Pass only the raw string content to the injected syntax.

Fixes: https://github.com/helix-editor/helix/issues/15591