### PR TITLE
feat(runtime/queries/go): public functions and methods

### DIFF
--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -240,10 +240,10 @@ We use a similar set of scopes as
 - `operator` - `||`, `+=`, `>`
 
 - `function` - Function definitions and calls
-  - `public` - Public functions that use a unique syntax or naming convention
+  - `public` - Public function definitions
   - `builtin` - Language built-in functions
   - `method` - Method definitions and calls (`obj.method()`)
-    - `public` - Public methods that use a unique syntax or naming convention
+    - `public` - Public method definitions
     - `private` - Private methods that use a unique syntax (currently just ECMAScript-based languages)
   - `macro` - Macro invocations (e.g. `println!` in Rust)
   - `special` (preprocessor in C)

--- a/book/src/themes.md
+++ b/book/src/themes.md
@@ -240,8 +240,10 @@ We use a similar set of scopes as
 - `operator` - `||`, `+=`, `>`
 
 - `function` - Function definitions and calls
+  - `public` - Public functions that use a unique syntax or naming convention
   - `builtin` - Language built-in functions
   - `method` - Method definitions and calls (`obj.method()`)
+    - `public` - Public methods that use a unique syntax or naming convention
     - `private` - Private methods that use a unique syntax (currently just ECMAScript-based languages)
   - `macro` - Macro invocations (e.g. `println!` in Rust)
   - `special` (preprocessor in C)

--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -27,18 +27,9 @@
 (call_expression
   function: (identifier) @function)
 
-((call_expression
-  function: (identifier) @function.public)
-  (#match? @function.public "^[A-Z]"))
-
 (call_expression
   function: (selector_expression
     field: (field_identifier) @function.method))
-
-((call_expression
-  function: (selector_expression
-    field: (field_identifier) @function.method.public))
-  (#match? @function.method.public "^[A-Z]"))
 
 (call_expression
   function: (identifier) @function.builtin

--- a/runtime/queries/go/highlights.scm
+++ b/runtime/queries/go/highlights.scm
@@ -27,9 +27,18 @@
 (call_expression
   function: (identifier) @function)
 
+((call_expression
+  function: (identifier) @function.public)
+  (#match? @function.public "^[A-Z]"))
+
 (call_expression
   function: (selector_expression
     field: (field_identifier) @function.method))
+
+((call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method.public))
+  (#match? @function.method.public "^[A-Z]"))
 
 (call_expression
   function: (identifier) @function.builtin
@@ -57,11 +66,23 @@
 (function_declaration
   name: (identifier) @function)
 
+((function_declaration
+  name: (identifier) @function.public)
+  (#match? @function.public "^[A-Z]"))
+
 (method_declaration
   name: (field_identifier) @function.method)
 
+((method_declaration
+  name: (field_identifier) @function.method.public)
+  (#match? @function.method.public "^[A-Z]"))
+
 (method_elem
   name: (field_identifier) @function.method)
+
+((method_elem
+  name: (field_identifier) @function.method.public)
+  (#match? @function.method.public "^[A-Z]"))
 
 ; Blank identifier `_` (Go's discard) — dim as unused.
 ; It parses as (blank_identifier) in imports and as (identifier) elsewhere

--- a/tests/query/highlights/go/constructs.go
+++ b/tests/query/highlights/go/constructs.go
@@ -5,7 +5,7 @@ type Point struct { X int }
 //                  ^ @variable.other.member
 //                    ^ @type.builtin
 func (p Point) Dist(count int) bool {
-//             ^ @function.method
+//             ^ @function.method.public
 //                  ^ @variable.parameter
     return helper(count)
 //         ^ @function


### PR DESCRIPTION
Same as https://github.com/helix-editor/helix/pull/15879 but for Go. Add dedicated scope for public functions/methods.

Also adds this scope to the `book` which wasn't covered by the initial PR.