### PR TITLE
Fix Python indent after definition header

### DIFF
--- a/helix-core/src/indent.rs
+++ b/helix-core/src/indent.rs
@@ -550,8 +550,9 @@ fn get_node_start_line(text: RopeSlice, node: &Node, new_line_byte_pos: Option<u
 }
 fn get_node_end_line(text: RopeSlice, node: &Node, new_line_byte_pos: Option<u32>) -> usize {
     let mut node_line = text.byte_to_line(node.end_byte() as usize);
-    // Adjust for the new line that will be inserted (with a strict inequality since end_byte is exclusive)
-    if new_line_byte_pos.is_some_and(|pos| node.end_byte() > pos) {
+    // Adjust for the new line that will be inserted. A node ending exactly at the
+    // cursor still contains the new line that opens its next indentation level.
+    if new_line_byte_pos.is_some_and(|pos| node.end_byte() >= pos) {
         node_line += 1;
     }
     node_line

--- a/helix-core/tests/data/indent/languages.toml
+++ b/helix-core/tests/data/indent/languages.toml
@@ -24,3 +24,16 @@ indent = { tab-width = 2, unit = "  " }
 [[grammar]]
 name = "cpp"
 source = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "2d2c4aee8672af4c7c8edff68e7dd4c07e88d2b1" }
+
+[[language]]
+name = "python"
+scope = "source.python"
+injection-regex = "py(thon)?"
+file-types = ["py"]
+roots = []
+comment-token = "#"
+indent = { tab-width = 4, unit = " " }
+
+[[grammar]]
+name = "python"
+source = { git = "https://github.com/tree-sitter/tree-sitter-python", rev = "293fdc02038ee2bf0e2e206711b69c90ac0d413f" }

--- a/helix-core/tests/indent.rs
+++ b/helix-core/tests/indent.rs
@@ -144,6 +144,42 @@ fn test_indent_level_for_line_with_spaces_and_tabs() {
     assert_eq!(indent_level, 2)
 }
 
+#[test]
+fn test_python_indent_after_definition_header() {
+    for source in ["def foo():", "class Foo:"] {
+        let loader = Loader::new(indent_tests_config()).unwrap();
+        let mut runtime = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        runtime.push("../runtime");
+        std::env::set_var("HELIX_RUNTIME", runtime.to_str().unwrap());
+
+        let language = loader.language_for_scope("source.python").unwrap();
+        let language_config = loader.language(language).config();
+        let indent_style = IndentStyle::from_str(&language_config.indent.as_ref().unwrap().unit);
+        let text = Rope::from_str(source);
+        let text = text.slice(..);
+        let syntax = Syntax::new(text, language, &loader).unwrap();
+        let indent_query = loader.indent_query(language).unwrap();
+        let tab_width = 4;
+        let pos = source.len();
+
+        let suggested_indent = treesitter_indent_for_pos(
+            indent_query,
+            &syntax,
+            &loader,
+            tab_width,
+            indent_style.indent_width(tab_width),
+            text,
+            0,
+            pos,
+            true,
+        )
+        .unwrap()
+        .to_string(&indent_style, tab_width);
+
+        assert_eq!(suggested_indent, " ");
+    }
+}
+
 fn indent_tests_dir() -> PathBuf {
     let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     test_dir.push("tests/data/indent");


### PR DESCRIPTION
Fixes #15985.

### Summary
- Treat a node ending exactly at a newly inserted newline position as spanning the new line for indentation purposes.
- Add a Python indent regression test for pressing Enter after `def foo():` and `class Foo:`.
- Add Python to the indent test language fixture.

### Tests
- `cargo fmt --check`
- `cargo test -p helix-core --test indent`
- `cargo xtask query-check python`