### PR TITLE
Use glob pattern to detect multi component file extensions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -609,9 +609,9 @@ file-types = [
   { glob = ".babelrc" },
   { glob = ".bowerrc" },
   { glob = ".jscrc" },
-  "js.map",
-  "ts.map",
-  "css.map",
+  { glob = "*.js.map" },
+  { glob = "*.ts.map" },
+  { glob = "*.css.map" },
   { glob = ".jslintrc" },
   "jsonl",
   { glob = ".vuerc" },
@@ -2879,7 +2879,10 @@ source = { git = "https://github.com/gmlarumbe/tree-sitter-systemverilog", rev =
 [[language]]
 name = "edoc"
 scope = "source.edoc"
-file-types = ["edoc", "edoc.in"]
+file-types = [
+  "edoc",
+  { glob = "*.edoc.in" },
+]
 injection-regex = "edoc"
 indent = { tab-width = 4, unit = "    " }
 
@@ -3270,7 +3273,7 @@ file-types = [
   "checkstyle",
   "cpt",
   "csl",
-  "csproj.user",
+  { glob = "*.csproj.user" },
   "dita",
   "ditamap",
   "dtml",
@@ -3303,7 +3306,7 @@ file-types = [
   "pt",
   "publishsettings",
   "pubxml",
-  "pubxml.user",
+  { glob = "*.pubxml.user" },
   "rbxlx",
   "rbxmx",
   "resx",
@@ -3318,9 +3321,9 @@ file-types = [
   "tld",
   "tmx",
   "ui",
-  "vbproj.user",
+  { glob = "*.vbproj.user" },
   "vcxproj",
-  "vcxproj.filters",
+  { glob = "*.vcxproj.filters" },
   "wixproj",
   "wsdl",
   "wxi",


### PR DESCRIPTION
The string form "<a>.<b>" does not work

I have used the following [nushell](https://nushell.sh) script to find all `file-types` patterns with this issue.

```nu
open languages.toml
| get language
| select name file-types
| update file-types {
  where (($it | describe) == string) and ($it | str contains '.') 
}
| where ($it.file-types | is-not-empty)
| to json
```

Which outputted (before applying this commit):

```json
[
  {
    "name": "json",
    "file-types": [
      "js.map",
      "ts.map",
      "css.map"
    ]
  },
  {
    "name": "edoc",
    "file-types": [
      "edoc.in"
    ]
  },
  {
    "name": "xml",
    "file-types": [
      "csproj.user",
      "pubxml.user",
      "vbproj.user",
      "vcxproj.filters"
    ]
  }
]
```