### PR TITLE
fix(lsp): query all active language servers for workspace symbols

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -7214,13 +7214,7 @@ fn lsp_or_syntax_symbol_picker(cx: &mut Context) {
 }
 
 fn lsp_or_syntax_workspace_symbol_picker(cx: &mut Context) {
-    let doc = doc!(cx.editor);
-
-    if doc
-        .language_servers_with_feature(LanguageServerFeature::WorkspaceSymbols)
-        .next()
-        .is_some()
-    {
+    if lsp::workspace_symbol_servers(cx.editor).next().is_some() {
         lsp::workspace_symbol_picker(cx);
     } else {
         syntax_workspace_symbol_picker(cx);

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -452,11 +452,11 @@ pub fn symbol_picker(cx: &mut Context) {
 pub fn workspace_symbol_picker(cx: &mut Context) {
     use crate::ui::picker::Injector;
 
-    let doc = doc!(cx.editor);
-    if doc
-        .language_servers_with_feature(LanguageServerFeature::WorkspaceSymbols)
-        .count()
-        == 0
+    if !cx
+        .editor
+        .language_servers
+        .iter_clients()
+        .any(|ls| ls.supports_feature(LanguageServerFeature::WorkspaceSymbols))
     {
         cx.editor
             .set_error("No configured language server supports workspace symbols");
@@ -464,11 +464,10 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
     }
 
     let get_symbols = |pattern: &str, editor: &mut Editor, _data, injector: &Injector<_, _>| {
-        let doc = doc!(editor);
-        let mut seen_language_servers = HashSet::new();
-        let mut futures: FuturesUnordered<_> = doc
-            .language_servers_with_feature(LanguageServerFeature::WorkspaceSymbols)
-            .filter(|ls| seen_language_servers.insert(ls.id()))
+        let mut futures: FuturesUnordered<_> = editor
+            .language_servers
+            .iter_clients()
+            .filter(|ls| ls.supports_feature(LanguageServerFeature::WorkspaceSymbols))
             .map(|language_server| {
                 let request = language_server
                     .workspace_symbols(pattern.to_string())

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -449,25 +449,32 @@ pub fn symbol_picker(cx: &mut Context) {
     });
 }
 
+/// Every language server that can answer a workspace symbol request, across all open
+/// documents rather than only the focused one, deduplicated by server id.
+///
+/// Workspace symbols are project-wide, so the focused document's servers are not the
+/// right scope. Collecting through each document's configured servers keeps the
+/// per-language `only-features` / `except-features` gates applied, and skips servers
+/// that have not finished initializing — `supports_feature` panics on those.
+pub fn workspace_symbol_servers(editor: &Editor) -> impl Iterator<Item = &helix_lsp::Client> {
+    let mut seen_language_servers = HashSet::new();
+    editor
+        .documents()
+        .flat_map(|doc| doc.language_servers_with_feature(LanguageServerFeature::WorkspaceSymbols))
+        .filter(move |ls| seen_language_servers.insert(ls.id()))
+}
+
 pub fn workspace_symbol_picker(cx: &mut Context) {
     use crate::ui::picker::Injector;
 
-    if !cx
-        .editor
-        .language_servers
-        .iter_clients()
-        .any(|ls| ls.supports_feature(LanguageServerFeature::WorkspaceSymbols))
-    {
+    if workspace_symbol_servers(cx.editor).next().is_none() {
         cx.editor
             .set_error("No configured language server supports workspace symbols");
         return;
     }
 
     let get_symbols = |pattern: &str, editor: &mut Editor, _data, injector: &Injector<_, _>| {
-        let mut futures: FuturesUnordered<_> = editor
-            .language_servers
-            .iter_clients()
-            .filter(|ls| ls.supports_feature(LanguageServerFeature::WorkspaceSymbols))
+        let mut futures: FuturesUnordered<_> = workspace_symbol_servers(editor)
             .map(|language_server| {
                 let request = language_server
                     .workspace_symbols(pattern.to_string())


### PR DESCRIPTION
## Summary

`workspace_symbol_picker` (`<space>S`) collected language servers from the **current document** only. When the focused buffer's language server does not support workspace symbols — e.g. editing a plaintext file (no server) while a C/C++ file with an active `clangd` is open — the picker returned nothing even though a capable server was running. Closes #15954.

Workspace symbols are project-wide, so this enumerates every active client that supports the `WorkspaceSymbols` feature via the editor's language server registry (`editor.language_servers.iter_clients()`) instead of the current document's servers. This mirrors how other editor-wide LSP operations already fan out (e.g. `will_rename`, `did_change_watched_files` in `helix-view`).

Since `iter_clients()` yields each client once, the previous per-document dedup set is no longer needed.

The **document** symbol picker (`<space>s`) is intentionally left scoped to the current document, since document symbols are per-file by definition.

## Behavior

- Before: `<space>S` shows workspace symbols only from servers attached to the current buffer.
- After: `<space>S` shows workspace symbols from all active servers that support the feature, regardless of which buffer is focused.

## Notes

This is an integration-level behavior change across running language servers, which the existing test harness can't drive without multiple live servers, so there is no added unit test. Verified manually: with a plaintext buffer focused and a C/C++ buffer open (clangd active), `<space>S` now returns clangd's workspace symbols; the "No configured language server supports workspace symbols" path still fires when no active server supports the feature.

- `cargo fmt --check`: clean
- `cargo clippy -p helix-term`: clean