### PR TITLE
grammars: update Just to support latest versions

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3859,7 +3859,7 @@ formatter = { command = "just", args = ["--fmt", "--justfile", "-"] }
 
 [[grammar]]
 name = "just"
-source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "f749ec853adcacc5f14e9ec375f244104e033d88" }
+source = { git = "https://github.com/poliorcetics/tree-sitter-just", rev = "00859eebfb774d371af174ea1e582d46e697b469" }
 
 [[language]]
 name = "gn"
@@ -5647,4 +5647,3 @@ comment-tokens = ["REM", "::"]
 [[grammar]]
 name = "batch"
 source = { git = "https://github.com/wharflab/tree-sitter-batch", rev = "5fc5f54267ef9a78e7a5319b80e092194252aabf" }
-

--- a/runtime/queries/just/highlights.scm
+++ b/runtime/queries/just/highlights.scm
@@ -10,6 +10,8 @@
 
 [
   "alias"
+  "assert"
+  "eager"
   "set"
   "shell"
 ] @keyword
@@ -18,11 +20,6 @@
   "if"
   "else"
 ] @keyword.control.conditional
-
-[
-  "&&"
-  "||"
-] @operator
 
 ; Variables
 
@@ -42,6 +39,9 @@
 
 ; Functions
 
+(function
+  name: (identifier) @function)
+
 (recipe
   name: (identifier) @function)
 
@@ -52,6 +52,12 @@
   name: (identifier) @function.builtin)
 
 ; Parameters
+
+(attribute_named_parameter
+  name: (identifier) @variable.parameter)
+
+(function_decl_parameters
+    (identifier) @variable.parameter)
 
 (recipe_parameter
   name: (identifier) @variable.parameter)
@@ -78,7 +84,6 @@
 (shebang_line
   (shebang_shell) @string.special)
 
-
 (shell_expanded_string
   [
     (expansion_short_start)
@@ -90,23 +95,26 @@
 ; Operators
 
 [
-  ":="
-  "?"
-  "=="
-  "!="
-  "=~"
-  "!~"
-  "@"
-  "="
-  "$"
-  "*"
-  "+"
-  "&&"
-  "@-"
-  "-@"
   "-"
-  "/"
+  "-@"
   ":"
+  ":="
+  "!"
+  "!="
+  "!~"
+  "?"
+  "@-"
+  "@"
+  "*"
+  "/"
+  "&&"
+  "+"
+  "++"
+  "="
+  "=="
+  "=~"
+  "||"
+  "$"
 ] @operator
 
 ; Punctuation

--- a/runtime/queries/just/injections.scm
+++ b/runtime/queries/just/injections.scm
@@ -10,6 +10,13 @@
   (_) @injection.content)
   (#set! injection.language "regex"))
 
+; Highlight the value of attribute `[arg(pattern = "...")]` as regex
+(attribute_named_parameter
+  name: (identifier) @_name
+  value: (expression (value (string) @injection.content
+    (#set! injection.language "regex")))
+  (#match? @_name "^pattern$"))
+
 ; ================ Global defaults ================
 
 ; Default recipe lines to be bash, but exclude interpolation nodes

--- a/runtime/queries/just/locals.scm
+++ b/runtime/queries/just/locals.scm
@@ -13,6 +13,9 @@
 (assignment
   name: (identifier) @local.definition.variable)
 
+(function
+  name: (identifier) @local.definition.function)
+
 (mod
   name: (identifier) @local.definition.namespace)
 

--- a/runtime/queries/just/tags.scm
+++ b/runtime/queries/just/tags.scm
@@ -6,6 +6,9 @@
 (assignment
   name: (identifier) @definition.constant)
 
+(function
+  name: (identifier) @definition.function)
+
 (import
   (path) @definition.module)
 

--- a/runtime/queries/just/textobjects.scm
+++ b/runtime/queries/just/textobjects.scm
@@ -3,6 +3,12 @@
 (assert_parameters
   ((_) @parameter.inside . ","? @parameter.around)) @parameter.around
 
+(function
+  (expression) @function.inside) @function.around
+
+(function_decl_parameters
+  ((_) @parameter.inside . ","? @parameter.around)) @parameter.around
+
 (recipe
   (recipe_body) @function.inside) @function.around
 
@@ -13,7 +19,7 @@
   (_) @parameter.inside) @parameter.around
 
 (function_call
-  (function_parameters
+  (function_call_parameters
     ((_) @parameter.inside . ","? @parameter.around)) @parameter.around) @function.around
 
 (comment) @comment.around


### PR DESCRIPTION
Closes #16037

Bring up Just support to 1.56.0, adding more keywords, injections, and other highlighted items.

<img width="1151" height="396" alt="Highlighted format strings" src="https://github.com/user-attachments/assets/05246458-0e0d-409f-bf03-b7f9a8e89b37" />

<img width="571" height="145" alt="Regex injection in `pattern` parameter" src="https://github.com/user-attachments/assets/494e814b-4449-4d16-af61-f99960f61196" />

<img width="606" height="251" alt="Function definitions" src="https://github.com/user-attachments/assets/fd7a746f-bd14-407f-a498-d8515bea3b04" />
