### PR TITLE
languages: uxntal: don't auto-pairs quotes

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3641,6 +3641,11 @@ file-types = ["tal"]
 auto-format = false
 block-comment-tokens = { start = "(", end = ")" }
 
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+'[' = ']'
+
 [[grammar]]
 name = "uxntal"
 source = { git = "https://github.com/Jummit/tree-sitter-uxntal", rev = "1a44f8d31053096b79c52f10a39da12479edbf64" }


### PR DESCRIPTION
Disable quotes auto-pairing in `.tal` files by filtering down to only actual pairs in the language: <https://wiki.xxiivv.com/site/uxntal.html#runes>.

Closes #15998