### PR TITLE
Add the official Typescript Language Server and make it the default

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -140,7 +140,7 @@
 | inko | ✓ | ✓ | ✓ | ✓ |  |  |
 | janet | ✓ |  | ✓ |  | ✓ |  |
 | java | ✓ | ✓ | ✓ | ✓ | ✓ | `jdtls` |
-| javascript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
+| javascript | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
 | jinja | ✓ |  |  |  |  |  |
 | jjconfig | ✓ | ✓ | ✓ |  |  | `taplo`, `tombi` |
 | jjdescription | ✓ |  |  |  |  |  |
@@ -153,7 +153,7 @@
 | json5 | ✓ | ✓ | ✓ |  | ✓ |  |
 | jsonc | ✓ | ✓ | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsonnet | ✓ |  |  |  |  | `jsonnet-language-server` |
-| jsx | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
+| jsx | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
 | julia | ✓ | ✓ | ✓ | ✓ | ✓ | `julia` |
 | just | ✓ | ✓ | ✓ | ✓ |  | `just-lsp` |
 | kcl | ✓ |  |  |  |  | `kcl-language-server` |
@@ -309,7 +309,7 @@
 | tsq | ✓ |  |  |  | ✓ | `ts_query_ls` |
 | tsx | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | twig | ✓ |  |  |  |  |  |
-| typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
+| typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
 | typespec | ✓ | ✓ | ✓ |  |  | `tsp-server` |
 | typst | ✓ | ✓ |  | ✓ |  | `tinymist` |
 | ungrammar | ✓ |  |  |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -140,7 +140,7 @@
 | inko | ✓ | ✓ | ✓ | ✓ |  |  |
 | janet | ✓ |  | ✓ |  | ✓ |  |
 | java | ✓ | ✓ | ✓ | ✓ | ✓ | `jdtls` |
-| javascript | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
+| javascript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | jinja | ✓ |  |  |  |  |  |
 | jjconfig | ✓ | ✓ | ✓ |  |  | `taplo`, `tombi` |
 | jjdescription | ✓ |  |  |  |  |  |
@@ -153,7 +153,7 @@
 | json5 | ✓ | ✓ | ✓ |  | ✓ |  |
 | jsonc | ✓ | ✓ | ✓ |  | ✓ | `vscode-json-language-server` |
 | jsonnet | ✓ |  |  |  |  | `jsonnet-language-server` |
-| jsx | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
+| jsx | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | julia | ✓ | ✓ | ✓ | ✓ | ✓ | `julia` |
 | just | ✓ | ✓ | ✓ | ✓ |  | `just-lsp` |
 | kcl | ✓ |  |  |  |  | `kcl-language-server` |
@@ -309,7 +309,7 @@
 | tsq | ✓ |  |  |  | ✓ | `ts_query_ls` |
 | tsx | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | twig | ✓ |  |  |  |  |  |
-| typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
+| typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
 | typespec | ✓ | ✓ | ✓ |  |  | `tsp-server` |
 | typst | ✓ | ✓ |  | ✓ |  | `tinymist` |
 | ungrammar | ✓ |  |  |  |  |  |

--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -307,7 +307,7 @@
 | toml | ✓ | ✓ | ✓ | ✓ | ✓ | `taplo`, `tombi` |
 | tql | ✓ |  | ✓ |  |  |  |
 | tsq | ✓ |  |  |  | ✓ | `ts_query_ls` |
-| tsx | ✓ | ✓ | ✓ | ✓ | ✓ | `typescript-language-server` |
+| tsx | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
 | twig | ✓ |  |  |  |  |  |
 | typescript | ✓ | ✓ | ✓ | ✓ | ✓ | `tsc` |
 | typespec | ✓ | ✓ | ✓ |  |  | `tsp-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -254,21 +254,23 @@ watcher = "server"
 command = "tsc"
 args = ["--lsp", "--stdio"]
 
-[language-server.typescript-language-server-official.config.typescript.inlayHints]
-enumMemberValues.enabled = true
-functionLikeReturnTypes.enabled = true
-parameterTypes.enabled = true
-parameterNames.enabled = "all"
-propertyDeclarationTypes.enabled = true
-variableTypes.enabled = true
+[language-server.typescript-language-server-official.config.typescript]
+format.enabled = false
+inlayHints.enumMemberValues.enabled = true
+inlayHints.functionLikeReturnTypes.enabled = true
+inlayHints.parameterTypes.enabled = true
+inlayHints.parameterNames.enabled = "all"
+inlayHints.propertyDeclarationTypes.enabled = true
+inlayHints.variableTypes.enabled = true
 
-[language-server.typescript-language-server-official.config.javascript.inlayHints]
-enumMemberValues.enabled = true
-functionLikeReturnTypes.enabled = true
-parameterTypes.enabled = true
-parameterNames.enabled = "all"
-propertyDeclarationTypes.enabled = true
-variableTypes.enabled = true
+[language-server.typescript-language-server-official.config.javascript]
+format.enabled = false
+inlayHints.enumMemberValues.enabled = true
+inlayHints.functionLikeReturnTypes.enabled = true
+inlayHints.parameterTypes.enabled = true
+inlayHints.parameterNames.enabled = "all"
+inlayHints.propertyDeclarationTypes.enabled = true
+inlayHints.variableTypes.enabled = true
 
 [language-server.typescript-language-server]
 command = "typescript-language-server"

--- a/languages.toml
+++ b/languages.toml
@@ -250,6 +250,26 @@ inlayHints.typeHints.hideClosureInitialization = false
 [language-server.rust-analyzer.config.files]
 watcher = "server"
 
+[language-server.typescript-language-server-official]
+command = "tsc"
+args = ["--lsp", "--stdio"]
+
+[language-server.typescript-language-server-official.config.typescript.inlayHints]
+enumMemberValues.enabled = true
+functionLikeReturnTypes.enabled = true
+parameterTypes.enabled = true
+parameterNames.enabled = "all"
+propertyDeclarationTypes.enabled = true
+variableTypes.enabled = true
+
+[language-server.typescript-language-server-official.config.javascript.inlayHints]
+enumMemberValues.enabled = true
+functionLikeReturnTypes.enabled = true
+parameterTypes.enabled = true
+parameterNames.enabled = "all"
+propertyDeclarationTypes.enabled = true
+variableTypes.enabled = true
+
 [language-server.typescript-language-server]
 command = "typescript-language-server"
 args = ["--stdio"]
@@ -999,7 +1019,7 @@ shebangs = ["node"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "typescript-language-server-official" ]
 indent = { tab-width = 2, unit = "  " }
 
 [language.debugger]
@@ -1028,7 +1048,7 @@ file-types = ["jsx"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "typescript-language-server-official" ]
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
@@ -1042,7 +1062,7 @@ shebangs = ["deno", "bun", "ts-node"]
 roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "typescript-language-server-official" ]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -272,6 +272,15 @@ inlayHints.parameterNames.enabled = "all"
 inlayHints.propertyDeclarationTypes.enabled = true
 inlayHints.variableTypes.enabled = true
 
+[language-server.tsc.config.tsx]
+format.enabled = false
+inlayHints.enumMemberValues.enabled = true
+inlayHints.functionLikeReturnTypes.enabled = true
+inlayHints.parameterTypes.enabled = true
+inlayHints.parameterNames.enabled = "all"
+inlayHints.propertyDeclarationTypes.enabled = true
+inlayHints.variableTypes.enabled = true
+
 [language-server.tsc.config.jsx]
 format.enabled = false
 inlayHints.enumMemberValues.enabled = true
@@ -1106,7 +1115,7 @@ file-types = ["tsx"]
 roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "tsc" ]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -1030,7 +1030,7 @@ shebangs = ["node"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "typescript-language-server-official" ]
 indent = { tab-width = 2, unit = "  " }
 
 [language.debugger]
@@ -1059,7 +1059,7 @@ file-types = ["jsx"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "typescript-language-server-official" ]
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
@@ -1073,7 +1073,7 @@ shebangs = ["deno", "bun", "ts-node"]
 roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server" ]
+language-servers = [ "typescript-language-server-official" ]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -250,11 +250,11 @@ inlayHints.typeHints.hideClosureInitialization = false
 [language-server.rust-analyzer.config.files]
 watcher = "server"
 
-[language-server.typescript-language-server-official]
+[language-server.tsc]
 command = "tsc"
 args = ["--lsp", "--stdio"]
 
-[language-server.typescript-language-server-official.config.typescript]
+[language-server.tsc.config.typescript]
 format.enabled = false
 inlayHints.enumMemberValues.enabled = true
 inlayHints.functionLikeReturnTypes.enabled = true
@@ -263,7 +263,7 @@ inlayHints.parameterNames.enabled = "all"
 inlayHints.propertyDeclarationTypes.enabled = true
 inlayHints.variableTypes.enabled = true
 
-[language-server.typescript-language-server-official.config.javascript]
+[language-server.tsc.config.javascript]
 format.enabled = false
 inlayHints.enumMemberValues.enabled = true
 inlayHints.functionLikeReturnTypes.enabled = true
@@ -272,7 +272,7 @@ inlayHints.parameterNames.enabled = "all"
 inlayHints.propertyDeclarationTypes.enabled = true
 inlayHints.variableTypes.enabled = true
 
-[language-server.typescript-language-server-official.config.jsx]
+[language-server.tsc.config.jsx]
 format.enabled = false
 inlayHints.enumMemberValues.enabled = true
 inlayHints.functionLikeReturnTypes.enabled = true
@@ -1030,7 +1030,7 @@ shebangs = ["node"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server-official" ]
+language-servers = [ "tsc" ]
 indent = { tab-width = 2, unit = "  " }
 
 [language.debugger]
@@ -1059,7 +1059,7 @@ file-types = ["jsx"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server-official" ]
+language-servers = [ "tsc" ]
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
@@ -1073,7 +1073,7 @@ shebangs = ["deno", "bun", "ts-node"]
 roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server-official" ]
+language-servers = [ "tsc" ]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]

--- a/languages.toml
+++ b/languages.toml
@@ -272,6 +272,15 @@ inlayHints.parameterNames.enabled = "all"
 inlayHints.propertyDeclarationTypes.enabled = true
 inlayHints.variableTypes.enabled = true
 
+[language-server.typescript-language-server-official.config.jsx]
+format.enabled = false
+inlayHints.enumMemberValues.enabled = true
+inlayHints.functionLikeReturnTypes.enabled = true
+inlayHints.parameterTypes.enabled = true
+inlayHints.parameterNames.enabled = "all"
+inlayHints.propertyDeclarationTypes.enabled = true
+inlayHints.variableTypes.enabled = true
+
 [language-server.typescript-language-server]
 command = "typescript-language-server"
 args = ["--stdio"]
@@ -1021,7 +1030,7 @@ shebangs = ["node"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server-official" ]
+language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 
 [language.debugger]
@@ -1050,7 +1059,7 @@ file-types = ["jsx"]
 roots = [ "package.json", "jsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server-official" ]
+language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 grammar = "javascript"
 
@@ -1064,7 +1073,7 @@ shebangs = ["deno", "bun", "ts-node"]
 roots = [ "package.json", "tsconfig.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }
-language-servers = [ "typescript-language-server-official" ]
+language-servers = [ "typescript-language-server" ]
 indent = { tab-width = 2, unit = "  " }
 
 [[grammar]]


### PR DESCRIPTION
Typescript 7 is out and now has an official language server making the old `typescript-language-server` obsolete.

I have tried to match these inlay hint settings to the `typescript-language-server` current Helix defaults and tested they all appear to work. I assume they are all good for JavaScript and JSX, but have not tested.

I have not worked in Typescript for a while and would like some feedback before marking this as ready for merging, please see https://github.com/helix-editor/helix/issues/15134

~~This enables the formatter (by not turning it off), do we want that on, or maybe people are using Prettier etc?~~
