### PR TITLE
Fix tutor exercise 8.1

### DIFF
--- a/runtime/tutor
+++ b/runtime/tutor
@@ -878,8 +878,8 @@ lines.
  5. Select "mangoes" and type R to replace it with "watermelons".
  6. Select "pineapples" then type "b R to replace with "bananas".
 
- --> I like watermelons and bananas because my favorite fruits
-     are mangoes and pineapples.
+ --> I like watermelons and bananas because mangoes and
+     pineapples are my favorite fruits.
 
 
 =================================================================


### PR DESCRIPTION
Pressing only `w` will select `bananas ` (mind the space) in the middle of the sentence and `pineapples` (no space) at the very end, meaning the user needs to manually remove the space again, harming the didactic value of this exercise. Avoid this by editing the sentence so both words end up in the middle.