### PR TITLE
docs: fix themes link in adding-languages guide

### DIFF
--- a/book/src/guides/adding_languages.md
+++ b/book/src/guides/adding_languages.md
@@ -37,7 +37,7 @@ below.
    [tree-sitter website](https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting.html#highlights)
    for more information on writing queries.
 4. The highlight captures (`@function`, `@type`, ...) and how they resolve are
-   documented [on the themes page](./themes.md):
+   documented [on the themes page](../themes.md):
    match the most specific scope that fits, capture the leaf node you mean, and
    remember that the last matching pattern (and the innermost node) wins.
 5. Helix loads several query files from that directory; only `highlights.scm` is


### PR DESCRIPTION
Fixes #16033.

The adding-languages guide is located under `book/src/guides`, so its existing
`./themes.md` target resolves to a nonexistent file. This updates the link to
`../themes.md`, which points to the existing themes page.
