### PR TITLE
Add Pyfun language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -237,6 +237,7 @@
 | pug | ✓ |  |  |  |  |  |
 | puppet | ✓ |  | ✓ |  |  | `puppet-languageserver` |
 | purescript | ✓ | ✓ |  |  |  | `purescript-language-server` |
+| pyfun | ✓ |  |  |  |  | `pyfun` |
 | python | ✓ | ✓ | ✓ | ✓ | ✓ | `ty`, `ruff`, `jedi-language-server`, `pylsp`, `zuban` |
 | qml | ✓ | ✓ | ✓ |  |  | `qmlls` |
 | qmv |  |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -116,6 +116,7 @@ pony-lsp = { command = "pony-lsp", args = ["--stdio"], config = {defines = [], p
 prisma-language-server = { command = "prisma-language-server", args = ["--stdio"], config.prisma.enableDiagnostics = true }
 puppet-languageserver = { command = "puppet-languageserver", args = ["--stdio"] }
 purescript-language-server = { command = "purescript-language-server", args = ["--stdio"] }
+pyfun = { command = "pyfun", args = ["lsp"] }
 pylsp = { command = "pylsp" }
 pyrefly = { command = "pyrefly", args = ["lsp"] }
 pyright = { command = "pyright-langserver", args = ["--stdio"], config = {} }
@@ -1181,6 +1182,19 @@ indent = { tab-width = 4, unit = "    " }
 [[grammar]]
 name = "python"
 source = { git = "https://github.com/tree-sitter/tree-sitter-python", rev = "293fdc02038ee2bf0e2e206711b69c90ac0d413f" }
+
+[[language]]
+name = "pyfun"
+scope = "source.pyfun"
+injection-regex = "pyfun"
+file-types = ["pyfun"]
+comment-token = "#"
+language-servers = ["pyfun"]
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "pyfun"
+source = { git = "https://github.com/simontreanor/Pyfun", rev = "90502f1857052920b8f3e80f959fa81522fc535a", subpath = "editors/tree-sitter-pyfun" }
 
 [[language]]
 name = "nickel"

--- a/runtime/queries/pyfun/highlights.scm
+++ b/runtime/queries/pyfun/highlights.scm
@@ -1,0 +1,164 @@
+; Highlights for Pyfun (https://github.com/simontreanor/Pyfun).
+; Generic rules first; later (more specific) patterns win on equal spans.
+
+; ---- identifiers (defaults) ----
+
+(identifier) @variable
+(constructor_identifier) @constructor
+(type_identifier) @type
+(type_variable) @type.parameter
+(module_identifier) @namespace
+(wildcard) @comment.unused
+(hole) @variable.builtin
+
+(parameter (identifier) @variable.parameter)
+
+; a `let` with parameters defines a function
+(let_binding
+  name: (identifier) @function
+  parameter: (parameter))
+
+(active_pattern_cases
+  case: (constructor_identifier) @function)
+
+; qualified access: the field of `Module.member` / record field access
+(field_expression
+  field: (identifier) @variable.other.member)
+(field_expression
+  field: (constructor_identifier) @constructor)
+
+; record fields
+(field_declaration name: (identifier) @variable.other.member)
+(field_initializer name: (identifier) @variable.other.member)
+(field_update path: (identifier) @variable.other.member)
+(field_pattern name: (identifier) @variable.other.member)
+
+; externs bind Python callables
+(extern_declaration name: (identifier) @function)
+(python_path (identifier) @namespace)
+(extern_kwarg name: (identifier) @variable.parameter)
+
+(measure_definition name: (identifier) @type)
+(measure_factor (identifier) @type)
+(effect_label) @attribute
+
+(ce_expression
+  builder: (module_identifier) @function.macro)
+
+; ---- literals ----
+
+(integer) @constant.numeric.integer
+(float) @constant.numeric.float
+(dimensionless) @constant.numeric
+(boolean) @constant.builtin.boolean
+(string) @string
+(raw_string) @string
+(fstring) @string
+(string_content) @string
+(escape_sequence) @constant.character.escape
+
+(interpolation
+  "{" @punctuation.special
+  "}" @punctuation.special)
+(debug_marker) @operator
+
+(comment) @comment.line
+
+; ---- keywords ----
+
+[
+  "module"
+  "with"
+  "as"
+] @keyword
+
+"let" @keyword.function
+"fun" @keyword.function
+
+[
+  "type"
+  "measure"
+  "extern"
+] @keyword.storage.type
+
+"mut" @keyword.storage.modifier
+"pure" @keyword.storage.modifier
+
+"import" @keyword.control.import
+
+[
+  "if"
+  "then"
+  "elif"
+  "else"
+  "match"
+  "case"
+] @keyword.control.conditional
+
+"try" @keyword.control.exception
+
+[
+  "return"
+  "return!"
+  "yield"
+  "yield!"
+] @keyword.control.return
+
+[
+  "let!"
+  "do!"
+] @keyword
+
+[
+  "async"
+  "seq"
+  "result"
+] @function.macro
+
+[
+  "and"
+  "or"
+  "not"
+] @keyword.operator
+
+; ---- operators & punctuation ----
+
+[
+  "|>"
+  "<|"
+  ">>"
+  "<<"
+  "->"
+  "<-"
+  "=="
+  "!="
+  "<="
+  ">="
+  "<"
+  ">"
+  "+"
+  "-"
+  "*"
+  "/"
+  "//"
+  "%"
+  "**"
+  "="
+  "^"
+  "|"
+] @operator
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+[
+  ","
+  "."
+  ":"
+] @punctuation.delimiter

--- a/runtime/queries/pyfun/injections.scm
+++ b/runtime/queries/pyfun/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
Adds built-in support for [Pyfun](https://github.com/simontreanor/Pyfun), an F#-inspired, functional-first language for the Python ecosystem (immutable-by-default, ADTs with exhaustive matching, inferred effects) whose compiler emits readable Python. File extension is `.pyfun`; the language server ships with the compiler (`pip install pyfun-lang`, run as `pyfun lsp`).

Included:
- `languages.toml`: language + language-server + grammar entries. The tree-sitter grammar (C scanner, committed `parser.c`) is maintained in the Pyfun repository under `editors/tree-sitter-pyfun` (Apache-2.0), pinned by rev with `subpath`.
- `runtime/queries/pyfun/`: `highlights.scm` and `injections.scm` (comment injection). The language is offside-rule/indentation-based, so no indent queries for now.
- `cargo xtask docgen` output.

Validated locally with `cargo xtask docgen`, `cargo xtask query-check pyfun`, and `hx --health pyfun` against a fresh fetch+build of the pinned grammar rev (parser + highlight queries load, LSP resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoP7DMAgjNCihZHsdBagYr