### PR TITLE
Add linkerscript language

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -169,6 +169,7 @@
 | lean | ✓ |  |  |  |  | `lake` |
 | ledger | ✓ |  |  |  |  |  |
 | less | ✓ |  | ✓ |  | ✓ | `vscode-css-language-server` |
+| linkerscript | ✓ |  | ✓ |  |  |  |
 | llvm | ✓ | ✓ | ✓ |  |  |  |
 | llvm-mir | ✓ | ✓ | ✓ |  |  |  |
 | llvm-mir-yaml | ✓ |  | ✓ |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -5648,3 +5648,18 @@ comment-tokens = ["REM", "::"]
 name = "batch"
 source = { git = "https://github.com/wharflab/tree-sitter-batch", rev = "5fc5f54267ef9a78e7a5319b80e092194252aabf" }
 
+[[language]]
+name = "linkerscript"
+scope = "source.linkerscript"
+file-types = ["ld", "x"]
+injection-regex = "ld|x"
+indent = { tab-width = 2, unit = "  " }
+block-comment-tokens = { start = "/*", end = "*/" }
+
+[language.auto-pairs]
+'(' = ')'
+'{' = '}'
+
+[[grammar]]
+name = "linkerscript"
+source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-linkerscript.git", rev = "f99011a3554213b654985a4b0a65b3b032ec4621" }

--- a/runtime/queries/linkerscript/folds.scm
+++ b/runtime/queries/linkerscript/folds.scm
@@ -1,0 +1,6 @@
+[
+  (sections_command)
+  (output_section)
+  (memory_command)
+  (phdrs_command)
+] @fold

--- a/runtime/queries/linkerscript/highlights.scm
+++ b/runtime/queries/linkerscript/highlights.scm
@@ -1,0 +1,146 @@
+; Keywords
+
+[
+  "ENTRY"
+  "SECTIONS"
+  "AT"
+  "OVERLAY"
+  "NOCROSSREFS"
+  "MEMORY"
+  "PHDRS"
+  "FILEHDR"
+] @keyword
+
+; Conditionals
+
+(conditional_expression [ "?" ":" ] @punctuation.special)
+
+; Variables
+
+(symbol) @variable
+
+(filename) @string.special.path
+
+; Functions
+
+(call_expression
+  function: (symbol) @function)
+
+((call_expression
+  function: (symbol) @function.special)
+  (#eq? @preproc "DEFINED"))
+
+((call_expression
+  function: (symbol) @function.builtin)
+  (#any-of? @function.builtin
+   "ABSOLUTE" "ALIAS" "ADDR" "ALIGN" "ALIGNOF" "BASE" "BLOCK" "CHIP" "DATA_SEGMENT_ALIGN"
+   "DATA_SEGMENT_END" "DATA_SEGMENT_RELRO_END" "END" "LENGTH" "LOADADDR" "LOG2CEIL" "MAX" "MIN"
+   "NEXT" "ORIGIN" "SEGMENT_START" "SIZEOF" "BYTE" "FILL" "LONG" "SHORT" "QUAD" "SQUAD" "WORD"))
+
+[
+  "KEEP"
+  "PROVIDE"
+  "PROVIDE_HIDDEN"
+] @function.builtin
+
+; Types
+
+(section_type "(" [ "NOLOAD" "DSECT" "COPY" "INFO" "OVERLAY" ] @type.builtin ")")
+
+; Fields
+
+[
+  "ORIGIN" "org" "o"
+  "LENGTH" "len" "l"
+] @variable.builtin
+
+; Constants
+
+((symbol) @constant
+  (#match? @constant "^[%u_][%u%d_]+$"))
+
+; Labels
+
+(entry_command name: (symbol) @label)
+
+(output_section name: (symbol) @label)
+
+(memory_command name: (symbol) @label)
+
+(phdrs_command name: (symbol) @label)
+
+(region ">" (symbol) @label)
+
+(lma_region ">" (symbol) @label)
+
+(phdr ":" (symbol) @label)
+
+([(symbol) (filename)] @label
+  (#match? @label "^%."))
+
+; Exceptions
+
+"ASSERT" @keyword.control.exception
+
+[
+  "/DISCARD/"
+  "."
+] @variable.builtin
+
+; Operators
+
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "||"
+  "&&"
+  "|"
+  "&"
+  "=="
+  "!="
+  ">"
+  ">="
+  "<="
+  "<"
+  "<<"
+  ">>"
+  "!"
+  "~"
+  "="
+  "+="
+  "-="
+  "*="
+  "/="
+  "<<="
+  ">>="
+  "&="
+  "|="
+] @operator
+
+; Literals
+
+(number) @constant.numeric.integer
+
+(quoted_symbol) @string
+
+(wildcard_pattern [ "*" "[" "]" ] @punctuation.special)
+
+(attributes) @attribute
+
+; Punctuation
+
+[ "{" "}" "(" ")" ] @punctuation.bracket
+
+[
+  ":"
+  ";"
+] @punctuation.delimiter
+
+">" @punctuation.special
+
+; Comments
+
+(comment) @comment

--- a/runtime/queries/linkerscript/indents.scm
+++ b/runtime/queries/linkerscript/indents.scm
@@ -1,0 +1,11 @@
+[
+  (sections_command)
+  (output_section)
+  (memory_command)
+  (phdrs_command)
+] @indent.begin
+
+[
+  "}"
+  ")"
+] @indent.branch @indent.end

--- a/runtime/queries/linkerscript/injections.scm
+++ b/runtime/queries/linkerscript/injections.scm
@@ -1,0 +1,2 @@
+((comment)
+  (#set! injection.language "comment"))

--- a/runtime/queries/linkerscript/locals.scm
+++ b/runtime/queries/linkerscript/locals.scm
@@ -1,0 +1,15 @@
+; References
+
+[
+ (symbol)
+ (filename)
+ (quoted_symbol)
+] @reference
+
+; Definitions
+
+(output_section name: (symbol) @definition.var)
+
+(memory_command name: (symbol) @definition.var)
+
+(phdrs_command name: (symbol) @definition.var)

--- a/runtime/queries/linkerscript/rainbows.scm
+++ b/runtime/queries/linkerscript/rainbows.scm
@@ -1,0 +1,12 @@
+[
+  (sections_command)
+  (output_section)
+  (memory_command)
+  (phdrs_command)
+] @rainbow.scope
+
+[
+  "(" ")"
+  "{" "}"
+  "[" "]"
+] @rainbow.bracket


### PR DESCRIPTION
Adds support for the linkerscript language.

The linkerscript language is used to configure how a linker combines object files into an elf file, is is supported by almost all linkers (gnu, lld, gold, mold), the language is ancient and extremely overengineered, however it is still used to link almost every elf file.
Custom linkerscripts are commonly used in embedded projects and Os-development, so i think this would be useful for a lot of people.

I adjusted the highlighting to the helix scopes and also added support for rainbow brackets.