### PR TITLE
Replace range panic in update_positions with clamping (fixes #15785)

### DIFF
--- a/helix-core/src/transaction.rs
+++ b/helix-core/src/transaction.rs
@@ -504,9 +504,12 @@ impl ChangeSet {
             }
             old_pos = old_end;
         }
-        let out_of_bounds: Vec<_> = positions.collect();
-
-        panic!("Positions {out_of_bounds:?} are out of range for changeset len {old_pos}!",)
+        // Any remaining positions are out of range (beyond the end of the old text).
+        // Clamp them to the end of the new text instead of panicking. This can happen
+        // when a position was computed against a slightly stale document version.
+        for (pos, _assoc) in positions {
+            *pos = new_pos;
+        }
     }
 
     /// Map a position through the changes.


### PR DESCRIPTION
This fixes the panic in: https://github.com/helix-editor/helix/issues/15785
which I just triggered today.

`thread 'main' panicked at helix-core/src/transaction.rs:509:9`

The solution here comes from an earlier PR by @rizvee:
https://github.com/helix-editor/helix/pull/15976
which got stalled for including too much scope in a single PR.

