### PR TITLE
Deduplicate goto locations from multiple language servers

### DIFF
--- a/helix-core/src/uri.rs
+++ b/helix-core/src/uri.rs
@@ -9,7 +9,7 @@ use std::{
 /// Currently this type only supports paths to local files.
 ///
 /// Cloning this type is cheap: the internal representation uses an Arc.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Uri {
     File(Arc<Path>),

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -66,7 +66,7 @@ impl From<sonic_rs::Error> for Error {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum OffsetEncoding {
     /// UTF-8 code units aka bytes
     Utf8,

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -15,7 +15,7 @@ use super::{align_view, push_jump, Align, Context, Editor};
 
 use helix_core::{
     diagnostic::DiagnosticProvider, syntax::config::LanguageServerFeature,
-    text_annotations::InlineAnnotation, Selection, Uri,
+    text_annotations::InlineAnnotation, Rope, Selection, Uri,
 };
 use helix_stdx::path;
 use helix_view::{
@@ -34,7 +34,7 @@ use crate::{
 };
 
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{HashMap, HashSet, VecDeque},
     fmt::Display,
     future::Future,
     path::Path,
@@ -64,7 +64,7 @@ macro_rules! language_server_with_feature {
 
 /// A wrapper around `lsp::Location` that swaps out the LSP URI for `helix_core::Uri` and adds
 /// the server's  offset encoding.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct Location {
     uri: Uri,
     range: lsp::Range,
@@ -911,8 +911,96 @@ impl Display for ApplyEditErrorKind {
     }
 }
 
+/// Removes duplicate locations, keeping the rest in their original order.
+///
+/// When multiple language servers respond to the same request with the same location, the
+/// duplicates may still differ in the servers' offset encodings. Locations which share an
+/// offset encoding are compared directly. Comparing `character` offsets across different
+/// offset encodings however requires the text they point into. To keep I/O to a minimum the
+/// text is only looked up when two locations could actually be duplicates of one another -
+/// when they point to the same lines of the same file (line numbers are the same in every
+/// offset encoding) - and each file's text is fetched at most once.
+fn deduplicate_locations(
+    locations: &mut Vec<Location>,
+    mut text_for_uri: impl FnMut(&Uri) -> Option<Rope>,
+) {
+    // Exact duplicates.
+    let mut seen = HashSet::new();
+    locations.retain(|location| seen.insert(location.clone()));
+
+    // Only locations which point to the same lines of the same file with different offset
+    // encodings can still be duplicates of each other.
+    let mut groups: HashMap<(&Uri, u32, u32), Vec<usize>> = HashMap::new();
+    for (index, location) in locations.iter().enumerate() {
+        groups
+            .entry((
+                &location.uri,
+                location.range.start.line,
+                location.range.end.line,
+            ))
+            .or_default()
+            .push(index);
+    }
+
+    let mut texts: HashMap<&Uri, Option<Rope>> = HashMap::new();
+    let mut duplicates = HashSet::new();
+    for ((uri, _, _), group) in groups {
+        let offset_encoding = locations[group[0]].offset_encoding;
+        if group[1..]
+            .iter()
+            .all(|&index| locations[index].offset_encoding == offset_encoding)
+        {
+            continue;
+        }
+        let Some(text) = texts
+            .entry(uri)
+            .or_insert_with(|| text_for_uri(uri))
+            .as_ref()
+        else {
+            continue;
+        };
+        let mut ranges = HashSet::new();
+        for &index in &group {
+            let location = &locations[index];
+            let Some(range) = lsp_range_to_range(text, location.range, location.offset_encoding)
+            else {
+                continue;
+            };
+            if !ranges.insert((range.anchor, range.head)) {
+                duplicates.insert(index);
+            }
+        }
+    }
+
+    if !duplicates.is_empty() {
+        let mut index = 0;
+        locations.retain(|_| {
+            let keep = !duplicates.contains(&index);
+            index += 1;
+            keep
+        });
+    }
+}
+
 /// Precondition: `locations` should be non-empty.
-fn goto_impl(editor: &mut Editor, compositor: &mut Compositor, locations: Vec<Location>) {
+fn goto_impl(editor: &mut Editor, compositor: &mut Compositor, mut locations: Vec<Location>) {
+    deduplicate_locations(&mut locations, |uri| {
+        let path = uri.as_path()?;
+        if let Some(doc) = editor.document_by_path(path) {
+            return Some(doc.text().clone());
+        }
+        match std::fs::read_to_string(path) {
+            Ok(text) => Some(Rope::from(text)),
+            Err(err) => {
+                log::warn!(
+                    "skipping deduplication of locations in {}: {err}",
+                    path.display()
+                );
+                None
+            }
+        }
+    });
+
     let cwdir = helix_stdx::env::current_working_dir();
 
     match locations.as_slice() {
@@ -1514,4 +1602,113 @@ fn compute_inlay_hints_for_view(
     );
 
     Some(callback)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn location(
+        path: &str,
+        offset_encoding: OffsetEncoding,
+        (start_line, start_character): (u32, u32),
+        (end_line, end_character): (u32, u32),
+    ) -> Location {
+        Location {
+            uri: PathBuf::from(path).into(),
+            range: lsp::Range {
+                start: lsp::Position {
+                    line: start_line,
+                    character: start_character,
+                },
+                end: lsp::Position {
+                    line: end_line,
+                    character: end_character,
+                },
+            },
+            offset_encoding,
+        }
+    }
+
+    #[test]
+    fn removes_exact_duplicates_without_reading_text() {
+        let mut locations = vec![
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 4), (0, 10)),
+            location("/bar.rs", OffsetEncoding::Utf16, (1, 0), (1, 5)),
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 4), (0, 10)),
+        ];
+        deduplicate_locations(&mut locations, |_| panic!("must not look at file contents"));
+        assert_eq!(
+            locations,
+            vec![
+                location("/foo.rs", OffsetEncoding::Utf16, (0, 4), (0, 10)),
+                location("/bar.rs", OffsetEncoding::Utf16, (1, 0), (1, 5)),
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_read_text_for_locations_on_different_lines() {
+        let mut locations = vec![
+            location("/foo.rs", OffsetEncoding::Utf8, (0, 4), (0, 10)),
+            location("/foo.rs", OffsetEncoding::Utf16, (1, 4), (1, 10)),
+        ];
+        deduplicate_locations(&mut locations, |_| panic!("must not look at file contents"));
+        assert_eq!(locations.len(), 2);
+    }
+
+    #[test]
+    fn does_not_read_text_when_offset_encodings_match() {
+        let mut locations = vec![
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 4), (0, 10)),
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 12), (0, 18)),
+        ];
+        deduplicate_locations(&mut locations, |_| panic!("must not look at file contents"));
+        assert_eq!(locations.len(), 2);
+    }
+
+    #[test]
+    fn compares_locations_across_offset_encodings_by_text() {
+        // 'é' is two UTF-8 code units and one UTF-16 code unit, so both ranges
+        // point at "foo".
+        let text = Rope::from("é foo\n");
+        let mut locations = vec![
+            location("/foo.rs", OffsetEncoding::Utf8, (0, 3), (0, 6)),
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 2), (0, 5)),
+        ];
+        let mut reads = 0;
+        deduplicate_locations(&mut locations, |_| {
+            reads += 1;
+            Some(text.clone())
+        });
+        assert_eq!(reads, 1, "the text should be fetched at most once");
+        assert_eq!(
+            locations,
+            vec![location("/foo.rs", OffsetEncoding::Utf8, (0, 3), (0, 6))]
+        );
+    }
+
+    #[test]
+    fn does_not_treat_equal_ranges_in_different_offset_encodings_as_duplicates() {
+        // Because of the multi-byte 'é' the same character offset resolves to
+        // different positions in different offset encodings.
+        let text = Rope::from("é foo\n");
+        let mut locations = vec![
+            location("/foo.rs", OffsetEncoding::Utf8, (0, 3), (0, 3)),
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 3), (0, 3)),
+        ];
+        deduplicate_locations(&mut locations, |_| Some(text.clone()));
+        assert_eq!(locations.len(), 2);
+    }
+
+    #[test]
+    fn keeps_locations_whose_text_is_unavailable() {
+        let mut locations = vec![
+            location("/foo.rs", OffsetEncoding::Utf8, (0, 3), (0, 6)),
+            location("/foo.rs", OffsetEncoding::Utf16, (0, 3), (0, 6)),
+        ];
+        deduplicate_locations(&mut locations, |_| None);
+        assert_eq!(locations.len(), 2);
+    }
 }


### PR DESCRIPTION
Fixes #14551. Alternative to #14573, addressing the review feedback there.

When several language servers respond to a `goto` request, the picker shows one entry *per server* for the same location.
This deduplicates locations in `goto_impl` while keeping I/O to a minimum:
locations sharing an offset encoding are compared directly with no I/O.
Since comparing character offsets across different offset encodings requires the text they point into,
that text is looked up only when two locations point to the same lines of the same file with different encodings —
taken from the open document when possible, otherwise read from disk at most once per file.
A single language server, or servers agreeing on the offset encoding, **never** cause a file read.
Locations are kept in their original order with their original encodings.

Tested locally, seems to work just fine.