### PR TITLE
languages: add `vtsls` language server

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -170,6 +170,7 @@ vlang-language-server = { command = "v-analyzer" }
 vscode-css-language-server = { command = "vscode-css-language-server", args = ["--stdio"], config = { provideFormatter = true, css = { validate = { enable = true } } } }
 vscode-html-language-server = { command = "vscode-html-language-server", args = ["--stdio"], config = { provideFormatter = true } }
 vscode-json-language-server = { command = "vscode-json-language-server", args = ["--stdio"], config = { provideFormatter = true, json = { validate = { enable = true } } } }
+vtsls = { command = "vtsls", args = ["--stdio"], config = { vtsls.autoUseWorkspaceTsdk = true } }
 vuels = { command = "vue-language-server", args = ["--stdio"], config = { typescript = { tsdk = "node_modules/typescript/lib/" } } }
 wgsl-analyzer = { command = "wgsl-analyzer" }
 wikitext-lsp = { command = "wikitext-lsp", args = ["--stdio"]}


### PR DESCRIPTION
# Summary

From the [`repository`](https://github.com/yioneko/vtsls)'s README:

> This is an LSP wrapper around TypeScript extension bundled with VSCode. All features and performance are nearly the same.
