### PR TITLE
prompt: right arrow fills history hint for editing

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -631,7 +631,16 @@ impl Component for Prompt {
             alt!('b') | ctrl!(Left) => self.move_cursor(Movement::BackwardWord(1)),
             alt!('f') | ctrl!(Right) => self.move_cursor(Movement::ForwardWord(1)),
             ctrl!('b') | key!(Left) => self.move_cursor(Movement::BackwardChar(1)),
-            ctrl!('f') | key!(Right) => self.move_cursor(Movement::ForwardChar(1)),
+            ctrl!('f') | key!(Right) => {
+                if self.line.is_empty() {
+                    if let Some(suggestion) = self.first_history_completion(cx.editor) {
+                        self.set_line(suggestion.into_owned(), cx.editor);
+                        (self.callback_fn)(cx, &self.line, PromptEvent::Update);
+                        return EventResult::Consumed(None);
+                    }
+                }
+                self.move_cursor(Movement::ForwardChar(1));
+            }
             ctrl!('e') | key!(End) => self.move_end(),
             ctrl!('a') | key!(Home) => self.move_start(),
             ctrl!('w') | alt!(Backspace) | ctrl!(Backspace) => {

--- a/helix-term/tests/test/command_line.rs
+++ b/helix-term/tests/test/command_line.rs
@@ -158,3 +158,19 @@ async fn percent_escaping() -> anyhow::Result<()> {
     .await?;
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn right_arrow_fills_history() -> anyhow::Result<()> {
+    test_key_sequence(
+        &mut AppBuilder::new().build()?,
+        Some(":echo 1<ret>:<right> 2<ret>"),
+        Some(&|app| {
+            let (status, &severity) = app.editor.get_status().unwrap();
+            assert_eq!(severity, Severity::Info);
+            assert_eq!(status.as_ref(), "1 2");
+        }),
+        false,
+    )
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
When the prompt is empty and shows the previous command as a dimmed hint, pressing Right now fills the prompt with that entry and places the cursor at the end, allowing the user to edit it before executing.