### PR TITLE
Add an overtype feature to the insert mode (sticky replace)

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -53,6 +53,7 @@
 | `extend_prev_char` | Extend to previous occurrence of char | select: `` F `` |
 | `repeat_last_motion` | Repeat last motion | normal: `` <A-.> ``, select: `` <A-.> `` |
 | `replace` | Replace with new char | normal: `` r ``, select: `` r `` |
+| `enter_overtype_mode` | Enter overtype mode | normal: `` <C-r> ``, select: `` <C-r> `` |
 | `switch_case` | Switch (toggle) case | normal: `` ~ ``, select: `` ~ `` |
 | `switch_to_uppercase` | Switch to uppercase | normal: `` <A-`> ``, select: `` <A-`> `` |
 | `switch_to_lowercase` | Switch to lowercase | normal: `` ` ``, select: `` ` `` |

--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -53,6 +53,7 @@
 | `extend_prev_char` | Extend to previous occurrence of char | select: `` F `` |
 | `repeat_last_motion` | Repeat last motion | normal: `` <A-.> ``, select: `` <A-.> `` |
 | `replace` | Replace with new char | normal: `` r ``, select: `` r `` |
+| `overtype_mode` | Enter overtype mode | normal: `` <C-r> ``, select: `` <C-r> `` |
 | `switch_case` | Switch (toggle) case | normal: `` ~ ``, select: `` ~ `` |
 | `switch_to_uppercase` | Switch to uppercase | normal: `` <A-`> ``, select: `` <A-`> `` |
 | `switch_to_lowercase` | Switch to lowercase | normal: `` ` ``, select: `` ` `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -356,6 +356,7 @@ impl MappableCommand {
         extend_prev_char, "Extend to previous occurrence of char",
         repeat_last_motion, "Repeat last motion",
         replace, "Replace with new char",
+        enter_overtype_mode, "Enter overtype mode",
         switch_case, "Switch (toggle) case",
         switch_to_uppercase, "Switch to uppercase",
         switch_to_lowercase, "Switch to lowercase",
@@ -3114,6 +3115,12 @@ fn ensure_selections_forward(cx: &mut Context) {
 
 fn enter_insert_mode(cx: &mut Context) {
     cx.editor.mode = Mode::Insert;
+    cx.editor.overtype = false;
+}
+
+fn enter_overtype_mode(cx: &mut Context) {
+    cx.editor.mode = Mode::Insert;
+    cx.editor.overtype = true;
 }
 
 // inserts at the start of each selection
@@ -4357,16 +4364,34 @@ pub mod insert {
             ((cursor, cursor, Some(t)), None)
         };
 
-        let transaction = Transaction::change_by_and_with_selection(text, selection, |range| {
-            auto_pairs
-                .as_ref()
-                .and_then(|ap| {
-                    auto_pairs::hook_insert(text, range, c, ap)
-                        .map(|(change, range)| (change, Some(range)))
-                        .or_else(|| Some(insert_char(*range, c)))
-                })
-                .unwrap_or_else(|| insert_char(*range, c))
-        });
+        let replace_char = |range: Range, ch: char| {
+            let cursor = range.cursor(text.slice(..));
+            let t = Tendril::from_iter([ch]);
+            // Don't eat the newline. If cursor is at end of line, fall back to pure insert.
+            if cursor < text.len_chars() && text.char(cursor) != '\n' {
+                let next_char = Some(Range::new(cursor + 1, cursor + 1));
+                ((cursor, cursor + 1, Some(t)), next_char)
+            } else {
+                ((cursor, cursor, Some(t)), None)
+            }
+        };
+
+        let transaction = if cx.editor.overtype {
+            Transaction::change_by_and_with_selection(text, selection, |range| {
+                replace_char(*range, c)
+            })
+        } else {
+            Transaction::change_by_and_with_selection(text, selection, |range| {
+                auto_pairs
+                    .as_ref()
+                    .and_then(|ap| {
+                        auto_pairs::hook_insert(text, range, c, ap)
+                            .map(|(change, range)| (change, Some(range)))
+                            .or_else(|| Some(insert_char(*range, c)))
+                    })
+                    .unwrap_or_else(|| insert_char(*range, c))
+            })
+        };
 
         let doc = doc_mut!(cx.editor, &doc.id());
         doc.apply(&transaction, view.id);

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -356,6 +356,7 @@ impl MappableCommand {
         extend_prev_char, "Extend to previous occurrence of char",
         repeat_last_motion, "Repeat last motion",
         replace, "Replace with new char",
+        overtype_mode, "Enter overtype mode",
         switch_case, "Switch (toggle) case",
         switch_to_uppercase, "Switch to uppercase",
         switch_to_lowercase, "Switch to lowercase",
@@ -3114,6 +3115,12 @@ fn ensure_selections_forward(cx: &mut Context) {
 
 fn enter_insert_mode(cx: &mut Context) {
     cx.editor.mode = Mode::Insert;
+    cx.editor.overtype = false;
+}
+
+fn overtype_mode(cx: &mut Context) {
+    cx.editor.mode = Mode::Insert;
+    cx.editor.overtype = true;
 }
 
 // inserts at the start of each selection
@@ -4357,16 +4364,34 @@ pub mod insert {
             ((cursor, cursor, Some(t)), None)
         };
 
-        let transaction = Transaction::change_by_and_with_selection(text, selection, |range| {
-            auto_pairs
-                .as_ref()
-                .and_then(|ap| {
-                    auto_pairs::hook_insert(text, range, c, ap)
-                        .map(|(change, range)| (change, Some(range)))
-                        .or_else(|| Some(insert_char(*range, c)))
-                })
-                .unwrap_or_else(|| insert_char(*range, c))
-        });
+        let replace_char = |range: Range, ch: char| {
+            let cursor = range.cursor(text.slice(..));
+            let t = Tendril::from_iter([ch]);
+            // Don't eat the newline. If cursor is at end of line, fall back to pure insert.
+            if cursor < text.len_chars() && text.char(cursor) != '\n' {
+                let next_char = Some(Range::new(cursor + 1, cursor + 1));
+                ((cursor, cursor + 1, Some(t)), next_char)
+            } else {
+                ((cursor, cursor, Some(t)), None)
+            }
+        };
+
+        let transaction = if cx.editor.overtype {
+            Transaction::change_by_and_with_selection(text, selection, |range| {
+                replace_char(*range, c)
+            })
+        } else {
+            Transaction::change_by_and_with_selection(text, selection, |range| {
+                auto_pairs
+                    .as_ref()
+                    .and_then(|ap| {
+                        auto_pairs::hook_insert(text, range, c, ap)
+                            .map(|(change, range)| (change, Some(range)))
+                            .or_else(|| Some(insert_char(*range, c)))
+                    })
+                    .unwrap_or_else(|| insert_char(*range, c))
+            })
+        };
 
         let doc = doc_mut!(cx.editor, &doc.id());
         doc.apply(&transaction, view.id);

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -338,6 +338,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
         "C-a" => increment,
         "C-x" => decrement,
+        "C-r" => enter_overtype_mode,
     });
     let mut select = normal.clone();
     select.merge_nodes(keymap!({ "Select mode"

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -338,6 +338,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
 
         "C-a" => increment,
         "C-x" => decrement,
+        "C-r" => overtype_mode,
     });
     let mut select = normal.clone();
     select.merge_nodes(keymap!({ "Select mode"

--- a/helix-term/src/ui/statusline.rs
+++ b/helix-term/src/ui/statusline.rs
@@ -169,7 +169,13 @@ where
     let config = context.editor.config();
     let modenames = &config.statusline.mode;
     let mode_str = match context.editor.mode() {
-        Mode::Insert => &modenames.insert,
+        Mode::Insert => {
+            if context.editor.overtype {
+                &modenames.overtype
+            } else {
+                &modenames.insert
+            }
+        }
         Mode::Select => &modenames.select,
         Mode::Normal => &modenames.normal,
     };

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -717,6 +717,7 @@ impl Default for StatusLineConfig {
 pub struct ModeConfig {
     pub normal: String,
     pub insert: String,
+    pub overtype: String,
     pub select: String,
 }
 
@@ -725,6 +726,7 @@ impl Default for ModeConfig {
         Self {
             normal: String::from("NOR"),
             insert: String::from("INS"),
+            overtype: String::from("OVR"),
             select: String::from("SEL"),
         }
     }
@@ -1273,6 +1275,7 @@ type Diagnostics = BTreeMap<Uri, Vec<(lsp::Diagnostic, DiagnosticProvider)>>;
 pub struct Editor {
     /// Current editing mode.
     pub mode: Mode,
+    pub overtype: bool,
     pub tree: Tree,
     pub next_document_id: DocumentId,
     pub documents: BTreeMap<DocumentId, Document>,
@@ -1427,6 +1430,7 @@ impl Editor {
 
         Self {
             mode: Mode::Normal,
+            overtype: false,
             tree: Tree::new(area),
             next_document_id: DocumentId::default(),
             documents: BTreeMap::new(),


### PR DESCRIPTION
Inspired by https://github.com/helix-editor/helix/pull/11265 and https://github.com/helix-editor/helix/pull/14120, I implemented a simple version of an overtype (sticky replace) mode. Instead of introducing a new mode, it uses the standard insert mode under the hood. This allows a single `undo` for all changes made while in the mode - which was a problem with other solutions so far.

By default, the mode can be entered with `ctrl-r`.

Implements https://github.com/helix-editor/helix/issues/5843.

https://github.com/user-attachments/assets/c5873799-b9ba-4c97-b453-e4640beef4ca

