### PR TITLE
feat(helix-term): open from global search selects search term

### DIFF
--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -90,6 +90,7 @@ use helix_stdx::Url;
 use once_cell::sync::Lazy;
 use serde::de::{self, Deserialize, Deserializer};
 
+use grep_matcher::Matcher;
 use grep_regex::RegexMatcherBuilder;
 use grep_searcher::{sinks, BinaryDetection, SearcherBuilder};
 use ignore::{DirEntry, WalkBuilder, WalkState};
@@ -2569,14 +2570,26 @@ fn global_search(cx: &mut Context) {
         line_start: usize,
         /// 0 indexed line end
         line_end: usize,
+        /// Match start byte offset relative to `line_start`
+        match_start_byte: usize,
+        /// Match end byte offset relative to `line_start`
+        match_end_byte: usize,
     }
 
     impl FileResult<'_> {
-        fn new(path: &Path, line_start: usize, line_end: usize) -> Self {
+        fn new(
+            path: &Path,
+            line_start: usize,
+            line_end: usize,
+            match_start_byte: usize,
+            match_end_byte: usize,
+        ) -> Self {
             Self {
                 path: helix_stdx::path::get_relative_path(path.to_path_buf()),
                 line_start,
                 line_end,
+                match_start_byte,
+                match_end_byte,
             }
         }
     }
@@ -2683,8 +2696,20 @@ fn global_search(cx: &mut Context) {
                         let sink = sinks::UTF8(|line_start, line_content| {
                             let line_start = line_start as usize - 1;
                             let line_end = line_start + line_content.lines().count() - 1;
+                            let Some(match_range) = matcher
+                                .find(line_content.as_bytes())
+                                .map_err(|err| std::io::Error::other(err.to_string()))?
+                            else {
+                                return Ok(true);
+                            };
                             stop = injector
-                                .push(FileResult::new(entry.path(), line_start, line_end))
+                                .push(FileResult::new(
+                                    entry.path(),
+                                    line_start,
+                                    line_end,
+                                    match_range.start(),
+                                    match_range.end(),
+                                ))
                                 .is_err();
 
                             Ok(!stop)
@@ -2742,7 +2767,8 @@ fn global_search(cx: &mut Context) {
               FileResult {
                   path,
                   line_start,
-                  line_end,
+                  match_start_byte,
+                  match_end_byte,
                   ..
               },
               action| {
@@ -2756,7 +2782,6 @@ fn global_search(cx: &mut Context) {
             };
 
             let line_start = *line_start;
-            let line_end = *line_end;
             let view = view_mut!(cx.editor);
             let text = doc.text();
             if line_start >= text.len_lines() {
@@ -2765,10 +2790,18 @@ fn global_search(cx: &mut Context) {
                 );
                 return;
             }
-            let start = text.line_to_char(line_start);
-            let end = text.line_to_char((line_end + 1).min(text.len_lines()));
+            let Some(selection) = selection_for_global_search_match(
+                text.slice(..),
+                line_start,
+                *match_start_byte,
+                *match_end_byte,
+            ) else {
+                cx.editor
+                    .set_error("The match you jumped to does not exist anymore.");
+                return;
+            };
 
-            doc.set_selection(view.id, Selection::single(start, end));
+            doc.set_selection(view.id, selection);
             if action.align_view(view, doc.id()) {
                 align_view(doc, view, Align::Center);
             }
@@ -2787,6 +2820,29 @@ fn global_search(cx: &mut Context) {
     .with_dynamic_query(get_files, Some(275));
 
     cx.push_layer(Box::new(overlaid(picker)));
+}
+
+fn selection_for_global_search_match(
+    text: RopeSlice,
+    line_start: usize,
+    match_start_byte: usize,
+    match_end_byte: usize,
+) -> Option<Selection> {
+    if line_start >= text.len_lines() || match_start_byte > match_end_byte {
+        return None;
+    }
+
+    let line_start_byte = text.line_to_byte(line_start);
+    let start_byte = line_start_byte + match_start_byte;
+    let end_byte = line_start_byte + match_end_byte;
+    if end_byte > text.len_bytes() {
+        return None;
+    }
+
+    Some(Selection::single(
+        text.byte_to_char(start_byte),
+        text.byte_to_char(end_byte),
+    ))
 }
 
 enum Extend {
@@ -7224,5 +7280,24 @@ fn lsp_or_syntax_workspace_symbol_picker(cx: &mut Context) {
         lsp::workspace_symbol_picker(cx);
     } else {
         syntax_workspace_symbol_picker(cx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn global_search_match_selection_uses_match_range() {
+        let text = Rope::from("hello search term world\n");
+        let line = text.line(0).to_string();
+        let match_start_byte = line.find("search").unwrap();
+        let match_end_byte = line.find(" term").unwrap();
+
+        let selection =
+            selection_for_global_search_match(text.slice(..), 0, match_start_byte, match_end_byte)
+                .unwrap();
+
+        assert_eq!(selection.primary().fragment(text.slice(..)), "search");
     }
 }


### PR DESCRIPTION
When opening a buffer from a global search (`space+/` by default) select the matching term instead of the whole line. This makes it easier to do things such as search and replace where one can immediately `change_selection` after opening the file and the selection already matches what the user searched for.
