### PR TITLE
Inject regex into html input tag pattern attribute

### DIFF
--- a/runtime/queries/html/injections.scm
+++ b/runtime/queries/html/injections.scm
@@ -8,3 +8,10 @@
 ((style_element
   (raw_text) @injection.content)
  (#set! injection.language "css"))
+
+; e.g. `<input pattern="[Bb]anana|[Cc]herry" />
+(attribute
+  (attribute_name) @_attr (#eq? @_attr "pattern")
+  (quoted_attribute_value
+    (attribute_value) @injection.content)
+  (#set! injection.language "regex"))


### PR DESCRIPTION
The value of the pattern attribute in <input> elements are
regular expressions. Documented here:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/pattern

**Preview**

<img width="1189" height="534" alt="image" src="https://github.com/user-attachments/assets/33c045c7-6343-410c-ad86-d1b9ac63aa6d" />
