### PR TITLE
fix(dap): Don't fetch expensive scopes

### DIFF
--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -562,16 +562,32 @@ pub fn dap_variables(cx: &mut Context) {
     let scope_style = theme.get("ui.linenr.selected");
     let type_style = theme.get("ui.text");
     let text_style = theme.get("ui.text.focus");
+    let inactive_style = theme.get("ui.text.inactive");
 
     for scope in scopes.iter() {
         // use helix_view::graphics::Style;
         use tui::text::Span;
-        let response = block_on(debugger.variables(scope.variables_reference));
 
         variables.push(Spans::from(Span::styled(
             format!("▸ {}", scope.name),
             scope_style,
         )));
+
+        // The adapter marked this scope `expensive`, meaning resolving its
+        // variables can be arbitrarily slow or hang entirely (e.g. a
+        // JavaScript "Global" scope). `debugger.variables` is awaited via
+        // `block_on` below, which would freeze the whole editor if the
+        // adapter never responds, so these scopes are skipped rather than
+        // fetched automatically.
+        if scope.expensive {
+            variables.push(Spans::from(Span::styled(
+                "  <expensive scope, not fetched>".to_string(),
+                inactive_style,
+            )));
+            continue;
+        }
+
+        let response = block_on(debugger.variables(scope.variables_reference));
 
         if let Ok(vars) = response {
             variables.reserve(vars.len());


### PR DESCRIPTION
Helix's debugger will hang if it tries to fetch an expensive scope, such as the "global" scope in JavaScript. Causing the debugger to be completely unusable.

Per the [DAP spec](https://microsoft.github.io/debug-adapter-protocol/specification#Types_Scope), `expensive` means "the number of variables in this scope is large or expensive to retrieve... recommended for UIs to not automatically expand and evaluate the scope. Some debug adapters (e.g. `vscode-js-debug`, used for JavaScript/Chrome debugging) mark scopes like "Global" as expensive because resolving them can hang forever. 

## Fix
The fix is to not fetch expensive scopes. This unblocks the debugger and improves performance for those who just care about seeing locals. This does mean expensive scopes can't be fetched because the UI doesn't allow that, we will need a follow up PR which allows expanding scopes within the Helix UI

## Reproduction Steps (to test)

Set your languages file to be this:

```toml
# JavaScript configuration (reuse everything)
[[language]]
name = "javascript"
language-servers = ["typescript-language-server"]
roots = ["package.json"]

[language.debugger]
name = "vscode-js-debug"
command = "node"
args = ["path/to/vscode-js-debug/dist/src/dapDebugServer.js"]
transport = "tcp"
port-arg = "{} 127.0.0.1"

[[language.debugger.templates]]
name = "Launch Node Script"
request = "launch"

[[language.debugger.templates.completion]]
name = "main"
completion = "filename"

[language.debugger.templates.args]
type = "pwa-node"
program = "{0}"
address = "127.0.0.1"
skipFiles = ["<node_internals>/**/*"]

[[language.debugger.templates]]
name = "Attach to mock CDP"
request = "attach"

[language.debugger.templates.args]
type = "pwa-chrome"
request = "attach"
address = "127.0.0.1"
port = 9333
pauseForSourceMap = false
```
(Helix master branch)
1. clone https://github.com/jasonwilliams/zed-dap-repro
1. `npm i`
1. `npm start`
1. in another terminal window open helix in this same directory, then do `space G` for debug, then `launch debug target`.
1. Choose the "attach to mock CDP" added above"
1. Wait for it to connect and you get control back (this is another bug we need to fix)
1. In another terminal window run  `curl 127.0.0.1:9333/control/pause`, this will trigger a breakpoint in helix
1. `space G`, then `v` to list variables
1. `curl 127.0.0.1:9333/control/status`  you should see
  hungOnExpensiveScope populated (even before you've clicked anything in the UI)
  
Switch to this PR and do the same, on the final step Helix wont hang

<img width="1219" height="678" alt="image" src="https://github.com/user-attachments/assets/31b9d5af-4434-40ee-ae19-3d0704cf0be1" />

Disclosure,  I applied the same fix for Zed: https://github.com/zed-industries/zed/pull/61144 but as i also use Helix i've added the same fix here too

## Follow Ups
- In the variables pop-up window, we probably want the arrow pointing downwards for variables populated, and sideways for an "unexpanded" scope. That way we don't need the message "expensive scope, not fetched".
- Scopes in the variables pop-up window need to be selectable and expandable (triggering a "variables" request in DAP)
- We will need to look into the long connection time (unrelated to this PR)