### PR TITLE
docs: new line on instructions for Helix tutor access

### DIFF
--- a/book/src/usage.md
+++ b/book/src/usage.md
@@ -2,7 +2,9 @@
 
 For a full interactive introduction to Helix, refer to the
 [tutor](https://github.com/helix-editor/helix/blob/master/runtime/tutor) which
-can be accessed via the command `hx --tutor` or `:tutor`.
+can be accessed via the next commands:
+
+`hx --tutor` or `:tutor`
 
 > 💡 Currently, not all functionality is fully documented, please refer to the
 > [key mappings](./keymap.md) list.


### PR DESCRIPTION
Clarified commands for accessing the Helix tutor, inserting a new line and adding the plural of 'command'.