### PR TITLE
fix: lsp: correctly clear workspace diagnostics on LSP(s) stop or restart

### DIFF
--- a/helix-core/src/command_line.rs
+++ b/helix-core/src/command_line.rs
@@ -923,6 +923,11 @@ impl<'a> Args<'a> {
         self.positionals.is_empty()
     }
 
+    /// Positionals arguments, in the order they were given.
+    pub fn positionals(&self) -> &[Cow<'a, str>] {
+        &self.positionals
+    }
+
     /// Gets the first positional argument, if one exists.
     pub fn first(&'a self) -> Option<&'a str> {
         self.positionals.first().map(AsRef::as_ref)

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -687,16 +687,24 @@ impl Registry {
         Some(Ok(client))
     }
 
-    pub fn stop(&mut self, name: &str) {
-        if let Some(clients) = self.inner_by_name.get_mut(name) {
+    pub fn stop(&mut self, server_id: LanguageServerId) {
+        if let Some(client) = self.inner.remove(server_id) {
             // Drain the clients vec so that the entry in `inner_by_name` remains
             // empty. We use the empty vec as a "tombstone" to mean that a server
             // has been manually stopped with :lsp-stop and shouldn't be automatically
             // restarted by `get`. :lsp-restart can be used to restart the server
             // manually.
-            for client in clients.drain(..) {
+            let mut saw_id = false;
+            for subclient in self.inner_by_name.entry(client.name().into()).or_default() {
+                saw_id |= client.id() == subclient.id();
+                self.inner.remove(subclient.id());
+                self.file_event_handler.remove_client(subclient.id());
+                subclient.force_shutdown();
+            }
+            // Thoroughness check, but in practice this should never be entered,
+            // iterating by name should always contain the client we're removing by id
+            if !saw_id {
                 self.file_event_handler.remove_client(client.id());
-                self.inner.remove(client.id());
                 client.force_shutdown();
             }
         }

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -687,17 +687,32 @@ impl Registry {
         Some(Ok(client))
     }
 
-    pub fn stop(&mut self, name: &str) {
-        if let Some(clients) = self.inner_by_name.get_mut(name) {
-            // Drain the clients vec so that the entry in `inner_by_name` remains
-            // empty. We use the empty vec as a "tombstone" to mean that a server
-            // has been manually stopped with :lsp-stop and shouldn't be automatically
-            // restarted by `get`. :lsp-restart can be used to restart the server
-            // manually.
-            for client in clients.drain(..) {
-                self.file_event_handler.remove_client(client.id());
-                self.inner.remove(client.id());
-                client.force_shutdown();
+    pub fn stop(&mut self, server_id: LanguageServerId, automatic_stop: bool) {
+        let Self {
+            inner,
+            inner_by_name,
+            syn_loader: _,
+            incoming: _,
+            file_event_handler,
+        } = self;
+
+        if let Some(client) = inner.remove(server_id) {
+            // Drain the clients vec so that the entry in `inner_by_name` remains empty. We use
+            // the empty vec as a "tombstone" to mean that a server has been manually stopped with
+            // :lsp-stop and shouldn't be automatically restarted by `get`. :lsp-restart can be used
+            // to restart the server manually.
+            if let Some(clients_by_name) = inner_by_name.get_mut(client.name()) {
+                for subclient in clients_by_name.drain(..) {
+                    inner.remove(subclient.id());
+                    file_event_handler.remove_client(subclient.id());
+                    subclient.force_shutdown();
+                }
+            }
+            // In case of automatic stop we remove the vec entirely because if the user closed the
+            // last Markdown file and then open a Markdown file again 5 minutes later, they likely
+            // expect the LS to start up again: they did not ask for manual stop after all
+            if automatic_stop {
+                inner_by_name.remove(client.name());
             }
         }
     }

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -1804,6 +1804,9 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
         return Ok(());
     }
 
+    // Stop existing LSPs to ensure their diagnostics are correctly cleared
+    lsp_stop_inner(cx, args.positionals(), event)?;
+
     let editor_config = cx.editor.config.load();
     let doc = doc!(cx.editor);
     let config = doc
@@ -1885,31 +1888,40 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
 }
 
 fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow::Result<()> {
+    lsp_stop_inner(cx, args.positionals(), event)
+}
+
+fn lsp_stop_inner(
+    cx: &mut compositor::Context,
+    args: &[Cow<'_, str>],
+    event: PromptEvent,
+) -> anyhow::Result<()> {
     if event != PromptEvent::Validate {
         return Ok(());
     }
+
     let doc = doc!(cx.editor);
 
     let language_servers: Vec<_> = doc
         .language_servers()
-        .map(|ls| ls.name().to_string())
+        .map(|ls| (ls.id(), ls.name().to_string()))
         .collect();
     let language_servers = if args.is_empty() {
         language_servers
     } else {
-        let (valid, invalid): (Vec<_>, Vec<_>) = args
-            .iter()
-            .map(|arg| arg.to_string())
-            .partition(|name| language_servers.contains(name));
+        let (valid, invalid): (Vec<_>, Vec<_>) = language_servers
+            .into_iter()
+            .partition(|(_, name)| args.contains(&Cow::Borrowed(name.as_str())));
         if !invalid.is_empty() {
+            let invalid: Vec<_> = invalid.into_iter().map(|i| i.1).collect();
             let s = if invalid.len() == 1 { "" } else { "s" };
             bail!("Unknown language server{s}: {}", invalid.join(", "));
         }
         valid
     };
 
-    for ls_name in &language_servers {
-        cx.editor.language_servers.stop(ls_name);
+    for (ls_id, ls_name) in &language_servers {
+        cx.editor.remove_language_server_by_id(*ls_id);
 
         for doc in cx.editor.documents_mut() {
             if let Some(client) = doc.remove_language_server_by_name(ls_name) {

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -10,6 +10,7 @@ use helix_core::command_line::{Args, Flag, Signature, Token, TokenKind};
 use helix_core::fuzzy::fuzzy_match;
 use helix_core::indent::MAX_INDENT;
 use helix_core::line_ending;
+use helix_lsp::LanguageServerId;
 use helix_stdx::path::home_dir;
 use helix_view::document::{read_to_string, DEFAULT_LANGUAGE_NAME};
 use helix_view::editor::{CloseError, ConfigEvent};
@@ -1804,38 +1805,23 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
         return Ok(());
     }
 
+    // Stop existing LSPs to ensure their diagnostics are correctly cleared
+    let selected = lsp_helper_filter_from_args(cx, &args)?;
+    lsp_stop_inner(cx.editor, &selected);
+
     let editor_config = cx.editor.config.load();
     let doc = doc!(cx.editor);
     let config = doc
         .language_config()
         .context("LSP not defined for the current document")?;
 
-    let language_servers: Vec<_> = config
-        .language_servers
-        .iter()
-        .map(|ls| ls.name.as_str())
-        .collect();
-    let language_servers = if args.is_empty() {
-        language_servers
-    } else {
-        let (valid, invalid): (Vec<_>, Vec<_>) = args
-            .iter()
-            .map(|arg| arg.as_ref())
-            .partition(|name| language_servers.contains(name));
-        if !invalid.is_empty() {
-            let s = if invalid.len() == 1 { "" } else { "s" };
-            bail!("Unknown language server{s}: {}", invalid.join(", "));
-        }
-        valid
-    };
-
     let mut errors = Vec::new();
-    for server in language_servers.iter() {
+    for (_, name) in &selected {
         match cx
             .editor
             .language_servers
             .restart_server(
-                server,
+                name,
                 config,
                 doc.path(),
                 &editor_config.workspace_lsp_roots,
@@ -1846,7 +1832,7 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
             // Ignore the executable-not-found error unless the server was explicitly requested
             // in the arguments.
             Err(helix_lsp::Error::ExecutableNotFound(_))
-                if !args.iter().any(|arg| arg == server) => {}
+                if !args.iter().any(|arg| **arg == **name) => {}
             Err(err) => errors.push(err.to_string()),
             _ => (),
         }
@@ -1859,9 +1845,9 @@ fn lsp_restart(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> 
         .filter_map(|doc| match doc.language_config() {
             Some(config)
                 if config.language_servers.iter().any(|ls| {
-                    language_servers
+                    selected
                         .iter()
-                        .any(|restarted_ls| restarted_ls == &ls.name)
+                        .any(|(_, restarted_ls)| **restarted_ls == *ls.name)
                 }) =>
             {
                 Some(doc.id())
@@ -1888,30 +1874,17 @@ fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
     if event != PromptEvent::Validate {
         return Ok(());
     }
-    let doc = doc!(cx.editor);
 
-    let language_servers: Vec<_> = doc
-        .language_servers()
-        .map(|ls| ls.name().to_string())
-        .collect();
-    let language_servers = if args.is_empty() {
-        language_servers
-    } else {
-        let (valid, invalid): (Vec<_>, Vec<_>) = args
-            .iter()
-            .map(|arg| arg.to_string())
-            .partition(|name| language_servers.contains(name));
-        if !invalid.is_empty() {
-            let s = if invalid.len() == 1 { "" } else { "s" };
-            bail!("Unknown language server{s}: {}", invalid.join(", "));
-        }
-        valid
-    };
+    let selected = lsp_helper_filter_from_args(cx, &args)?;
+    lsp_stop_inner(cx.editor, &selected);
+    Ok(())
+}
 
-    for ls_name in &language_servers {
-        cx.editor.language_servers.stop(ls_name);
+fn lsp_stop_inner(editor: &mut Editor, selected: &[(LanguageServerId, Box<str>)]) {
+    for (ls_id, ls_name) in selected {
+        editor.remove_language_server_by_id(*ls_id, false);
 
-        for doc in cx.editor.documents_mut() {
+        for doc in editor.documents_mut() {
             if let Some(client) = doc.remove_language_server_by_name(ls_name) {
                 doc.clear_diagnostics_for_language_server(client.id());
                 doc.reset_all_inlay_hints();
@@ -1919,8 +1892,42 @@ fn lsp_stop(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> any
             }
         }
     }
+}
 
-    Ok(())
+fn lsp_helper_filter_from_args(
+    cx: &compositor::Context,
+    args: &Args,
+) -> anyhow::Result<Vec<(LanguageServerId, Box<str>)>> {
+    let doc = doc!(cx.editor);
+
+    let language_servers: Vec<_> = doc
+        .language_servers()
+        .map(|ls| (ls.id(), ls.name()))
+        .collect();
+
+    let mut selected = Vec::new();
+    let mut invalid = Vec::new();
+    if args.positionals().is_empty() {
+        selected = language_servers
+            .into_iter()
+            .map(|(i, s)| (i, Box::from(s)))
+            .collect();
+    } else {
+        for arg in args.positionals() {
+            let item = language_servers.iter().find(|(_, name)| arg == name);
+            match item {
+                Some((id, name)) => selected.push((*id, Box::from(*name))),
+                None => invalid.push(arg.as_ref()),
+            }
+        }
+    }
+
+    if !invalid.is_empty() {
+        let s = if invalid.len() == 1 { "" } else { "s" };
+        bail!("Unknown language server{s}: {}", invalid.join(", "));
+    }
+
+    Ok(selected)
 }
 
 fn tree_sitter_scopes(

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -437,6 +437,17 @@ pub fn register_hooks(_handlers: &Handlers) {
         // Send textDocument/didClose notifications.
         for language_server in event.doc.language_servers() {
             language_server.text_document_did_close(event.doc.identifier());
+
+            // Stop the language server if this was the last open document using it.
+            if event
+                .editor
+                .documents()
+                .all(|d| !d.supports_language_server(language_server.id()))
+            {
+                event
+                    .editor
+                    .remove_language_server_by_id(language_server.id());
+            };
         }
 
         Ok(())

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -386,6 +386,14 @@ impl Editor {
             }
         });
     }
+
+    pub fn remove_language_server_by_id(&mut self, server_id: LanguageServerId) {
+        self.language_servers.stop(server_id);
+        self.diagnostics.retain(|_, diags| {
+            diags.retain(|(_, provider)| provider.language_server_id() != Some(server_id));
+            !diags.is_empty()
+        });
+    }
 }
 
 pub fn register_hooks(_handlers: &Handlers) {

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -386,6 +386,18 @@ impl Editor {
             }
         });
     }
+
+    pub fn remove_language_server_by_id(
+        &mut self,
+        server_id: LanguageServerId,
+        automatic_stop: bool,
+    ) {
+        self.language_servers.stop(server_id, automatic_stop);
+        self.diagnostics.retain(|_, diags| {
+            diags.retain(|(_, provider)| provider.language_server_id() != Some(server_id));
+            !diags.is_empty()
+        });
+    }
 }
 
 pub fn register_hooks(_handlers: &Handlers) {
@@ -429,6 +441,17 @@ pub fn register_hooks(_handlers: &Handlers) {
         // Send textDocument/didClose notifications.
         for language_server in event.doc.language_servers() {
             language_server.text_document_did_close(event.doc.identifier());
+
+            // Stop the language server if this was the last open document using it.
+            if event
+                .editor
+                .documents()
+                .all(|d| !d.supports_language_server(language_server.id()))
+            {
+                event
+                    .editor
+                    .remove_language_server_by_id(language_server.id(), true);
+            };
         }
 
         Ok(())


### PR DESCRIPTION
This also stops language servers when the last document using them is closed.

As in #16070, workspace diagnostics would accumulate infinitely when doing `:lsp-restart` and not disappear when doing `:lsp-stop`

Closes #16076 