### PR TITLE
Detect .lfsconfig as git-config language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2299,7 +2299,7 @@ source = { git = "https://github.com/tree-sitter/tree-sitter-regex", rev = "b2ac
 [[language]]
 name = "git-config"
 scope = "source.gitconfig"
-file-types = ["gitconfig", { glob = ".gitmodules" }, { glob = "gitconfig" }, { glob = ".gitconfig" }, { glob = ".git/config" }, { glob = ".config/git/config" }, { glob = ".git/modules/*/config" }, { glob = "config.worktree" }]
+file-types = ["gitconfig", { glob = ".gitmodules" }, { glob = "gitconfig" }, { glob = ".gitconfig" }, { glob = ".git/config" }, { glob = ".config/git/config" }, { glob = ".git/modules/*/config" }, { glob = "config.worktree" }, { glob = ".lfsconfig" }]
 injection-regex = "git-config"
 comment-token = "#"
 indent = { tab-width = 4, unit = "\t" }


### PR DESCRIPTION
.lfsconfig uses the same configuration file format as git, as documented here https://github.com/git-lfs/git-lfs/blob/main/docs/man/git-lfs-config.adoc#lfsconfig