### PR TITLE
docs(helix-view): fix grammar in tree comment and try_get docs

### DIFF
--- a/helix-view/src/tree.rs
+++ b/helix-view/src/tree.rs
@@ -90,7 +90,7 @@ impl Tree {
         let mut nodes = SlotMap::with_key();
         let root = nodes.insert(root);
 
-        // root is it's own parent
+        // root is its own parent
         nodes[root].parent = root;
 
         Self {
@@ -303,7 +303,7 @@ impl Tree {
 
     /// Try to get reference to a [View] by index. Returns `None` if node content is not a [`Content::View`].
     ///
-    /// Does not panic if the view does not exists anymore.
+    /// Does not panic if the view does not exist anymore.
     pub fn try_get(&self, index: ViewId) -> Option<&View> {
         match self.nodes.get(index) {
             Some(Node {


### PR DESCRIPTION
## Summary

- Fix two small grammar nits in `helix-view` tree docs/comments
- No behavior change

## Motivation

Spotted while scanning tree layout code:

1. `// root is it's own parent` → possessive **its**
2. `try_get` rustdoc said "does not exists" → "does not exist"

## Verification

- Diff is two comment/doc strings in `helix-view/src/tree.rs`
- No runtime / API / test changes

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h
