### PR TITLE
fix grammar fetch using a tag revision (#5111)

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -390,7 +390,7 @@ impl VendoredGrammar {
         self.reinit(remote, object_format)?;
 
         git(&self.dir, ["fetch", "--depth", "1", REMOTE_NAME, rev])?;
-        git(&self.dir, ["checkout", rev])?;
+        git(&self.dir, ["checkout", "FETCH_HEAD"])?;
 
         Ok(())
     }


### PR DESCRIPTION
Fixes [#5111](https://github.com/helix-editor/helix/issues/5111) by implementing the suggestion in [this comment](https://github.com/helix-editor/helix/issues/5111#issuecomment-4412055320).

In order to fetch a grammar, using `git checkout FETCH_HEAD` instead of `git checkout REV` makes it work even if the specified `source.rev` key is a tag, as mentionned in the [documentation](https://docs.helix-editor.com/languages.html#tree-sitter-grammar-configuration).