### PR TITLE
languages: add Clean programming language support

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -2942,6 +2942,19 @@ formatter = { command = "cljfmt", args = ["fix", "-"] }
 [[grammar]]
 name = "clojure"
 source = { git = "https://github.com/sogaiu/tree-sitter-clojure", rev = "e43eff80d17cf34852dcd92ca5e6986d23a7040f" }
+[[language]]
+name = "clean"
+scope = "source.clean"
+injection-regex = "clean"
+file-types = ["icl", "dcl"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "clean"
+source = { git = "https://github.com/ishaq2321/tree-sitter-clean", rev = "2b0fe49" }
+
 
 [[language]]
 name = "starlark"

--- a/runtime/queries/clean/highlights.scm
+++ b/runtime/queries/clean/highlights.scm
@@ -1,0 +1,70 @@
+; Keywords
+"module" @keyword
+"import" @keyword
+"from" @keyword
+"where" @keyword
+"with" @keyword
+"class" @keyword
+"instance" @keyword
+"let" @keyword
+"in" @keyword
+"case" @keyword
+"of" @keyword
+"implementation" @keyword
+"definition" @keyword
+"system" @keyword
+"infix" @keyword
+"infixl" @keyword
+"infixr" @keyword
+"generic" @keyword
+"derive" @keyword
+"if" @keyword
+
+; Module and import names
+(module_identifier) @module
+(module_name (module_identifier) @module)
+
+; Types and constructors
+(type_signature name: (signature_name (identifier) @type))
+(type_definition name: (constructor) @type)
+(class_declaration name: (class_name (constructor) @type))
+(class_name (constructor) @type)
+(constructor) @constructor
+
+; Functions
+(function_declaration name: (identifier) @function)
+(macro_definition name: (identifier) @function)
+
+; Variables
+(identifier) @variable
+
+; Literals
+(string) @string
+(number) @number
+(char) @string
+(integer) @number
+
+; Comments
+(line_comment) @comment
+(block_comment) @comment
+
+; Operators
+(operator) @operator
+(operator_add) @operator
+(operator_mul) @operator
+(operator_compare) @operator
+(operator_cons) @operator
+(operator_and) @operator
+(operator_or) @operator
+
+; Patterns
+(wildcard) @keyword
+
+; Punctuation
+"=" @operator
+(arrow) @operator
+"," @punctuation.delimiter
+"." @punctuation.delimiter
+"|" @operator
+"::" @operator
+(comprehension_sep) @operator

--- a/runtime/queries/clean/injections.scm
+++ b/runtime/queries/clean/injections.scm
@@ -1,0 +1,1 @@
+(code_expression (abc_instruction) @content)

--- a/runtime/queries/clean/textobjects.scm
+++ b/runtime/queries/clean/textobjects.scm
@@ -1,0 +1,6 @@
+(function_declaration name: (identifier) @function.around) @function.around
+(class_declaration name: (class_name) @class.around) @class.around
+(line_comment) @comment.inside
+(block_comment) @comment.inside
+(line_comment)+ @comment.around
+(block_comment) @comment.around


### PR DESCRIPTION
Add tree-sitter grammar support for the Clean programming language.

**Grammar**: https://github.com/ishaq2321/tree-sitter-clean (v1.1.0, 32/32 tests, npm + PyPI published)
**Queries**: highlights, injections, textobjects under runtime/queries/clean/