### PR TITLE
languages: add initial support for `sieve`: language definition and TS grammar

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -266,6 +266,7 @@
 | scss | ✓ |  | ✓ |  | ✓ | `vscode-css-language-server` |
 | sgf | ✓ | ✓ | ✓ |  |  |  |
 | shellcheckrc | ✓ | ✓ |  |  |  |  |
+| sieve | ✓ | ✓ | ✓ | ✓ | ✓ |  |
 | slang | ✓ | ✓ | ✓ |  |  | `slangd` |
 | slint | ✓ | ✓ | ✓ |  |  | `slint-lsp` |
 | slisp | ✓ |  |  | ✓ |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -5655,3 +5655,16 @@ comment-tokens = ["REM", "::"]
 [[grammar]]
 name = "batch"
 source = { git = "https://github.com/wharflab/tree-sitter-batch", rev = "5fc5f54267ef9a78e7a5319b80e092194252aabf" }
+
+[[language]]
+name = "sieve"
+scope = "source.sieve"
+injection-regex = "^(siv|sieve)$"
+file-types = ["siv"]
+comment-tokens = "#"
+block-comment-tokens = { start = "/*", end = "*/"}
+indent = { tab-width = 2, unit = "  " }
+
+[[grammar]]
+name = "sieve"
+source = { git = "https://codeberg.org/poliorcetics/tree-sitter-sieve", rev = "770beaf4744492411fe296c6f848b90e87b4bf25" }

--- a/runtime/queries/sieve/highlights.scm
+++ b/runtime/queries/sieve/highlights.scm
@@ -1,0 +1,133 @@
+; Comments
+
+(comment_line) @comment.line
+(comment_block) @comment.block
+
+; Function
+
+[
+  (action_command)
+  (control_command)
+  (known_test)
+] @function.builtin
+
+(command
+  name: (identifier) @function)
+(test
+  name: (identifier) @function)
+
+; Keywords
+
+[
+  "if"
+  "elsif"
+  "else"
+] @keyword.control.conditional
+
+[
+  "include"
+  "require"
+] @keyword.control.import
+
+"foreverypart" @keyword.control.repeat
+
+[
+  "break"
+  "return"
+  "stop"
+] @keyword.control.return
+
+[
+  "allof"
+  "anyof"
+  "not"
+] @keyword.operator
+
+(declare_command) @keyword.storage
+
+; Builtin constants
+
+[
+  "false"
+  "true"
+] @constant.builtin.boolean
+
+(escape_sequence) @constant.character.escape
+
+(number_maybe_unit) @constant.numeric.float
+
+[
+  (hex_pair)
+  (unicode_val)
+] @constant.numeric.integer
+
+; Punctuation
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+] @punctuation.bracket
+
+";" @punctuation.delimiter
+
+(interpolation_marker) @punctuation.special
+
+; String
+
+[
+  (string)
+  (string_content)
+] @string
+
+((string
+  (_
+    (string_content) @_inbox))
+    (#match? @_inbox "^INBOX\..*")) @string.special.path
+
+(command
+  (known_command
+    (action_command) @keyword.control.import
+    (#eq? @keyword.control.import "include"))
+  (arguments
+    (argument
+      (tag))*
+    .
+    (argument
+      (string
+        (_
+          (string_content) @string.special.path))
+    )
+  )
+)
+
+; Variables
+
+(variable_interpolation (variable_name) @variable)
+
+(command
+  (known_command
+    (declare_command) @keyword.storage
+    (#any-of? @keyword.storage "global" "set"))
+  (arguments
+    (argument
+      (tag))*
+    .
+    (argument
+      (string
+        (_
+          (string_content) @variable))
+    )
+  )
+)
+
+; Namespaces
+
+(namespace)* @namespace
+
+; Operators
+
+(tag) @operator

--- a/runtime/queries/sieve/indents.scm
+++ b/runtime/queries/sieve/indents.scm
@@ -1,0 +1,23 @@
+[
+  (command)
+  (block)
+  (comment_block)
+  (test_list)
+  ; string list
+  (
+    "["
+    (string)
+    ("," (string))*
+    "]"
+  )
+] @indent
+
+[
+  "}"
+  "]"
+  ")"
+  ";"
+] @outdent
+
+; Strings are opaque and space-sensitive, don't indent them
+(string) @opaque

--- a/runtime/queries/sieve/injections.scm
+++ b/runtime/queries/sieve/injections.scm
@@ -1,0 +1,26 @@
+; Specify nested languages that live within a `siv` file
+
+; ================ Always applicable ================
+
+((comment_line) @injection.content
+  (#set! injection.language "comment"))
+
+((comment_block) @injection.content
+  (#set! injection.language "comment"))
+
+; ================ Global defaults ================
+
+; `:matches` are technically globs and not regexes, but it's fine
+(arguments
+  (argument
+    ((tag) @_tag (#any-of? @_tag ":matches" ":regex"))
+  )
+  .
+  (argument)
+  .
+  (argument
+    ((string) @injection.content
+      (#set! injection.language "regex")
+      (#set! injection.include-children))
+  )
+)

--- a/runtime/queries/sieve/locals.scm
+++ b/runtime/queries/sieve/locals.scm
@@ -1,0 +1,19 @@
+(block) @local.scope
+
+(command
+  (known_command
+    (declare_command) @_dc
+    (#any-of? @_dc "global" "set"))
+  (arguments
+    (argument
+      (tag))*
+    .
+    (argument
+      (string
+        (_
+          (string_content) @local.definition.variable.mutable))
+    )
+  )
+)
+
+(variable_interpolation (variable_name) @local.reference)

--- a/runtime/queries/sieve/rainbows.scm
+++ b/runtime/queries/sieve/rainbows.scm
@@ -1,0 +1,18 @@
+[
+  (block)
+  (comment_block)
+  (test_list)
+  ; string list
+  (
+    "["
+    (string)
+    ("," (string))*
+    "]"
+  )
+] @rainbow.scope
+
+[
+  "[" "]"
+  "(" ")"
+  "{" "}"
+] @rainbow.bracket

--- a/runtime/queries/sieve/tags.scm
+++ b/runtime/queries/sieve/tags.scm
@@ -1,0 +1,15 @@
+(command
+  (known_command
+    (action_command) @_command
+    (#eq? @_command "include"))
+  (arguments
+    (argument
+      (tag))*
+    .
+    (argument
+      (string
+        (_
+          (string_content) @name))
+    )
+  )
+) @definition.module

--- a/runtime/queries/sieve/textobjects.scm
+++ b/runtime/queries/sieve/textobjects.scm
@@ -1,0 +1,14 @@
+[
+  (comment_line)
+  (comment_block)
+] @comment.inside
+
+(comment_line)+ @comment.around
+
+(comment_block) @comment.around
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(test_list
+  (_) @entry.around)


### PR DESCRIPTION
The TreeSitter grammar comes with extensive queries, the highlighting queries in particular are the exact same as those tested in the TS grammar repo.

<img width="521" height="1101" alt="Screenshot 2026-07-26 at 21 57 03" src="https://github.com/user-attachments/assets/3dfc6a5f-cf76-4623-88bc-82fdf30058e2" />
