### PR TITLE
chore(languages): update tree-sitter-proverif

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5513,7 +5513,7 @@ block-comment-tokens = { start = "(*", end = "*)" }
 
 [[grammar]]
 name = "proverif"
-source = { git = "https://codeberg.org/maribu/tree-sitter-proverif", rev = "7741807092c4009c1fe4c3648da60ca72b1b80f1" }
+source = { git = "https://github.com/maribu/tree-sitter-proverif", rev = "7741807092c4009c1fe4c3648da60ca72b1b80f1" }
 
 [[language]]
 name = "ptx"


### PR DESCRIPTION
Development has moved to https://github.com/maribu/tree-sitter-proverif, so update the URL.