### PR TITLE
languages: Kconfig: match files named "Kconfig"

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5127,7 +5127,7 @@ source = { git = "https://github.com/tree-sitter-grammars/tree-sitter-requiremen
 
 [[language]]
 name = "kconfig"
-file-types = ["Kconfig", { glob = "Kconfig.*" }]
+file-types = ["Kconfig", { glob = "Kconfig.*" }, { glob = "Kconfig" }]
 scope = "source.kconfig"
 
 [[grammar]]


### PR DESCRIPTION
Big projects like the Linux kernel and Zephyr RTOS mostly use files that are simply named "Kconfig", without any pre- or postfix.