### PR TITLE
feat(languages): AsciiDoc

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -5,6 +5,8 @@
 | agda | ✓ |  |  |  |  |  |
 | alloy | ✓ |  |  |  |  |  |
 | amber | ✓ | ✓ | ✓ | ✓ | ✓ | `amber-lsp` |
+| asciidoc | ✓ |  |  |  |  |  |
+| asciidoc_inline | ✓ |  |  |  |  |  |
 | astro | ✓ |  |  |  |  | `astro-ls` |
 | awk | ✓ | ✓ |  |  |  | `awk-language-server` |
 | bash | ✓ | ✓ | ✓ | ✓ | ✓ | `bash-language-server` |

--- a/languages.toml
+++ b/languages.toml
@@ -2103,6 +2103,28 @@ name = "mail"
 source = { git = "https://codeberg.org/ficd/tree-sitter-mail", rev = "5eddbfdbec4c893182c79047499901c196332e78" }
 
 [[language]]
+name = "asciidoc"
+scope = "source.adoc"
+injection-regex = "adoc|asciidoc"
+file-types = ["adoc", "asciidoc"]
+comment-tokens = ["//"]
+block-comment-tokens = { start = "////", end = "////" }
+
+[[grammar]]
+name = "asciidoc"
+source = { git = "https://github.com/cathaysia/tree-sitter-asciidoc", rev = "e0710115e7b060ce6681b5182a49a792813006f1", subpath = "tree-sitter-asciidoc" }
+
+[[language]]
+name = "asciidoc_inline"
+scope = "source.asciidoc_inline"
+injection-regex = "asciidoc_inline"
+file-types = []
+
+[[grammar]]
+name = "asciidoc_inline"
+source = { git = "https://github.com/cathaysia/tree-sitter-asciidoc", rev = "e0710115e7b060ce6681b5182a49a792813006f1", subpath = "tree-sitter-asciidoc_inline" }
+
+[[language]]
 name = "markdown"
 scope = "source.md"
 injection-regex = "md|markdown"

--- a/runtime/queries/asciidoc/highlights.scm
+++ b/runtime/queries/asciidoc/highlights.scm
@@ -1,0 +1,199 @@
+(document_title
+  (title_h0_marker) @markup.heading.marker) @markup.heading.1
+
+(title1
+  (title_h1_marker) @markup.heading.marker) @markup.heading.2
+
+(title2
+  (title_h2_marker) @markup.heading.marker) @markup.heading.3
+
+(title3
+  (title_h3_marker) @markup.heading.marker) @markup.heading.4
+
+(title4
+  (title_h4_marker) @markup.heading.marker) @markup.heading.5
+
+(title5
+  (title_h5_marker) @markup.heading.marker) @markup.heading.6
+
+(email) @markup.link @markup.link.url
+
+(author_line
+  ";" @punctuation.delimiter)
+
+(revision_line
+  "," @punctuation.delimiter
+  ":" @punctuation.delimiter)
+
+(list_continuation) @punctuation.special
+
+[
+  (firstname)
+  (middlename)
+  (lastname)
+] @attribute
+
+(revnumber) @constant.numeric
+
+(revdate) @string.special
+
+(revremark) @string
+
+[
+  (table_block_marker)
+  (csv_table_block_marker)
+  (dsv_table_block_marker)
+] @punctuation.special
+
+(table_cell_attr) @attribute
+
+(table_cell
+  "|" @punctuation.special)
+
+(csv_record
+  "," @punctuation.special)
+
+(dsv_record
+  ":" @punctuation.special)
+
+[
+  (breaks)
+  (hard_wrap)
+  (quoted_block_md_marker)
+  (quoted_paragraph_marker)
+  (open_block_marker)
+  (listing_block_start_marker)
+  (listing_block_end_marker)
+  (literal_block_marker)
+  (passthrough_block_marker)
+  (quoted_block_start_marker)
+  (quoted_block_end_marker)
+  (sidebar_block_start_marker)
+  (sidebar_block_end_marker)
+  (ntable_block_marker)
+  (callout_marker)
+] @punctuation.special
+
+(ntable_cell
+  "!" @punctuation.special)
+
+(checked_list_marker_unchecked) @markup.list.unchecked
+
+(checked_list_marker_checked) @markup.list.checked
+
+[
+  (list_marker_star)
+  (list_marker_hyphen)
+] @markup.list.unnumbered
+
+[
+  (list_marker_dot)
+  (list_marker_digit)
+  (list_marker_geek)
+  (list_marker_alpha)
+] @markup.list.numbered
+
+(description_marker) @markup.list.unnumbered
+
+(description_list_item
+  (term) @markup.bold)
+
+[
+  (line_comment)
+  (block_comment)
+] @comment @spell
+
+[
+  (document_attr_marker)
+  (element_attr_marker)
+] @punctuation.delimiter
+
+(document_attr
+  (attr_name) @attribute)
+
+(block_style) @keyword
+(positional_attr) @attribute
+(id) @label
+(role) @attribute
+(option) @attribute
+
+(block_title
+  (block_title_marker) @punctuation.special) @markup.heading
+
+(ident_block) @markup.raw.block
+
+(callout_list_marker) @punctuation.special
+
+(block_macro
+  (block_macro_name) @function.macro
+  "::" @punctuation.delimiter
+  (target)? @markup.link.url
+  "[" @punctuation.bracket
+  "]" @punctuation.bracket)
+
+(attribute_name) @attribute
+
+(attribute_value) @string
+
+(admonition
+  (admonition_important) @keyword
+  ":" @punctuation.delimiter)
+
+(admonition
+  (admonition_warning) @keyword
+  ":" @punctuation.delimiter)
+
+(admonition
+  (admonition_caution) @keyword
+  ":" @punctuation.delimiter)
+
+(admonition
+  (admonition_note) @keyword
+  ":" @punctuation.delimiter)
+
+(admonition
+  (admonition_tip) @keyword
+  ":" @punctuation.delimiter)
+
+((section_block
+  (element_attr
+    (element_attr_marker) @punctuation.delimiter
+    (positional_attr (block_style) @_style @keyword)
+    (element_attr_marker) @punctuation.delimiter)
+  (delimited_block
+    (delimited_block_start_marker) @punctuation.special
+    (delimited_block_end_marker) @punctuation.special))
+  (#any-of? @_style "NOTE" "TIP"))
+
+((section_block
+  (element_attr
+    (element_attr_marker) @punctuation.delimiter
+    (positional_attr (block_style) @_style @keyword)
+    (element_attr_marker) @punctuation.delimiter)
+  (delimited_block
+    (delimited_block_start_marker) @punctuation.special
+    (delimited_block_end_marker) @punctuation.special))
+  (#any-of? @_style "CAUTION" "WARNING"))
+
+((section_block
+  (element_attr
+    (element_attr_marker) @punctuation.delimiter
+    (positional_attr (block_style) @_style @keyword)
+    (element_attr_marker) @punctuation.delimiter)
+  (delimited_block
+    (delimited_block_start_marker) @punctuation.special
+    (delimited_block_end_marker) @punctuation.special))
+  (#eq? @_style "IMPORTANT"))
+
+((section_block
+  (element_attr
+    (positional_attr
+      (block_style) @_style))
+  (listing_block
+    (listing_block_body) @markup.raw.block))
+  (#not-any-of? @_style
+    "a2s" "barcode" "blockdiag" "bpmn" "bytefield" "d2" "dbml" "diagrams" "ditaa" "dpic" "erd"
+    "gnuplot" "graphviz" "lilypond" "meme" "mermaid" "msc" "nomnoml" "pikchr" "plantuml" "shaape"
+    "smcat" "structurizr" "svgbob" "symbolator" "syntrax" "tikz" "umlet" "vega" "wavedrom"))
+
+(paragraph) @spell

--- a/runtime/queries/asciidoc/injections.scm
+++ b/runtime/queries/asciidoc/injections.scm
@@ -1,0 +1,62 @@
+((block_macro
+  (block_macro_name)
+  (target) @injection.content)
+  (#set! injection.language "asciidoc_inline"))
+
+((table_cell
+  (table_cell_content) @injection.content)
+  (#set! injection.language "asciidoc_inline"))
+
+((paragraph) @injection.content
+  (#set! injection.include-children)
+  (#set! injection.language "asciidoc_inline"))
+
+((line) @injection.content
+  (#set! injection.include-children)
+  (#set! injection.language "asciidoc_inline"))
+
+; Source listing: `[source,ruby]` - the language is the second positional.
+((section_block
+  (element_attr
+    (positional_attr
+      (block_style))
+    (positional_attr) @injection.language)
+  (listing_block
+    (listing_block_start_marker)
+    (listing_block_body) @injection.content
+    (listing_block_end_marker))))
+
+; Diagram listing: `[mermaid]` - the language is the style itself.
+((section_block
+  (element_attr
+    (positional_attr
+      (block_style) @injection.language))
+  (listing_block
+    (listing_block_start_marker)
+    (listing_block_body) @injection.content
+    (listing_block_end_marker)))
+  (#any-of? @injection.language
+    "a2s" "barcode" "blockdiag" "bpmn" "bytefield" "d2" "dbml" "diagrams" "ditaa" "dpic" "erd"
+    "gnuplot" "graphviz" "lilypond" "meme" "mermaid" "msc" "nomnoml" "pikchr" "plantuml" "shaape"
+    "smcat" "structurizr" "svgbob" "symbolator" "syntrax" "tikz" "umlet" "vega" "wavedrom"))
+
+; Source paragraph: `[source,ruby]` over a paragraph.
+((section_block
+  (element_attr
+    (positional_attr
+      (block_style))
+    (positional_attr) @injection.language)
+  (paragraph) @injection.content)
+  (#set! injection.include-children))
+
+; latexmath passthrough block, mapped onto the latex grammar.
+(section_block
+  (element_attr
+    (positional_attr
+      (block_style) @_style))
+  (passthrough_block
+    (passthrough_block_marker)
+    (listing_block_body) @injection.content
+    (passthrough_block_marker))
+  (#any-of? @_style "latexmath")
+  (#set! injection.language "latex"))

--- a/runtime/queries/asciidoc_inline/highlights.scm
+++ b/runtime/queries/asciidoc_inline/highlights.scm
@@ -1,0 +1,85 @@
+[
+  (monospace)
+  (passthrough)
+] @nospell @markup.raw.inline
+
+(emphasis) @markup.bold
+
+(italic) @markup.italic
+
+(highlight) @markup.bold
+
+(superscript) @markup.italic
+
+(subscript) @markup.italic
+
+[
+  (link_url)
+  (email)
+] @markup.link @markup.link.url
+
+(uri_label) @markup.link.label
+
+[
+  "["
+  "]"
+  "{"
+  "}"
+  "<<" @punctuation.bracket
+  ">>" @punctuation.bracket
+] @punctuation.bracket
+
+":" @punctuation.delimiter
+
+(replacement) @string.special
+
+(roled_text
+  (role) @attribute)
+
+(attribute_reference
+  (attribute_name) @constant)
+
+(xref
+  (id) @markup.link.label
+  (reftext)? @markup.link.text)
+
+[
+  (macro_name)
+  "((("
+  ")))"
+  "(("
+  "))"
+] @function.macro
+
+(escaped_sequence) @string.escape
+
+(inline_macro
+  (macro_name) @function.macro
+  (target)? @label
+  (attr)? @label)
+
+((inline_macro
+  (macro_name) @function.macro
+  (target) @markup.link.url
+  (attr)? @markup.link.text)
+  (#any-of? @function.macro "link" "mailto"))
+
+(stem_macro
+  (target)? @label
+  (attr)? @nospell @markup.raw.inline)
+
+(footnote
+  (target)? @label
+  (attr) @attribute)
+
+; The value of a named macro attribute (e.g. `window=_blank`).
+(named_attr
+  (attribute_value) @string)
+
+(term) @attribute
+
+(id_assignment) @label
+
+(super_escape) @string.special
+
+(hard_wrap) @punctuation.special

--- a/runtime/queries/asciidoc_inline/injections.scm
+++ b/runtime/queries/asciidoc_inline/injections.scm
@@ -1,0 +1,7 @@
+((stem_macro
+  (attr) @injection.content)
+  (#set! injection.language "latex"))
+
+((stem_macro
+  (attr) @injection.content)
+  (#set! injection.language "asciimath"))

--- a/tests/query/highlights/asciidoc/scopes.adoc
+++ b/tests/query/highlights/asciidoc/scopes.adoc
@@ -1,0 +1,35 @@
+= Document title
+//^^^^^^^^^^^^^^ @markup.heading.1
+
+== Section
+// ^^^^^^^ @markup.heading.2
+
+* Unordered
+
+. Ordered
+
+NOTE: Notice
+//   ^ @punctuation.delimiter
+
+X *bold* _italic_ `code` #highlight#
+// ^^^^ @markup.bold
+//        ^^^^^^ @markup.italic
+//                 ^^^^ @markup.raw.inline
+//                        ^^^^^^^^^ @markup.bold
+
+See https://example.com[Example]
+//  ^^^^^^^^^^^^^^^^^^^ @markup.link.url
+//                      ^^^^^^^ @markup.link.label
+
+See <<section-id,Section reference>>
+//    ^^^^^^^^^^ @markup.link.label
+//               ^^^^^^^^^^^^^^^^^ @markup.link.text
+
+Use kbd:[Ctrl+K]
+//  ^^^ @function.macro
+//       ^^^^^^ @label
+
+Use link:https://example.com[Example]
+//  ^^^^ @function.macro
+//       ^^^^^^^^^^^^^^^^^^^ @markup.link.url
+//                           ^^^^^^^ @markup.link.text


### PR DESCRIPTION
Add [AsciiDoc](https://asciidoc.org/) block and inline Tree-sitter grammars, file detection, and highlight/injection queries. Based on https://github.com/cathaysia/tree-sitter-asciidoc.

The inline grammar matches the upstream implementation of the tree sitter grammar. It is injected into prose and table cells to highlight inline syntax such as emphasis, links, macros, cross-references, and code spans.

Fixes: https://github.com/helix-editor/helix/issues/6781
Syntax-reference: https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/
