### PR TITLE
feat(commands): add sort unique flag

### DIFF
--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -2453,22 +2453,26 @@ fn sort(cx: &mut compositor::Context, args: Args, event: PromptEvent) -> anyhow:
         .map(|fragment| fragment.chunks().collect())
         .collect();
 
-    fragments.sort_by(
-        match (args.has_flag("insensitive"), args.has_flag("reverse")) {
-            (true, true) => |a: &Tendril, b: &Tendril| b.to_lowercase().cmp(&a.to_lowercase()),
-            (true, false) => |a: &Tendril, b: &Tendril| a.to_lowercase().cmp(&b.to_lowercase()),
-            (false, true) => |a: &Tendril, b: &Tendril| b.cmp(a),
-            (false, false) => |a: &Tendril, b: &Tendril| a.cmp(b),
-        },
-    );
+    let insensitive = args.has_flag("insensitive");
+    fragments.sort_by(match (insensitive, args.has_flag("reverse")) {
+        (true, true) => |a: &Tendril, b: &Tendril| b.to_lowercase().cmp(&a.to_lowercase()),
+        (true, false) => |a: &Tendril, b: &Tendril| a.to_lowercase().cmp(&b.to_lowercase()),
+        (false, true) => |a: &Tendril, b: &Tendril| b.cmp(a),
+        (false, false) => |a: &Tendril, b: &Tendril| a.cmp(b),
+    });
 
-    let transaction = Transaction::change(
-        doc.text(),
-        selection
-            .into_iter()
-            .zip(fragments)
-            .map(|(s, fragment)| (s.from(), s.to(), Some(fragment))),
-    );
+    if args.has_flag("unique") {
+        if insensitive {
+            fragments.dedup_by_key(|fragment| fragment.to_lowercase());
+        } else {
+            fragments.dedup();
+        }
+    }
+
+    let mut fragments = fragments.into_iter();
+    let transaction = Transaction::change_by_and_with_selection(doc.text(), selection, |range| {
+        ((range.from(), range.to(), fragments.next()), None)
+    });
 
     doc.apply(&transaction, view.id);
     doc.append_changes_to_history(view);
@@ -3862,6 +3866,12 @@ pub const TYPABLE_COMMAND_LIST: &[TypableCommand] = &[
                     name: "reverse",
                     alias: Some('r'),
                     doc: "sort ranges in reverse order",
+                    ..Flag::DEFAULT
+                },
+                Flag {
+                    name: "unique",
+                    alias: Some('u'),
+                    doc: "remove duplicate ranges after sorting",
                     ..Flag::DEFAULT
                 },
             ],

--- a/helix-term/tests/test/commands.rs
+++ b/helix-term/tests/test/commands.rs
@@ -1,4 +1,5 @@
 use helix_term::application::Application;
+use helix_view::doc;
 
 use super::*;
 
@@ -269,6 +270,45 @@ async fn test_multi_selection_shell_commands() -> anyhow::Result<()> {
             dolor#(|foo)#
             "},
     ))
+    .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_sort_unique() -> anyhow::Result<()> {
+    helpers::test_key_sequence_with_input_text(
+        None,
+        (
+            indoc! {"\
+            #(beta\n|)##(alpha\n|)##(beta\n|)##[beta\n|]##(gamma\n|)#"},
+            ":sort -u<ret>",
+            "#[|]#",
+            LineFeedHandling::AsIs,
+        ),
+        &|app| {
+            let doc = doc!(app.editor);
+            assert_eq!("alpha\nbeta\ngamma\n", doc.text().to_string());
+        },
+        false,
+    )
+    .await?;
+
+    helpers::test_key_sequence_with_input_text(
+        None,
+        (
+            indoc! {"\
+            #(beta\n|)##(alpha\n|)##(beta\n|)##[beta\n|]##(gamma\n|)#"},
+            ":sort --unique<ret>",
+            "#[|]#",
+            LineFeedHandling::AsIs,
+        ),
+        &|app| {
+            let doc = doc!(app.editor);
+            assert_eq!("alpha\nbeta\ngamma\n", doc.text().to_string());
+        },
+        false,
+    )
     .await?;
 
     Ok(())


### PR DESCRIPTION
Adds very basic support for `--unique` / `-u` flag for `:sort` which removes duplicate adjacent lines. This is as simple as it gets and could be eventually optimized, for now, keeping the PR small.