### PR TITLE
theme: kanagawa: fix focused match in picker

### DIFF
--- a/runtime/themes/kanagawa.toml
+++ b/runtime/themes/kanagawa.toml
@@ -35,7 +35,7 @@
 "ui.help" = { fg = "fujiWhite", bg = "sumiInk0" }
 "ui.text" = "fujiWhite"
 "ui.text.inactive" = "fujiGray"
-"ui.text.focus" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+"ui.text.focus" = { bg = "waveBlue2", modifiers = ["bold"] }
 
 "ui.cursor" = { fg = "waveBlue1", bg = "waveAqua2" }
 "ui.cursor.primary" = { fg = "waveBlue1", bg = "fujiWhite" }


### PR DESCRIPTION
In the Kanagawa theme, matching substrings in the picker are supposed to be highlighted in "peachRed", controlled by the "special" key. This was incorrectly overridden by "ui.text.focus".fg, which lead to matching substrings not being highlighted specifically on the currently focused line in the picker. "ui.text.focus" doesn't need to override "fg", since the (non-matching) text is otherwise already white.

The "ui.text.focus".fg override has been present from the very beginning, so it seems the regression doesn't stem from a change to the theme. Rather, a change to how the theme keys are handled in Helix seems to have "revealed" this unnecessary override.

before:
<img width="174" height="106" alt="screenshot_2026-07-31T13:06:11" src="https://github.com/user-attachments/assets/e15c8525-8d1f-40c1-bc5b-08098dec770d" />

after:
<img width="174" height="106" alt="screenshot_2026-07-31T13:05:58" src="https://github.com/user-attachments/assets/a6675233-8bd0-43f8-99f2-c8a7bb20e6e2" />
