### PR TITLE
ci: only build grammars where necessary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
     name: Check (msrv)
     runs-on: ubuntu-latest
     if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
+    env:
+      HELIX_DISABLE_AUTO_GRAMMAR_BUILD: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7
@@ -70,6 +72,8 @@ jobs:
     name: Lints
     runs-on: ubuntu-latest
     if: github.repository == 'helix-editor/helix' || github.event_name != 'schedule'
+    env:
+      HELIX_DISABLE_AUTO_GRAMMAR_BUILD: true
     steps:
       - name: Checkout sources
         uses: actions/checkout@v7


### PR DESCRIPTION
A recent CI run failed due to a Codeberg outage. Only the "Lints" and "Check (MSRV)" jobs failed, because the others cache grammar builds via cache-grammars: 'true'. This setting of the rust-setup action says: "Only set true for jobs that fetch grammars". It seems reasonable that the "Lints" and "Check (MSRV)" jobs don't need to build grammars at all.