### PR TITLE
Stop keymap sequences after closing the last view

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -964,6 +964,7 @@ impl EditorView {
             }
 
             last_mode = current_mode;
+            cxt.editor.should_close()
         };
 
         match &key_result {
@@ -973,7 +974,9 @@ impl EditorView {
             KeymapResult::Pending(node) => cxt.editor.autoinfo = Some(node.infobox()),
             KeymapResult::MatchedSequence(commands) => {
                 for command in commands {
-                    execute_command(command);
+                    if execute_command(command) {
+                        break;
+                    }
                 }
             }
             KeymapResult::NotFound | KeymapResult::Cancelled(_) => return Some(key_result),

--- a/helix-term/tests/test/splits.rs
+++ b/helix-term/tests/test/splits.rs
@@ -3,6 +3,21 @@ use super::*;
 use helix_stdx::path;
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_keymap_sequence_stops_after_closing_last_view() -> anyhow::Result<()> {
+    let mut config = helpers::test_config();
+    let raw_config: helix_term::config::ConfigRaw = toml::from_str(
+        r#"
+        [keys.insert]
+        C-q = ["wclose", "normal_mode"]
+        "#,
+    )?;
+    config.keys = raw_config.keys.unwrap();
+
+    let mut app = helpers::AppBuilder::new().with_config(config).build()?;
+    test_key_sequence(&mut app, Some("i<C-q>"), None, true).await
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_split_write_quit_all() -> anyhow::Result<()> {
     let mut file1 = tempfile::NamedTempFile::new()?;
     let mut file2 = tempfile::NamedTempFile::new()?;


### PR DESCRIPTION
A command sequence can close the last view with `wclose` and then continue to its next command. If that command needs the current view, Helix panics because the view tree is already empty.

Stop executing a matched command sequence as soon as the editor reports that its last view has closed. Single-command keymaps keep their existing behavior.

The regression test uses the reported insert-mode mapping, `C-q = ["wclose", "normal_mode"]`, and verifies that Helix exits cleanly.

Fixes #16111

Testing:
- `cargo integration-test` (178 passed)
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`