### PR TITLE
[DAP] improve protocol compliance and compatibility

### DIFF
--- a/helix-dap/src/client.rs
+++ b/helix-dap/src/client.rs
@@ -83,7 +83,11 @@ impl Client {
             id,
             _process: process,
             server_tx,
-            request_counter: AtomicU64::new(0),
+            // > The `seq` for the first message sent by a client or debug adapter
+            // > is 1, and for each subsequent message is 1 greater than the
+            // > previous message sent by that actor
+            // <https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_ProtocolMessage>
+            request_counter: AtomicU64::new(1),
             caps: None,
             connection_type: None,
             starting_request_args: None,
@@ -233,11 +237,7 @@ impl Client {
     }
 
     fn next_request_id(&self) -> u64 {
-        // > The `seq` for the first message sent by a client or debug adapter
-        // > is 1, and for each subsequent message is 1 greater than the
-        // > previous message sent by that actor
-        // <https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol_ProtocolMessage>
-        self.request_counter.fetch_add(1, Ordering::Relaxed) + 1
+        self.request_counter.fetch_add(1, Ordering::Relaxed)
     }
 
     // Internal, called by specific DAP commands when resuming
@@ -319,10 +319,12 @@ impl Client {
     ) -> impl Future<Output = Result<()>> {
         let server_tx = self.server_tx.clone();
         let command = command.to_string();
+        let seq = Some(self.next_request_id());
 
         async move {
             let response = match result {
                 Ok(result) => Response {
+                    seq,
                     request_seq,
                     command,
                     success: true,
@@ -330,6 +332,7 @@ impl Client {
                     body: Some(result),
                 },
                 Err(error) => Response {
+                    seq,
                     request_seq,
                     command,
                     success: false,

--- a/helix-dap/src/transport.rs
+++ b/helix-dap/src/transport.rs
@@ -24,11 +24,16 @@ pub struct Request {
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize, Serialize)]
 pub struct Response {
-    // seq is omitted as unused and is not sent by some implementations
+    // seq is unused in received responses and is not sent by some implementations,
+    // but other implementations could expect it in response to reverse requests
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub seq: Option<u64>,
     pub request_seq: u64,
     pub success: bool,
     pub command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub body: Option<Value>,
 }
 


### PR DESCRIPTION
This adds the seq number field to DAP responses as an `Option`.

According to the [protocol specification](https://microsoft.github.io/debug-adapter-protocol/specification#Base_Protocol), this field should be present in all messages (requests, responses and events). In practice, this field is useless in received responses, and according to comment in existing code, it is not send by some implementations. Omitting this field is perfectly nice when deserializing responses received by the editor from the debug adapter, but DAP protocol also have some *reverse requests*, where the editor is *sending* the response. In this case, it seems better for compatibility to provide this seq field, as some implementation could expect it to be present. As it is an `Option`, we are compatible with both cases.

I did not add the field to the Event type, as events are only send by the debug adapter to the editor, never the other way.

I also made the counter directly initialized at 1, instead of adding 1 to each generated value.