### PR TITLE
rust: injections: add `anyhow::ensure!(e, "fmt")` as formatted strings

### DIFF
--- a/runtime/queries/rust/injections.scm
+++ b/runtime/queries/rust/injections.scm
@@ -168,6 +168,8 @@
 
     ; std
     "write" "writeln" "assert" "debug_assert"
+    ; anyhow
+    "ensure"
     ; defmt
     "expect" "unwrap"
     ; ratatui


### PR DESCRIPTION
[`anyhow::ensure!`](https://docs.rs/anyhow/latest/anyhow/macro.ensure.html)'s documentation.