### PR TITLE
Smear cursor

### DIFF
--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1736,10 +1736,11 @@ impl Component for EditorView {
 
     fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
         match editor.cursor() {
-            // all block cursors are drawn manually
+            // block cursors are also drawn manually, but keep the terminal
+            // cursor visible so terminals can still track it for effects
             (pos, CursorKind::Block) => {
                 if self.terminal_focused {
-                    (pos, CursorKind::Hidden)
+                    (pos, CursorKind::Block)
                 } else {
                     // use terminal cursor when terminal loses focus
                     (pos, CursorKind::Underline)

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1736,8 +1736,7 @@ impl Component for EditorView {
 
     fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
         match editor.cursor() {
-            // block cursors are also drawn manually, but keep the terminal
-            // cursor visible so terminals can still track it for effects
+            // keep hardware cursor visible for terminal shader effects
             (pos, CursorKind::Block) => {
                 if self.terminal_focused {
                     (pos, CursorKind::Block)


### PR DESCRIPTION
Enables smear cursor shader on word movements. Tested with ghostty.

Fixes https://github.com/helix-editor/helix/issues/14512

Edit: https://github.com/helix-editor/helix/pull/16163 looks like a more forward-looking change in a similar vein.