### PR TITLE
Add AL (Microsoft Dynamics 365 Business Central) language support

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -3,6 +3,7 @@
 | ada | ✓ | ✓ |  |  |  | `ada_language_server` |
 | adl | ✓ | ✓ | ✓ |  |  |  |
 | agda | ✓ |  |  |  |  |  |
+| al | ✓ | ✓ | ✓ | ✓ |  |  |
 | alloy | ✓ |  |  |  |  |  |
 | amber | ✓ | ✓ | ✓ | ✓ | ✓ | `amber-lsp` |
 | astro | ✓ |  |  |  |  | `astro-ls` |

--- a/languages.toml
+++ b/languages.toml
@@ -5655,3 +5655,16 @@ comment-tokens = ["REM", "::"]
 [[grammar]]
 name = "batch"
 source = { git = "https://github.com/wharflab/tree-sitter-batch", rev = "5fc5f54267ef9a78e7a5319b80e092194252aabf" }
+
+[[language]]
+name = "al"
+scope = "source.al"
+injection-regex = "al"
+file-types = ["al"]
+comment-token = "//"
+block-comment-tokens = { start = "/*", end = "*/" }
+indent = { tab-width = 4, unit = "    " }
+
+[[grammar]]
+name = "al"
+source = { git = "https://github.com/SShadowS/tree-sitter-al", rev = "335d1ffc04a123a1812a033f768827db710d9239" }

--- a/runtime/queries/al/highlights.scm
+++ b/runtime/queries/al/highlights.scm
@@ -1,0 +1,810 @@
+; AL (Microsoft Dynamics 365 Business Central) highlight queries.
+; =============================================================================
+; Comments
+; =============================================================================
+(comment) @comment.line
+
+(multiline_comment) @comment.block
+
+; =============================================================================
+; Preprocessor Directives
+; =============================================================================
+[
+  (preproc_if)
+  (preproc_else)
+  (preproc_elif)
+  (preproc_endif)
+  (pragma)
+  (preproc_region)
+  (preproc_endregion)
+] @keyword.directive
+
+; =============================================================================
+; Keywords - Control Flow
+; =============================================================================
+[
+  (if_keyword)
+  (then_keyword)
+  (else_keyword)
+  (case_keyword)
+  (of_keyword)
+  (while_keyword)
+  (do_keyword)
+  (for_keyword)
+  (foreach_keyword)
+  (in_keyword)
+  (repeat_keyword)
+  (until_keyword)
+  (exit_keyword)
+  (break_keyword)
+  (continue_keyword)
+  (with_keyword)
+  (asserterror_keyword)
+  (to_keyword)
+  (downto_keyword)
+  (begin_keyword)
+  (end_keyword)
+] @keyword.control
+
+; =============================================================================
+; Keywords - Declarations
+; =============================================================================
+[
+  (procedure_keyword)
+  (trigger_keyword)
+  (var_keyword)
+  (event_keyword)
+] @keyword.storage.type
+
+; =============================================================================
+; Keywords - Object Types
+; =============================================================================
+[
+  (table_keyword)
+  (tableextension_keyword)
+  (page_keyword)
+  (pageextension_keyword)
+  (codeunit_keyword)
+  (report_keyword)
+  (reportextension_keyword)
+  (query_keyword)
+  (xmlport_keyword)
+  (enum_keyword)
+  (enumextension_keyword)
+  (interface_keyword)
+  (controladdin_keyword)
+  (dotnet_keyword)
+  (profile_keyword)
+  (profileextension_keyword)
+  (permissionset_keyword)
+  (permissionsetextension_keyword)
+  (entitlement_keyword)
+  (pagecustomization_keyword)
+] @keyword.storage.type
+
+; =============================================================================
+; Keywords - Structure
+; =============================================================================
+[
+  (namespace_keyword)
+  (using_keyword)
+  (extends_keyword)
+  (implements_keyword)
+  (customizes_keyword)
+] @keyword.control.import
+
+; =============================================================================
+; Keywords - Sections
+; =============================================================================
+[
+  (fields_keyword)
+  (keys_keyword)
+  (key_keyword)
+  (fieldgroups_keyword)
+  (fieldgroup_keyword)
+  (actions_keyword)
+  (layout_keyword)
+  (area_keyword)
+  (group_keyword)
+  (repeater_keyword)
+  (cuegroup_keyword)
+  (fixed_keyword)
+  (grid_keyword)
+  (part_keyword)
+  (systempart_keyword)
+  (usercontrol_keyword)
+  (dataset_keyword)
+  (elements_keyword)
+  (dataitem_keyword)
+  (column_keyword)
+  (filter_keyword)
+  (labels_keyword)
+  (rendering_keyword)
+  (requestpage_keyword)
+  (schema_keyword)
+  (views_keyword)
+  (view_keyword)
+] @keyword.storage.type
+
+; =============================================================================
+; Keywords - Modifiers
+; =============================================================================
+[
+  (local_keyword)
+  (internal_keyword)
+  (protected_keyword)
+  (temporary_keyword)
+] @keyword.storage.modifier
+
+; Procedure modifier (access modifiers on procedures)
+(procedure_modifier) @keyword.storage.modifier
+
+; Object type keyword (used in permission sets, database refs, etc.)
+(object_type_keyword) @keyword
+
+; =============================================================================
+; Operators
+; =============================================================================
+; Assignment operator
+":=" @operator
+
+; Arithmetic operators
+[
+  "+"
+  "-"
+  "*"
+  "/"
+] @operator
+
+; Comparison operators (named node wrapping =, <>, <, >, <=, >=)
+(comparison_operator) @operator
+
+; Range operator
+".." @operator
+
+; Member access
+"." @punctuation.delimiter
+
+; Enum/scope qualifier
+"::" @operator
+
+; Ternary conditional
+"?" @operator
+
+; Keyword operators (string literal alternatives, matchable)
+[
+  "and"
+  "AND"
+  "And"
+  "or"
+  "OR"
+  "Or"
+  "xor"
+  "XOR"
+  "Xor"
+  "not"
+  "NOT"
+  "Not"
+  "div"
+  "DIV"
+  "Div"
+  "mod"
+  "MOD"
+  "Mod"
+  "in"
+  "IN"
+  "In"
+] @keyword.operator
+
+; =============================================================================
+; Punctuation
+; =============================================================================
+";" @punctuation.delimiter
+
+":" @punctuation.delimiter
+
+"," @punctuation.delimiter
+
+"(" @punctuation.bracket
+
+")" @punctuation.bracket
+
+"[" @punctuation.bracket
+
+"]" @punctuation.bracket
+
+"{" @punctuation.bracket
+
+"}" @punctuation.bracket
+
+; =============================================================================
+; Literals
+; =============================================================================
+(string_literal) @string
+
+(integer) @constant.numeric.integer
+
+(decimal) @constant.numeric.float
+
+(biginteger_literal) @constant.numeric.integer
+
+(boolean) @constant.builtin
+
+(date_literal) @string.special
+
+(time_literal) @string.special
+
+(datetime_literal) @string.special
+
+; =============================================================================
+; Types
+; =============================================================================
+; Built-in types (Integer, Text, Boolean, Date, etc.)
+(basic_type) @type.builtin
+
+; Parameterized built-in types
+(text_type) @type.builtin
+
+(code_type) @type.builtin
+
+; Record type references
+(record_type
+  reference: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Object reference types (Codeunit, Page, Report, etc.)
+(object_reference_type
+  reference: [
+    (identifier)
+    (quoted_identifier)
+    (integer)
+  ] @type)
+
+; Array, List, Dictionary types
+(array_type) @type
+
+(list_type) @type
+
+(dictionary_type) @type
+
+; Option type
+(option_type) @type
+
+; Type specifications
+(type_specification) @type
+
+; DotNet type references
+(dotnet_type
+  reference: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; =============================================================================
+; Object Declarations
+; =============================================================================
+; Tables
+(table_declaration
+  object_id: (integer) @constant)
+
+(table_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Pages
+(page_declaration
+  object_id: (integer) @constant)
+
+(page_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Codeunits
+(codeunit_declaration
+  object_id: (integer) @constant)
+
+(codeunit_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Reports
+(report_declaration
+  object_id: (integer) @constant)
+
+(report_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Queries
+(query_declaration
+  object_id: (integer) @constant)
+
+(query_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; XMLports
+(xmlport_declaration
+  object_id: (integer) @constant)
+
+(xmlport_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Enums
+(enum_declaration
+  object_id: (integer) @constant)
+
+(enum_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Interfaces
+(interface_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; ControlAddins
+(controladdin_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Profiles
+(profile_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Permission Sets
+(permissionset_declaration
+  object_id: (integer) @constant)
+
+(permissionset_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Entitlements
+(entitlement_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Page Customizations
+(pagecustomization_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; DotNet
+(dotnet_declaration) @type
+
+; =============================================================================
+; Extension Declarations
+; =============================================================================
+(tableextension_declaration
+  object_id: (integer) @constant)
+
+(tableextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+(pageextension_declaration
+  object_id: (integer) @constant)
+
+(pageextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+(enumextension_declaration
+  object_id: (integer) @constant)
+
+(enumextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+(reportextension_declaration
+  object_id: (integer) @constant)
+
+(reportextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+(profileextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+(permissionsetextension_declaration
+  object_id: (integer) @constant)
+
+(permissionsetextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Split declarations (preprocessor-split object headers)
+(preproc_split_declaration
+  object_id: (integer) @constant)
+
+(preproc_split_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; =============================================================================
+; Procedures and Triggers
+; =============================================================================
+; Procedure names
+(procedure
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+; Event declarations
+(event_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+; Trigger names
+(trigger_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+; Scoped member-trigger name (`Object::Member`)
+(trigger_declaration
+  name: (member_trigger_name
+    object: [
+      (identifier)
+      (quoted_identifier)
+    ] @type
+    member: [
+      (identifier)
+      (quoted_identifier)
+    ] @function))
+
+; Interface procedures
+(interface_procedure
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+; Split procedures (preprocessor-split)
+(preproc_split_procedure
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+; =============================================================================
+; Fields and Variables
+; =============================================================================
+; Table field declarations
+(field_declaration
+  id: (integer) @constant)
+
+(field_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; Variable declarations
+(variable_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable)
+
+; Parameters
+(parameter
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.parameter)
+
+; Label declarations
+(label_declaration
+  name: (identifier) @constant)
+
+; Enum value declarations
+(enum_value_declaration
+  value_id: (integer) @constant)
+
+(enum_value_declaration
+  value_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @constant)
+
+; Key declarations
+(key_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; Fieldgroup declarations
+(fieldgroup_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; Return values
+(procedure
+  return_value: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable)
+
+(trigger_declaration
+  return_value: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable)
+
+; For loop variables
+(for_statement
+  variable: (identifier) @variable)
+
+; Foreach loop variables
+(foreach_statement
+  variable: (identifier) @variable)
+
+; =============================================================================
+; Expressions
+; =============================================================================
+; Direct function calls
+(call_expression
+  function: (identifier) @function)
+
+; Method calls on objects
+(call_expression
+  function: (member_expression
+    member: (identifier) @function.method))
+
+; Member expression components
+(member_expression
+  object: (identifier) @variable)
+
+(member_expression
+  member: (identifier) @variable.other.member)
+
+; Database references
+(database_reference
+  table_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Qualified enum values
+(qualified_enum_value
+  enum_type: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+(qualified_enum_value
+  value: [
+    (identifier)
+    (quoted_identifier)
+  ] @constant)
+
+; Option members
+(option_member) @constant
+
+; =============================================================================
+; Actions
+; =============================================================================
+(action_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+(actionref_declaration
+  action_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+(customaction_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+(systemaction_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+(fileuploadaction_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @function)
+
+(separator_action
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @punctuation.special)
+
+; =============================================================================
+; Namespace and Using
+; =============================================================================
+(namespace_declaration
+  name: (namespace_name) @namespace)
+
+(using_statement
+  namespace: (namespace_name) @namespace)
+
+; =============================================================================
+; Implements Clause
+; =============================================================================
+(implements_clause
+  interface: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; =============================================================================
+; Attributes
+; =============================================================================
+(attribute_item) @attribute
+
+(attribute_content
+  name: (identifier) @attribute)
+
+; =============================================================================
+; Properties
+; =============================================================================
+; Property name
+(property
+  name: (property_name) @variable.other.member)
+
+; Keyword identifiers (contextual keywords used as values)
+(keyword_identifier) @keyword
+
+; =============================================================================
+; Query and Report Elements
+; =============================================================================
+; Query dataitems
+(query_dataitem
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable)
+
+(query_dataitem
+  table_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Query columns
+(query_column
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; Report dataitems
+(report_dataitem
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable)
+
+(report_dataitem
+  table_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)
+
+; Report columns
+(report_column
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; =============================================================================
+; Page Fields
+; =============================================================================
+(page_field
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; =============================================================================
+; XMLport Elements
+; =============================================================================
+(xmlport_element
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+(xmlport_attribute
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; =============================================================================
+; View Definitions
+; =============================================================================
+(view_definition
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @variable.other.member)
+
+; =============================================================================
+; DotNet
+; =============================================================================
+(assembly_declaration
+  name: [
+    (string_literal)
+    (quoted_identifier)
+    (dotnet_assembly_name)
+  ] @string)
+
+(type_declaration) @type
+
+; =============================================================================
+; Permission Types
+; =============================================================================
+(permission_type) @keyword
+
+(tabledata_permission
+  table_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @type)

--- a/runtime/queries/al/indents.scm
+++ b/runtime/queries/al/indents.scm
@@ -1,0 +1,228 @@
+; AL (Microsoft Dynamics 365 Business Central) indent queries.
+;
+; One indent level per bracketed scope, per begin/end code block, and per
+; control-flow body; the matching close token dedents.
+; =============================================================================
+; Nodes that open an indented scope
+; =============================================================================
+; Object declarations (all use { ... })
+[
+  (table_declaration)
+  (tableextension_declaration)
+  (page_declaration)
+  (pageextension_declaration)
+  (pagecustomization_declaration)
+  (codeunit_declaration)
+  (report_declaration)
+  (reportextension_declaration)
+  (query_declaration)
+  (xmlport_declaration)
+  (enum_declaration)
+  (enumextension_declaration)
+  (interface_declaration)
+  (controladdin_declaration)
+  (dotnet_declaration)
+  (profile_declaration)
+  (profileextension_declaration)
+  (permissionset_declaration)
+  (permissionsetextension_declaration)
+  (entitlement_declaration)
+] @indent
+
+; Code blocks (begin ... end)
+(code_block) @indent
+
+; Sections that use { ... }
+[
+  (fields_section)
+  (keys_section)
+  (fieldgroups_section)
+  (layout_section)
+  (actions_section)
+  (dataset_section)
+  (elements_section)
+  (labels_section)
+  (rendering_section)
+  (requestpage_section)
+  (views_section)
+  (schema_section)
+] @indent
+
+; Layout elements
+[
+  (area_section)
+  (group_section)
+  (repeater_section)
+  (cuegroup_section)
+  (fixed_section)
+  (grid_section)
+  (part_section)
+  (systempart_section)
+  (usercontrol_section)
+] @indent
+
+; Action sections
+[
+  (action_area_section)
+  (action_group_section)
+  (action_declaration)
+  (customaction_declaration)
+  (systemaction_declaration)
+  (fileuploadaction_declaration)
+  (actionref_declaration)
+] @indent
+
+; Report sections
+[
+  (report_dataitem)
+  (report_column)
+  (rendering_layout)
+  (label_section)
+] @indent
+
+; Query sections
+[
+  (query_dataitem)
+  (query_column)
+  (query_filter)
+] @indent
+
+; XMLport elements
+[
+  (xmlport_element)
+  (xmlport_attribute)
+] @indent
+
+; Declarations with bodies
+[
+  (field_declaration)
+  (enum_value_declaration)
+  (key_declaration)
+  (view_definition)
+  (assembly_declaration)
+] @indent
+
+; Var sections
+(var_section) @indent
+
+; Control flow (bodies are indented)
+[
+  (case_branch)
+  (case_else_branch)
+] @indent
+
+; case ... of ... end; the branches are indented, `end` outdents.
+[
+  (case_statement)
+  (case_branch)
+  (case_else_branch)
+] @indent
+
+; Modification blocks
+[
+  (addafter_modification)
+  (addbefore_modification)
+  (addfirst_modification)
+  (addlast_modification)
+  (modify_modification)
+  (moveafter_modification)
+  (movebefore_modification)
+  (movefirst_modification)
+  (movelast_modification)
+  (addafter_action_modification)
+  (addbefore_action_modification)
+  (addfirst_action_modification)
+  (addlast_action_modification)
+  (modify_action_modification)
+  (addafter_dataset_modification)
+  (addbefore_dataset_modification)
+  (addfirst_dataset_modification)
+  (addlast_dataset_modification)
+  (add_dataset_modification)
+  (addfirst_fieldgroup_modification)
+  (addlast_fieldgroup_modification)
+  (addafter_views_modification)
+  (addbefore_views_modification)
+  (addfirst_views_modification)
+  (addlast_views_modification)
+] @indent
+
+; Preprocessor conditionals
+[
+  (preproc_conditional)
+  (preproc_conditional_actions)
+  (preproc_conditional_case)
+  (preproc_conditional_controladdin)
+  (preproc_conditional_dataset)
+  (preproc_conditional_fieldgroups)
+  (preproc_conditional_fields)
+  (preproc_conditional_keys)
+  (preproc_conditional_layout)
+  (preproc_conditional_object)
+  (preproc_conditional_query)
+  (preproc_conditional_report)
+  (preproc_conditional_statement)
+  (preproc_conditional_var)
+  (preproc_conditional_var_block)
+  (preproc_conditional_xmlport)
+] @indent
+
+; Argument and parameter lists
+(argument_list) @indent
+
+(parameter_list) @indent
+
+; =============================================================================
+; Tokens that close it
+; =============================================================================
+; AL is written Allman style: the braces live inside the declaration node,
+; so the declaration scope already covers the line the brace sits on.
+"{" @outdent
+
+"}" @outdent
+
+")" @outdent
+
+"]" @outdent
+
+(end_keyword) @outdent
+
+; repeat ... until brackets its body, so it scopes like begin/end.
+(repeat_statement) @indent
+
+(repeat_statement
+  (until_keyword) @outdent)
+
+; Brace-less bodies: a single statement on the line after then/else/do.
+; When the body is a begin/end block the code_block capture already opens the
+; scope, so these must not fire as well.
+(if_statement
+  then_branch: (_) @indent
+  (#not-kind-eq? @indent "code_block")
+  (#set! "scope" "header"))
+
+(if_statement
+  else_branch: (_) @indent
+  (#not-kind-eq? @indent "code_block")
+  (#not-kind-eq? @indent "if_statement")
+  (#set! "scope" "header"))
+
+(while_statement
+  body: (_) @indent
+  (#not-kind-eq? @indent "code_block")
+  (#set! "scope" "header"))
+
+(for_statement
+  body: (_) @indent
+  (#not-kind-eq? @indent "code_block")
+  (#set! "scope" "header"))
+
+(foreach_statement
+  body: (_) @indent
+  (#not-kind-eq? @indent "code_block")
+  (#set! "scope" "header"))
+
+(with_statement
+  body: (_) @indent
+  (#not-kind-eq? @indent "code_block")
+  (#set! "scope" "header"))

--- a/runtime/queries/al/injections.scm
+++ b/runtime/queries/al/injections.scm
@@ -1,0 +1,5 @@
+([
+  (comment)
+  (multiline_comment)
+] @injection.content
+ (#set! injection.language "comment"))

--- a/runtime/queries/al/locals.scm
+++ b/runtime/queries/al/locals.scm
@@ -1,0 +1,129 @@
+; AL (Microsoft Dynamics 365 Business Central) local scope queries.
+; =============================================================================
+; Scope Definitions
+; =============================================================================
+; Object declarations create scopes
+[
+  (table_declaration)
+  (tableextension_declaration)
+  (page_declaration)
+  (pageextension_declaration)
+  (pagecustomization_declaration)
+  (codeunit_declaration)
+  (report_declaration)
+  (reportextension_declaration)
+  (query_declaration)
+  (xmlport_declaration)
+  (enum_declaration)
+  (enumextension_declaration)
+  (interface_declaration)
+  (controladdin_declaration)
+  (profile_declaration)
+  (profileextension_declaration)
+  (permissionset_declaration)
+  (permissionsetextension_declaration)
+  (entitlement_declaration)
+  (dotnet_declaration)
+] @local.scope
+
+; Procedures and triggers create scopes
+(procedure) @local.scope
+
+(trigger_declaration) @local.scope
+
+(event_declaration) @local.scope
+
+(interface_procedure) @local.scope
+
+(preproc_split_procedure) @local.scope
+
+; Code blocks create scopes
+(code_block) @local.scope
+
+; Control flow statements with bodies create scopes
+(if_statement) @local.scope
+
+(case_statement) @local.scope
+
+(case_branch) @local.scope
+
+(for_statement) @local.scope
+
+(foreach_statement) @local.scope
+
+(while_statement) @local.scope
+
+(repeat_statement) @local.scope
+
+(with_statement) @local.scope
+
+; =============================================================================
+; Local Definitions
+; =============================================================================
+; Variable declarations define local variables
+(variable_declaration
+  name: (identifier) @local.definition.variable)
+
+(variable_declaration
+  name: (quoted_identifier) @local.definition.variable)
+
+; Parameters define local variables
+(parameter
+  name: (identifier) @local.definition.variable.parameter)
+
+(parameter
+  name: (quoted_identifier) @local.definition.variable.parameter)
+
+; Return values define local variables
+(procedure
+  return_value: (identifier) @local.definition.variable)
+
+(procedure
+  return_value: (quoted_identifier) @local.definition.variable)
+
+(trigger_declaration
+  return_value: (identifier) @local.definition.variable)
+
+(trigger_declaration
+  return_value: (quoted_identifier) @local.definition.variable)
+
+; Label declarations
+(label_declaration
+  name: (identifier) @local.definition.variable)
+
+; Object members are not locals. Captured without a definition suffix so
+; they act as discards, stopping them resolving as variable references.
+(field_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @local.member)
+
+(enum_value_declaration
+  value_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @local.member)
+
+(key_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @local.member)
+
+; For loop variables
+(for_statement
+  variable: (identifier) @local.definition.variable)
+
+; Foreach loop variables
+(foreach_statement
+  variable: (identifier) @local.definition.variable)
+
+; =============================================================================
+; References
+; =============================================================================
+; Identifiers are references
+(identifier) @local.reference
+
+; Quoted identifiers are references
+(quoted_identifier) @local.reference

--- a/runtime/queries/al/tags.scm
+++ b/runtime/queries/al/tags.scm
@@ -1,0 +1,344 @@
+; AL (Microsoft Dynamics 365 Business Central) tag queries.
+; =============================================================================
+; Object Definitions
+; =============================================================================
+(table_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(page_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(codeunit_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(report_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(query_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(xmlport_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(enum_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(interface_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.interface
+
+(controladdin_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+; =============================================================================
+; Extension Definitions
+; =============================================================================
+(tableextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(pageextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(enumextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(reportextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(profileextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(permissionsetextension_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+; =============================================================================
+; Other Object Types
+; =============================================================================
+(profile_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(permissionset_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(entitlement_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+(pagecustomization_declaration
+  object_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.class
+
+; =============================================================================
+; Procedure and Trigger Definitions
+; =============================================================================
+; Procedure definitions
+(procedure
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+; Event declarations
+(event_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+; Trigger declarations
+(trigger_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+; Scoped member-trigger name (`Object::Member`) — tag on the member
+(trigger_declaration
+  name: (member_trigger_name
+    member: [
+      (identifier)
+      (quoted_identifier)
+    ] @name)) @definition.function
+
+; Interface procedures
+(interface_procedure
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+; Split procedures (preprocessor-split)
+(preproc_split_procedure
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+; =============================================================================
+; Test Definitions (for test runners like neotest)
+; =============================================================================
+; [Test] as first attribute, 0+ trailing attributes before procedure
+((attribute_item
+  (attribute_content
+    name: (identifier) @_test_attr
+    (#match? @_test_attr "^[Tt][Ee][Ss][Tt]$")))
+  (attribute_item)*
+  .
+  (procedure
+    name: [
+      (identifier)
+      (quoted_identifier)
+    ] @test.name) @test.definition)
+
+; [Test] after 1+ other attributes (e.g. [Obsolete][Test][Scope] procedure)
+((attribute_item)
+  .
+  (attribute_item
+    (attribute_content
+      name: (identifier) @_test_attr
+      (#match? @_test_attr "^[Tt][Ee][Ss][Tt]$")))
+  (attribute_item)*
+  .
+  (procedure
+    name: [
+      (identifier)
+      (quoted_identifier)
+    ] @test.name) @test.definition)
+
+; =============================================================================
+; Field Definitions
+; =============================================================================
+; Table field definitions
+(field_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.field
+
+; Enum value definitions
+(enum_value_declaration
+  value_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.constant
+
+; Key definitions
+(key_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.field
+
+; Fieldgroup definitions
+(fieldgroup_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.field
+
+; Label declarations
+(label_declaration
+  name: (identifier) @name) @definition.constant
+
+; =============================================================================
+; Action Definitions
+; =============================================================================
+(action_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+(customaction_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+(systemaction_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+(fileuploadaction_declaration
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+(actionref_declaration
+  action_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.function
+
+; =============================================================================
+; Module/Namespace Definitions
+; =============================================================================
+(namespace_declaration
+  name: (namespace_name) @name) @definition.module
+
+; =============================================================================
+; View Definitions
+; =============================================================================
+(view_definition
+  name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @definition.field
+
+; =============================================================================
+; Function/Method References
+; =============================================================================
+; Direct function calls
+(call_expression
+  function: (identifier) @name) @reference.call
+
+; Method calls on objects
+(call_expression
+  function: (member_expression
+    member: (identifier) @name)) @reference.call
+
+; =============================================================================
+; Type References
+; =============================================================================
+; Record type references
+(record_type
+  reference: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @reference.type
+
+; Object reference type references
+(object_reference_type
+  reference: [
+    (identifier)
+    (quoted_identifier)
+    (integer)
+  ] @name) @reference.type
+
+; Database references
+(database_reference
+  table_name: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @reference.class
+
+; =============================================================================
+; Interface References
+; =============================================================================
+(implements_clause
+  interface: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @reference.implementation
+
+; =============================================================================
+; Enum Value References
+; =============================================================================
+(qualified_enum_value
+  enum_type: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @reference.class
+
+(qualified_enum_value
+  value: [
+    (identifier)
+    (quoted_identifier)
+  ] @name) @reference.constant

--- a/runtime/queries/al/textobjects.scm
+++ b/runtime/queries/al/textobjects.scm
@@ -1,0 +1,111 @@
+; AL (Microsoft Dynamics 365 Business Central) textobject queries.
+; =============================================================================
+; Objects / types  ->  class.inside / class.around
+; =============================================================================
+[
+  (table_declaration)
+  (tableextension_declaration)
+  (page_declaration)
+  (pageextension_declaration)
+  (pagecustomization_declaration)
+  (codeunit_declaration)
+  (report_declaration)
+  (reportextension_declaration)
+  (query_declaration)
+  (xmlport_declaration)
+  (enum_declaration)
+  (enumextension_declaration)
+  (interface_declaration)
+  (controladdin_declaration)
+  (dotnet_declaration)
+  (permissionset_declaration)
+  (permissionsetextension_declaration)
+] @class.around
+
+(table_declaration
+  body: (_) @class.inside)
+
+(tableextension_declaration
+  body: (_) @class.inside)
+
+(page_declaration
+  body: (_) @class.inside)
+
+(pageextension_declaration
+  body: (_) @class.inside)
+
+(pagecustomization_declaration
+  body: (_) @class.inside)
+
+(codeunit_declaration
+  body: (_) @class.inside)
+
+(report_declaration
+  body: (_) @class.inside)
+
+(reportextension_declaration
+  body: (_) @class.inside)
+
+(query_declaration
+  body: (_) @class.inside)
+
+(xmlport_declaration
+  body: (_) @class.inside)
+
+(enum_declaration
+  body: (_) @class.inside)
+
+(enumextension_declaration
+  body: (_) @class.inside)
+
+(interface_declaration
+  body: (_) @class.inside)
+
+(controladdin_declaration
+  body: (_) @class.inside)
+
+(dotnet_declaration
+  body: (_) @class.inside)
+
+(permissionset_declaration
+  body: (_) @class.inside)
+
+(permissionsetextension_declaration
+  body: (_) @class.inside)
+
+; =============================================================================
+; Procedures / triggers  ->  function.inside / function.around
+; (code blocks keep begin/end inside the body node, Rust `block` model)
+; =============================================================================
+(procedure) @function.around
+
+(trigger_declaration) @function.around
+
+(interface_procedure) @function.around
+
+; Inside = the statement run only (excludes begin/end). The code_block now nests
+; a content-only statement_block (no delimiters); target it for a clean inside.
+(procedure
+  body: (code_block
+    body: (statement_block) @function.inside))
+
+(trigger_declaration
+  body: (code_block
+    body: (statement_block) @function.inside))
+
+; Parameters — each parameter selectable individually
+(parameter) @parameter.inside
+
+(parameter) @parameter.around
+
+; =============================================================================
+; Comments
+; =============================================================================
+(comment) @comment.inside
+
+(multiline_comment) @comment.inside
+
+[
+  (comment)
+  (multiline_comment)
+] @comment.around

--- a/tests/indent/al.al
+++ b/tests/indent/al.al
@@ -1,0 +1,86 @@
+namespace MyCompany.Sales;
+
+using Microsoft.Foundation.Address;
+
+table 50100 "My Table"
+{
+    Caption = 'My Table';
+
+    fields
+    {
+        field(1; Name; Text[50])
+        {
+            Caption = 'Name';
+            NotBlank = true;
+        }
+        field(2; Amount; Decimal)
+        {
+            Caption = 'Amount';
+        }
+    }
+
+    keys
+    {
+        key(PK; Name)
+        {
+            Clustered = true;
+        }
+    }
+
+    trigger OnInsert()
+    var
+        Customer: Record Customer;
+        Total: Decimal;
+    begin
+        Total := 0;
+        if Amount > 0 then
+            Total := Amount
+        else
+            Total := 1;
+
+        if Amount > 100 then begin
+            Total := Amount * 2;
+            Customer.Init();
+        end;
+
+        while Total > 0 do
+            Total -= 1;
+
+        for Total := 1 to 10 do begin
+            Customer.Init();
+            Customer.Insert();
+        end;
+
+        repeat
+            Total += 1;
+        until Total > 5;
+
+        case Amount of
+            0:
+                Total := 0;
+            1:
+                begin
+                    Total := 1;
+                    Customer.Init();
+                end;
+            else
+                Total := 99;
+        end;
+    end;
+
+    procedure Compute(Value: Decimal): Decimal
+    var
+        Result: Decimal;
+    begin
+        Result := Value * 2;
+        exit(Result);
+    end;
+}
+
+codeunit 50100 "My Codeunit"
+{
+    procedure DoWork()
+    begin
+        Message('working');
+    end;
+}

--- a/tests/query/highlights/al/constructs.al
+++ b/tests/query/highlights/al/constructs.al
@@ -1,0 +1,27 @@
+table 50100 "My Table"
+//    ^ @constant
+{
+    Caption = 'My Table';
+//  ^ @variable.other.member
+
+    fields
+    {
+        field(1; Name; Text[50])
+        {
+            NotBlank = true;
+//          ^ @variable.other.member
+        }
+    }
+
+    procedure Compute(Value: Decimal): Decimal
+//            ^ @function
+//                    ^ @variable.parameter
+    var
+        Total: Decimal;
+    begin
+        // a line comment
+//      ^ @comment.line
+        Total := Value * 2;
+        exit(Total);
+    end;
+}


### PR DESCRIPTION
Adds AL, the language of Microsoft Dynamics 365 Business Central.

## The language

AL is what Business Central extensions are written in. It is a recognised language in GitHub Linguist (since 2020), and already has editor support in VS Code (Microsoft's own extension), Zed and Sublime Text.

## The grammar

[SShadowS/tree-sitter-al](https://github.com/SShadowS/tree-sitter-al), pinned to v3.2.1.

* published to [crates.io](https://crates.io/crates/tree-sitter-al), npm and PyPI
* CI runs the upstream `tree-sitter/parser-test-action` on Linux, macOS and Windows, fuzzes the external scanner, and validates the queries with `ts_query_ls`
* 1472 corpus tests, external scanner in C99, ABI 15
* also carried by [tree-sitter-language-pack](https://github.com/xberg-io/tree-sitter-language-pack)

## Queries

The queries come from the grammar repository, which targets nvim-treesitter, so they are adapted rather than copied.

**indents.scm** is rewritten. Two things make AL different from most C-likes here:

* AL is written Allman style, and the grammar keeps the braces inside the declaration node instead of exposing a brace-delimited node like C's `compound_statement`. So the declaration's scope already covers the line the opening brace sits on, and `"{"` has to outdent.
* Nodes whose body is a `begin`/`end` block must not open a scope of their own, because the `code_block` opens one on the following line and the two stack into a double indent.

Brace-less `if`/`while`/`for`/`foreach`/`with` bodies use header-scoped captures in the same shape as the C query; `repeat`/`until` scopes like a block.

**locals.scm** definitions gained the suffixes Helix resolves against (`local.definition.variable`, `.variable.parameter`). A bare `local.definition` is a discard, so the file as inherited did nothing at all. Table fields, enum values and keys are deliberately left as discards, since they are object members rather than locals.

**highlights.scm** captures are renamed to the documented theme scopes: `property` to `variable.other.member`, `number` to `constant.numeric.*`, `module` to `namespace`, and the `keyword.*` and `*.definition` variants onto their Helix equivalents. The `(ERROR)` capture is dropped, since repainting half-typed code while typing is not wanted.

**textobjects.scm** loses the `block.*` captures, which Helix has no textobject for, and a `repeat`-body capture that made `mif` inside a loop select the loop rather than the enclosing procedure.

**tags.scm** is added, with `definition.method` mapped onto `definition.function` and local symbols removed, so the symbol pickers are useful.

**injections.scm** is added for comment injection.

**folds.scm** from the grammar repo is deliberately not included, since Helix does not load a folds query.

## Verification

```
$ cargo xtask query-check al
Query check succeeded

$ cargo xtask indent-check al
Indent check succeeded

$ cargo xtask highlight-check al
Highlight check succeeded (6 assertions)
```

`query-check` fetched the grammar from the pinned revision and built it before compiling the queries, so it also confirms the pin resolves and the grammar builds and loads under Helix.

`indent-check` runs against the new `tests/indent/al.al` fixture, which covers objects, sections, fields, keys, `var` sections, `begin`/`end`, braced and brace-less `if`/`else`, `while`, `for`, `repeat`/`until`, `case` with an `else` branch, and procedures. It caught two real bugs during development that `query-check` cannot see, which is why the fixture is included rather than offered.

`highlight-check` runs against `tests/query/highlights/al/constructs.al` and pins the renamed captures, which are the riskiest part of this change.

`cargo xtask docgen` was run and the regenerated `lang-support.md` row is in the commit; re-running it produces no further change.

`cargo test --workspace` passes apart from `test_treesitter_indent_rust_helix`, which fails identically on `master` on this machine and is unrelated to this change (it re-indents Helix's own Rust sources, and the checkout has CRLF line endings).

No `rainbows.scm` is included; happy to add one if you would like the language to land with it.

## AI disclosure

This change was prepared with AI assistance (Claude). The query adaptation was driven by the checks above, all run locally.
