### PR TITLE
Add support for terminal block cursor

### DIFF
--- a/book/src/editor.md
+++ b/book/src/editor.md
@@ -184,7 +184,7 @@ The following statusline elements can be configured:
 ### `[editor.cursor-shape]` Section
 
 Defines the shape of cursor in each mode.
-Valid values for these options are `block`, `bar`, `underline`, or `hidden`.
+Valid values for these options are `block`, `terminal-block`, `bar`, `underline`, or `hidden`.
 
 > 💡 Due to limitations of the terminal environment, only the primary cursor can
 > change shape.

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -11,7 +11,7 @@ use helix_view::{
     align_view,
     document::{DocumentOpenError, DocumentSavedEventResult},
     editor::{ConfigEvent, EditorEvent},
-    graphics::Rect,
+    graphics::{CursorKind, Modifier, Rect},
     theme,
     tree::Layout,
     Align, Editor,
@@ -288,6 +288,22 @@ impl Application {
         self.editor.cursor_cache.reset();
 
         let pos = pos.map(|pos| (pos.col as u16, pos.row as u16));
+
+        // Hide the manually drawn cursor under the terminal block cursor
+        if kind == CursorKind::TerminalBlock {
+            if let Some((x, y)) = pos {
+                if let Some(cell) = surface.get_mut(x, y) {
+                    if cell.modifier.contains(Modifier::REVERSED) {
+                        // Themes with reversed cursor colors: remove the reverse modifier
+                        cell.modifier.remove(Modifier::REVERSED);
+                    } else {
+                        // Themes with static cursor colors: swap foreground and background
+                        std::mem::swap(&mut cell.fg, &mut cell.bg);
+                    }
+                }
+            }
+        }
+
         self.terminal.draw(pos, kind).unwrap();
     }
 

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1274,7 +1274,7 @@ impl Application {
         use helix_view::graphics::CursorKind;
         self.terminal
             .backend_mut()
-            .show_cursor(CursorKind::Block)
+            .show_cursor(CursorKind::default())
             .ok();
         self.terminal.restore()
     }

--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -1271,11 +1271,6 @@ impl Application {
     }
 
     fn restore_term(&mut self) -> std::io::Result<()> {
-        use helix_view::graphics::CursorKind;
-        self.terminal
-            .backend_mut()
-            .show_cursor(CursorKind::default())
-            .ok();
         self.terminal.restore()
     }
 

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -541,7 +541,8 @@ impl EditorView {
         let primary_idx = selection.primary_index();
 
         let cursorkind = cursor_shape_config.from_mode(mode);
-        let cursor_is_block = cursorkind == CursorKind::Block;
+        let cursor_is_block =
+            cursorkind == CursorKind::Block || cursorkind == CursorKind::TerminalBlock;
 
         let selection_scope = theme
             .find_highlight_exact("ui.selection")

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1736,18 +1736,7 @@ impl Component for EditorView {
     }
 
     fn cursor(&self, _area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
-        match editor.cursor() {
-            // all block cursors are drawn manually
-            (pos, CursorKind::Block) => {
-                if self.terminal_focused {
-                    (pos, CursorKind::Hidden)
-                } else {
-                    // use terminal cursor when terminal loses focus
-                    (pos, CursorKind::Underline)
-                }
-            }
-            cursor => cursor,
-        }
+        editor.cursor()
     }
 }
 

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -599,6 +599,18 @@ impl Prompt {
                 |_| prompt_color,
             );
         }
+
+        // Draw the block cursor
+        let cursor_kind = cx.editor.config().cursor_shape.from_mode(Mode::Insert);
+        let cursor_is_block =
+            cursor_kind == CursorKind::Block || cursor_kind == CursorKind::TerminalBlock;
+        if cursor_is_block {
+            let pos = self.cursor_position(area);
+            if let Some(cell) = surface.get_mut(pos.col as u16, pos.row as u16) {
+                let cursor_style = cx.editor.theme.get("ui.cursor.primary");
+                cell.set_style(cursor_style);
+            }
+        }
     }
 
     fn cursor_position(&self, area: Rect) -> Position {

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -600,6 +600,32 @@ impl Prompt {
             );
         }
     }
+
+    fn cursor_position(&self, area: Rect) -> Position {
+        let area = area
+            .clip_left(self.prompt.len() as u16)
+            .clip_right(if self.prompt.is_empty() { 2 } else { 0 });
+
+        let mut col = area.left() as usize + self.line[self.anchor..self.cursor].width();
+
+        // ensure the cursor does not go beyond elipses
+        if self.truncate_end
+            && self.line[self.anchor..self.cursor].width() >= self.line_area.width as usize
+        {
+            col -= 1;
+        }
+
+        if self.truncate_start && self.cursor == self.anchor {
+            col += self.line[self.cursor..]
+                .graphemes(true)
+                .next()
+                .map_or(0, |g| g.width());
+        }
+
+        let row = area.y as usize + area.height as usize - 1;
+
+        Position::new(row, col)
+    }
 }
 
 impl Component for Prompt {
@@ -770,30 +796,8 @@ impl Component for Prompt {
     }
 
     fn cursor(&self, area: Rect, editor: &Editor) -> (Option<Position>, CursorKind) {
-        let area = area
-            .clip_left(self.prompt.len() as u16)
-            .clip_right(if self.prompt.is_empty() { 2 } else { 0 });
-
-        let mut col = area.left() as usize + self.line[self.anchor..self.cursor].width();
-
-        // ensure the cursor does not go beyond elipses
-        if self.truncate_end
-            && self.line[self.anchor..self.cursor].width() >= self.line_area.width as usize
-        {
-            col -= 1;
-        }
-
-        if self.truncate_start && self.cursor == self.anchor {
-            col += self.line[self.cursor..]
-                .graphemes(true)
-                .next()
-                .map_or(0, |g| g.width());
-        }
-
-        let line = area.height as usize - 1;
-
         (
-            Some(Position::new(area.y as usize + line, col)),
+            Some(self.cursor_position(area)),
             editor.config().cursor_shape.from_mode(Mode::Insert),
         )
     }

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -296,7 +296,7 @@ where
 
     fn show_cursor(&mut self, kind: CursorKind) -> io::Result<()> {
         let shape = match kind {
-            CursorKind::Block => SetCursorStyle::SteadyBlock,
+            CursorKind::Block | CursorKind::TerminalBlock => SetCursorStyle::SteadyBlock,
             CursorKind::Bar => SetCursorStyle::SteadyBar,
             CursorKind::Underline => SetCursorStyle::SteadyUnderScore,
             CursorKind::Hidden => unreachable!(),

--- a/helix-tui/src/backend/crossterm.rs
+++ b/helix-tui/src/backend/crossterm.rs
@@ -296,7 +296,8 @@ where
 
     fn show_cursor(&mut self, kind: CursorKind) -> io::Result<()> {
         let shape = match kind {
-            CursorKind::Block | CursorKind::TerminalBlock => SetCursorStyle::SteadyBlock,
+            CursorKind::Block => unreachable!(),
+            CursorKind::TerminalBlock => SetCursorStyle::SteadyBlock,
             CursorKind::Bar => SetCursorStyle::SteadyBar,
             CursorKind::Underline => SetCursorStyle::SteadyUnderScore,
             CursorKind::Hidden => unreachable!(),

--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -560,7 +560,7 @@ impl Backend for TerminaBackend {
 
     fn show_cursor(&mut self, kind: CursorKind) -> io::Result<()> {
         let style = match kind {
-            CursorKind::Block => CursorStyle::SteadyBlock,
+            CursorKind::Block | CursorKind::TerminalBlock => CursorStyle::SteadyBlock,
             CursorKind::Bar => CursorStyle::SteadyBar,
             CursorKind::Underline => CursorStyle::SteadyUnderline,
             CursorKind::Hidden => unreachable!(),

--- a/helix-tui/src/backend/termina.rs
+++ b/helix-tui/src/backend/termina.rs
@@ -560,7 +560,8 @@ impl Backend for TerminaBackend {
 
     fn show_cursor(&mut self, kind: CursorKind) -> io::Result<()> {
         let style = match kind {
-            CursorKind::Block | CursorKind::TerminalBlock => CursorStyle::SteadyBlock,
+            CursorKind::Block => unreachable!(),
+            CursorKind::TerminalBlock => CursorStyle::SteadyBlock,
             CursorKind::Bar => CursorStyle::SteadyBar,
             CursorKind::Underline => CursorStyle::SteadyUnderline,
             CursorKind::Hidden => unreachable!(),

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -112,7 +112,7 @@ where
                 Buffer::empty(options.viewport.area),
             ],
             current: 0,
-            cursor_kind: CursorKind::Block,
+            cursor_kind: CursorKind::default(),
             viewport: options.viewport,
             force_clear: false,
         })

--- a/helix-tui/src/terminal.rs
+++ b/helix-tui/src/terminal.rs
@@ -210,7 +210,7 @@ where
         }
 
         match cursor_kind {
-            CursorKind::Hidden => self.hide_cursor()?,
+            CursorKind::Hidden | CursorKind::Block => self.hide_cursor()?,
             kind => self.show_cursor(kind)?,
         }
 

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -856,7 +856,7 @@ impl std::ops::Deref for CursorShapeConfig {
 
 impl Default for CursorShapeConfig {
     fn default() -> Self {
-        Self([CursorKind::Block; 3])
+        Self([CursorKind::default(); 3])
     }
 }
 

--- a/helix-view/src/graphics.rs
+++ b/helix-view/src/graphics.rs
@@ -48,13 +48,15 @@ const fn byte_from_hex(mut h: [u8; 2]) -> Option<u8> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "kebab-case")]
 /// UNSTABLE
 #[derive(Default)]
 pub enum CursorKind {
     /// █
     #[default]
     Block,
+    /// █
+    TerminalBlock,
     /// |
     Bar,
     /// _


### PR DESCRIPTION
This PR builds upon https://github.com/helix-editor/helix/pull/16151. Additionally the software block cursor no longer uses any hardware cursor anywhere, which fixes the visual artifacts with Kitty/Ghostty cursor trails.

Side effect: there is no longer any cursor effect when the terminal emulator loses focus. This is the only way to avoid visual artifacts.

Sample configuration if you would like to test.
```
[editor.cursor-shape]
normal = "terminal-block"
insert = "terminal-block"
select = "terminal-block"
```