### PR TITLE
[DAP] toggle breakpoints for all selections

### DIFF
--- a/book/src/generated/static-cmd.md
+++ b/book/src/generated/static-cmd.md
@@ -281,7 +281,7 @@
 | `goto_prev_paragraph` | Goto previous paragraph | normal: `` [p ``, select: `` [p `` |
 | `dap_launch` | Launch debug target | normal: `` <space>Gl ``, select: `` <space>Gl `` |
 | `dap_restart` | Restart debugging session | normal: `` <space>Gr ``, select: `` <space>Gr `` |
-| `dap_toggle_breakpoint` | Toggle breakpoint | normal: `` <space>Gb ``, select: `` <space>Gb `` |
+| `dap_toggle_breakpoints` | Toggle breakpoints | normal: `` <space>Gb ``, select: `` <space>Gb `` |
 | `dap_continue` | Continue program execution | normal: `` <space>Gc ``, select: `` <space>Gc `` |
 | `dap_pause` | Pause program execution | normal: `` <space>Gh ``, select: `` <space>Gh `` |
 | `dap_step_in` | Step in | normal: `` <space>Gi ``, select: `` <space>Gi `` |

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -584,7 +584,7 @@ impl MappableCommand {
         goto_prev_paragraph, "Goto previous paragraph",
         dap_launch, "Launch debug target",
         dap_restart, "Restart debugging session",
-        dap_toggle_breakpoint, "Toggle breakpoint",
+        dap_toggle_breakpoints, "Toggle breakpoints",
         dap_continue, "Continue program execution",
         dap_pause, "Pause program execution",
         dap_step_in, "Step in",

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -398,7 +398,7 @@ fn debug_parameter_prompt(
     )
 }
 
-pub fn dap_toggle_breakpoint(cx: &mut Context) {
+pub fn dap_toggle_breakpoints(cx: &mut Context) {
     let (view, doc) = current!(cx.editor);
 
     let Some(path) = doc.path().map(ToOwned::to_owned) else {
@@ -408,26 +408,38 @@ pub fn dap_toggle_breakpoint(cx: &mut Context) {
     };
 
     let text = doc.text().slice(..);
-    let line = doc.selection(view.id).primary().cursor_line(text);
-    dap_toggle_breakpoint_impl(cx, path, line);
+
+    let mut lines: Vec<usize> = doc
+        .selection(view.id)
+        .ranges()
+        .iter()
+        .map(|r| r.cursor_line(text))
+        .collect();
+    lines.sort();
+    lines.dedup();
+
+    dap_toggle_breakpoints_impl(cx, path, lines);
 }
 
-pub fn dap_toggle_breakpoint_impl(cx: &mut Context, path: PathBuf, line: usize) {
+pub fn dap_toggle_breakpoints_impl(cx: &mut Context, path: PathBuf, lines: Vec<usize>) {
     // TODO: need to map breakpoints over edits and update them?
     // we shouldn't really allow editing while debug is running though
 
     let breakpoints = cx.editor.breakpoints.entry(path.clone()).or_default();
     // TODO: always keep breakpoints sorted and use binary search to determine insertion point
-    if let Some(pos) = breakpoints
-        .iter()
-        .position(|breakpoint| breakpoint.line == line)
-    {
-        breakpoints.remove(pos);
-    } else {
-        breakpoints.push(Breakpoint {
-            line,
-            ..Default::default()
-        });
+
+    for line in lines {
+        if let Some(pos) = breakpoints
+            .iter()
+            .position(|breakpoint| breakpoint.line == line)
+        {
+            breakpoints.remove(pos);
+        } else {
+            breakpoints.push(Breakpoint {
+                line,
+                ..Default::default()
+            });
+        }
     }
 
     let debugger = debugger!(cx.editor);

--- a/helix-term/src/keymap/default.rs
+++ b/helix-term/src/keymap/default.rs
@@ -239,7 +239,7 @@ pub fn default() -> HashMap<Mode, KeyTrie> {
             "G" => { "Debug (experimental)" sticky=true
                 "l" => dap_launch,
                 "r" => dap_restart,
-                "b" => dap_toggle_breakpoint,
+                "b" => dap_toggle_breakpoints,
                 "c" => dap_continue,
                 "h" => dap_pause,
                 "i" => dap_step_in,

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1284,7 +1284,7 @@ impl EditorView {
                         view.pos_at_visual_coords(doc, coords.row as u16, coords.col as u16, true)
                     {
                         let line = doc.text().char_to_line(char_idx);
-                        commands::dap_toggle_breakpoint_impl(cxt, path, line);
+                        commands::dap_toggle_breakpoints_impl(cxt, path, vec![line]);
                         return EventResult::Consumed(None);
                     }
                 }


### PR DESCRIPTION
Toggles breakpoints for all selections, not only the primary one. More exactly : toggles breakpoint for each *line* with at least one selection.