### PR TITLE
nix: maintenance (dependencies, formatting)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,82 +6,85 @@
   installShellFiles,
   git,
   gitRev ? null,
-  grammarOverlays ? [],
+  grammarOverlays ? [ ],
   includeGrammarIf ? _: true,
-}: let
+}:
+let
   fs = lib.fileset;
 
-  src = fs.difference (fs.gitTracked ./.) (fs.unions [
-    ./.envrc
-    ./rustfmt.toml
-    ./screenshot.png
-    ./book
-    ./docs
-    ./runtime
-    ./flake.lock
-    (fs.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.)
-    (fs.fileFilter (file: file.hasExt "svg") ./.)
-    (fs.fileFilter (file: file.hasExt "md") ./.)
-    (fs.fileFilter (file: file.hasExt "nix") ./.)
-  ]);
+  src = fs.difference (fs.gitTracked ./.) (
+    fs.unions [
+      ./.envrc
+      ./rustfmt.toml
+      ./screenshot.png
+      ./book
+      ./docs
+      ./runtime
+      ./flake.lock
+      (fs.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.)
+      (fs.fileFilter (file: file.hasExt "svg") ./.)
+      (fs.fileFilter (file: file.hasExt "md") ./.)
+      (fs.fileFilter (file: file.hasExt "nix") ./.)
+    ]
+  );
 
   # Next we actually need to build the grammars and the runtime directory
   # that they reside in. It is built by calling the derivation in the
   # grammars.nix file, then taking the runtime directory in the git repo
   # and hooking symlinks up to it.
-  grammars = callPackage ./grammars.nix {inherit grammarOverlays includeGrammarIf;};
-  runtimeDir = runCommand "helix-runtime" {} ''
+  grammars = callPackage ./grammars.nix { inherit grammarOverlays includeGrammarIf; };
+  runtimeDir = runCommand "helix-runtime" { } ''
     mkdir -p $out
     ln -s ${./runtime}/* $out
     rm -r $out/grammars
     ln -s ${grammars} $out/grammars
   '';
 in
-  rustPlatform.buildRustPackage (self: {
-    cargoLock = {
-      lockFile = ./Cargo.lock;
-      # This is not allowed in nixpkgs but is very convenient here: it allows us to
-      # avoid specifying `outputHashes` here for any git dependencies we might take
-      # on temporarily.
-      allowBuiltinFetchGit = true;
-    };
+rustPlatform.buildRustPackage (self: {
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+    # This is not allowed in nixpkgs but is very convenient here: it allows us to
+    # avoid specifying `outputHashes` here for any git dependencies we might take
+    # on temporarily.
+    allowBuiltinFetchGit = true;
+  };
 
-    propagatedBuildInputs = [ runtimeDir ];
-    
-    nativeBuildInputs = [
-      installShellFiles
-      git
-    ];
+  propagatedBuildInputs = [ runtimeDir ];
 
-    buildType = "release";
+  nativeBuildInputs = [
+    installShellFiles
+    git
+  ];
 
-    name = with builtins; (fromTOML (readFile ./helix-term/Cargo.toml)).package.name;
-    src = fs.toSource {
-      root = ./.;
-      fileset = src;
-    };
+  buildType = "release";
 
-    # Helix attempts to reach out to the network and get the grammars. Nix doesn't allow this.
-    HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
+  name = with builtins; (fromTOML (readFile ./helix-term/Cargo.toml)).package.name;
+  src = fs.toSource {
+    root = ./.;
+    fileset = src;
+  };
 
-    # So Helix knows what rev it is.
-    HELIX_NIX_BUILD_REV = gitRev;
+  # Helix attempts to reach out to the network and get the grammars. Nix doesn't allow this.
+  HELIX_DISABLE_AUTO_GRAMMAR_BUILD = "1";
 
-    doCheck = false;
-    strictDeps = true;
+  # So Helix knows what rev it is.
+  HELIX_NIX_BUILD_REV = gitRev;
 
-    # Sets the Helix runtime dir to the grammars
-    env.HELIX_DEFAULT_RUNTIME = "${runtimeDir}";
+  doCheck = false;
+  strictDeps = true;
 
-    # Get all the application stuff in the output directory.
-    postInstall = ''
-      mkdir -p $out/lib
-      installShellCompletion ${./contrib/completion}/hx.{bash,fish,zsh}
-      mkdir -p $out/share/{applications,icons/hicolor/{256x256,scalable}/apps}
-      cp ${./contrib/Helix.desktop} $out/share/applications/Helix.desktop
-      cp ${./logo.svg} $out/share/icons/hicolor/scalable/apps/helix.svg
-      cp ${./contrib/helix.png} $out/share/icons/hicolor/256x256/apps/helix.png
-    '';
+  # Sets the Helix runtime dir to the grammars
+  env.HELIX_DEFAULT_RUNTIME = "${runtimeDir}";
 
-    meta.mainProgram = "hx";
-  })
+  # Get all the application stuff in the output directory.
+  postInstall = ''
+    mkdir -p $out/lib
+    installShellCompletion ${./contrib/completion}/hx.{bash,fish,zsh}
+    mkdir -p $out/share/{applications,icons/hicolor/{256x256,scalable}/apps}
+    cp ${./contrib/Helix.desktop} $out/share/applications/Helix.desktop
+    cp ${./logo.svg} $out/share/icons/hicolor/scalable/apps/helix.svg
+    cp ${./contrib/helix.png} $out/share/icons/hicolor/256x256/apps/helix.png
+  '';
+
+  meta.mainProgram = "hx";
+})

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775358767,
-        "narHash": "sha256-f2eC+WIfhjevCPQILuV08i/kmKZzYZpUvkom/33VxCA=",
+        "lastModified": 1786420161,
+        "narHash": "sha256-PU4CY4GUCDFOoS67dGrc/fS6Y+d1cYZSh6nbgYqAAwE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "20fd44bc663daa53a2575e01293e24e681d62244",
+        "rev": "3a646bd5daa3af78a78a1cb32329cb72d18fcae0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,66 +14,77 @@
     extra-trusted-public-keys = [ "helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs=" ];
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    rust-overlay,
-    ...
-  }: let
-    inherit (nixpkgs) lib;
-    eachSystem = lib.genAttrs lib.systems.flakeExposed;
-    pkgsFor = eachSystem (system:
-      import nixpkgs {
-        localSystem.system = system;
-        overlays = [(import rust-overlay) self.overlays.helix];
+  outputs =
+    {
+      self,
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      eachSystem = lib.genAttrs lib.systems.flakeExposed;
+      pkgsFor = eachSystem (
+        system:
+        import nixpkgs {
+          localSystem.system = system;
+          overlays = [
+            (import rust-overlay)
+            self.overlays.helix
+          ];
+        }
+      );
+      gitRev = self.rev or self.dirtyRev or null;
+    in
+    {
+      packages = eachSystem (system: {
+        inherit (pkgsFor.${system}) helix;
+        /*
+          The default Helix build. Uses the latest stable Rust toolchain, and unstable
+          nixpkgs.
+
+          The build inputs can be overridden with the following:
+
+              packages.${system}.default.override { rustPlatform = newPlatform; };
+
+          Overriding a derivation attribute can be done as well:
+
+              packages.${system}.default.overrideAttrs { buildType = "debug"; };
+        */
+        default = self.packages.${system}.helix;
       });
-    gitRev = self.rev or self.dirtyRev or null;
-  in {
-    packages = eachSystem (system: {
-      inherit (pkgsFor.${system}) helix;
-      /*
-      The default Helix build. Uses the latest stable Rust toolchain, and unstable
-      nixpkgs.
-
-      The build inputs can be overridden with the following:
-
-      packages.${system}.default.override { rustPlatform = newPlatform; };
-
-      Overriding a derivation attribute can be done as well:
-
-      packages.${system}.default.overrideAttrs { buildType = "debug"; };
-      */
-      default = self.packages.${system}.helix;
-    });
-    checks =
-      lib.mapAttrs (system: pkgs: let
-        # Get Helix's MSRV toolchain to build with by default.
-        msrvToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-        msrvPlatform = pkgs.makeRustPlatform {
-          cargo = msrvToolchain;
-          rustc = msrvToolchain;
-        };
-      in {
-        helix = self.packages.${system}.helix.override {
-          rustPlatform = msrvPlatform;
-        };
-      })
-      pkgsFor;
-
-    # Devshell behavior is preserved.
-    devShells =
-      lib.mapAttrs (system: pkgs: {
-        default = let
-          commonRustFlagsEnv = "-C link-arg=-fuse-ld=lld -C target-cpu=native --cfg tokio_unstable";
-          platformRustFlagsEnv = lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-Wl,--no-rosegment";
+      checks = lib.mapAttrs (
+        system: pkgs:
+        let
+          # Get Helix's MSRV toolchain to build with by default.
+          msrvToolchain = pkgs.pkgsBuildHost.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          msrvPlatform = pkgs.makeRustPlatform {
+            cargo = msrvToolchain;
+            rustc = msrvToolchain;
+          };
         in
+        {
+          helix = self.packages.${system}.helix.override {
+            rustPlatform = msrvPlatform;
+          };
+        }
+      ) pkgsFor;
+
+      # Devshell behavior is preserved.
+      devShells = lib.mapAttrs (system: pkgs: {
+        default =
+          let
+            commonRustFlagsEnv = "-C link-arg=-fuse-ld=lld -C target-cpu=native --cfg tokio_unstable";
+            platformRustFlagsEnv = lib.optionalString pkgs.stdenv.isLinux "-Clink-arg=-Wl,--no-rosegment";
+          in
           pkgs.mkShell {
             inputsFrom = [
               (self.checks.${system}.helix.override {
                 includeGrammarIf = _: false;
               })
             ];
-            nativeBuildInputs = with pkgs;
+            nativeBuildInputs =
+              with pkgs;
               [
                 lld
                 cargo-flamegraph
@@ -87,15 +98,14 @@
               export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv} ${platformRustFlagsEnv}"
             '';
           };
-      })
-      pkgsFor;
+      }) pkgsFor;
 
-    overlays = {
-      helix = final: prev: {
-        helix = final.callPackage ./default.nix {inherit gitRev;};
+      overlays = {
+        helix = final: prev: {
+          helix = final.callPackage ./default.nix { inherit gitRev; };
+        };
+
+        default = self.overlays.helix;
       };
-
-      default = self.overlays.helix;
     };
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,11 @@
     };
   };
 
+  nixConfig = {
+    extra-substituters = [ "https://helix.cachix.org" ];
+    extra-trusted-public-keys = [ "helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs=" ];
+  };
+
   outputs = {
     self,
     nixpkgs,
@@ -92,9 +97,5 @@
 
       default = self.overlays.helix;
     };
-  };
-  nixConfig = {
-    extra-substituters = ["https://helix.cachix.org"];
-    extra-trusted-public-keys = ["helix.cachix.org-1:ejp9KQpR1FBI2onstMQ34yogDm4OgU2ru6lIwPvuCVs="];
   };
 }

--- a/grammars.nix
+++ b/grammars.nix
@@ -3,53 +3,58 @@
   lib,
   runCommand,
   includeGrammarIf ? _: true,
-  grammarOverlays ? [],
+  grammarOverlays ? [ ],
   ...
-}: let
-  languagesConfig =
-    builtins.fromTOML (builtins.readFile ./languages.toml);
-  isGitGrammar = grammar:
+}:
+let
+  languagesConfig = builtins.fromTOML (builtins.readFile ./languages.toml);
+  isGitGrammar =
+    grammar:
     builtins.hasAttr "source" grammar
     && builtins.hasAttr "git" grammar.source
     && builtins.hasAttr "rev" grammar.source;
   isGitHubGrammar = grammar: lib.hasPrefix "https://github.com" grammar.source.git;
-  toGitHubFetcher = url: let
-    match = builtins.match "https://github\\.com/([^/]*)/([^/]*)/?" url;
-  in {
-    owner = builtins.elemAt match 0;
-    repo = builtins.elemAt match 1;
-  };
+  toGitHubFetcher =
+    url:
+    let
+      match = builtins.match "https://github\\.com/([^/]*)/([^/]*)/?" url;
+    in
+    {
+      owner = builtins.elemAt match 0;
+      repo = builtins.elemAt match 1;
+    };
   # If `use-grammars.only` is set, use only those grammars.
   # If `use-grammars.except` is set, use all other grammars.
   # Otherwise use all grammars.
-  useGrammar = grammar:
-    if languagesConfig ? use-grammars.only
-    then builtins.elem grammar.name languagesConfig.use-grammars.only
-    else if languagesConfig ? use-grammars.except
-    then !(builtins.elem grammar.name languagesConfig.use-grammars.except)
-    else true;
+  useGrammar =
+    grammar:
+    if languagesConfig ? use-grammars.only then
+      builtins.elem grammar.name languagesConfig.use-grammars.only
+    else if languagesConfig ? use-grammars.except then
+      !(builtins.elem grammar.name languagesConfig.use-grammars.except)
+    else
+      true;
   grammarsToUse = builtins.filter useGrammar languagesConfig.grammar;
   gitGrammars = builtins.filter isGitGrammar grammarsToUse;
-  buildGrammar = grammar: let
-    gh = toGitHubFetcher grammar.source.git;
-    sourceGit = builtins.fetchTree {
-      type = "git";
-      url = grammar.source.git;
-      rev = grammar.source.rev;
-      ref = grammar.source.ref or "HEAD";
-      shallow = true;
-    };
-    sourceGitHub = builtins.fetchTree {
-      type = "github";
-      owner = gh.owner;
-      repo = gh.repo;
-      inherit (grammar.source) rev;
-    };
-    source =
-      if isGitHubGrammar grammar
-      then sourceGitHub
-      else sourceGit;
-  in
+  buildGrammar =
+    grammar:
+    let
+      gh = toGitHubFetcher grammar.source.git;
+      sourceGit = builtins.fetchTree {
+        type = "git";
+        url = grammar.source.git;
+        rev = grammar.source.rev;
+        ref = grammar.source.ref or "HEAD";
+        shallow = true;
+      };
+      sourceGitHub = builtins.fetchTree {
+        type = "github";
+        owner = gh.owner;
+        repo = gh.repo;
+        inherit (grammar.source) rev;
+      };
+      source = if isGitHubGrammar grammar then sourceGitHub else sourceGit;
+    in
     stdenv.mkDerivation {
       # see https://github.com/NixOS/nixpkgs/blob/fbdd1a7c0bc29af5325e0d7dd70e804a972eb465/pkgs/development/tools/parsing/tree-sitter/grammar.nix
 
@@ -58,9 +63,7 @@
 
       src = source;
       sourceRoot =
-        if builtins.hasAttr "subpath" grammar.source
-        then "source/${grammar.source.subpath}"
-        else "source";
+        if builtins.hasAttr "subpath" grammar.source then "source/${grammar.source.subpath}" else "source";
 
       dontConfigure = true;
 
@@ -105,24 +108,20 @@
       '';
     };
   grammarsToBuild = builtins.filter includeGrammarIf gitGrammars;
-  builtGrammars =
-    builtins.map (grammar: {
-      inherit (grammar) name;
-      value = buildGrammar grammar;
-    })
-    grammarsToBuild;
-  extensibleGrammars =
-    lib.makeExtensible (self: builtins.listToAttrs builtGrammars);
-  overlaidGrammars =
-    lib.pipe extensibleGrammars
-    (builtins.map (overlay: grammar: grammar.extend overlay) grammarOverlays);
+  builtGrammars = builtins.map (grammar: {
+    inherit (grammar) name;
+    value = buildGrammar grammar;
+  }) grammarsToBuild;
+  extensibleGrammars = lib.makeExtensible (self: builtins.listToAttrs builtGrammars);
+  overlaidGrammars = lib.pipe extensibleGrammars (
+    builtins.map (overlay: grammar: grammar.extend overlay) grammarOverlays
+  );
   sharedLibExtension = stdenv.hostPlatform.extensions.sharedLibrary;
-  grammarLinks =
-    lib.mapAttrsToList
-    (name: artifact: "ln -s ${artifact}/${name}${sharedLibExtension} $out/${name}${sharedLibExtension}")
-    (lib.filterAttrs (n: v: lib.isDerivation v) overlaidGrammars);
+  grammarLinks = lib.mapAttrsToList (
+    name: artifact: "ln -s ${artifact}/${name}${sharedLibExtension} $out/${name}${sharedLibExtension}"
+  ) (lib.filterAttrs (n: v: lib.isDerivation v) overlaidGrammars);
 in
-  runCommand "consolidated-helix-grammars" {} ''
-    mkdir -p $out
-    ${builtins.concatStringsSep "\n" grammarLinks}
-  ''
+runCommand "consolidated-helix-grammars" { } ''
+  mkdir -p $out
+  ${builtins.concatStringsSep "\n" grammarLinks}
+''

--- a/shell.nix
+++ b/shell.nix
@@ -5,4 +5,4 @@ let
     sha256 = "sha256:1qc703yg0babixi6wshn5wm2kgl5y1drcswgszh4xxzbrwkk9sv7";
   };
 in
-  (import compat {src = ./.;}).shellNix.default
+(import compat { src = ./.; }).shellNix.default


### PR DESCRIPTION
I made sure not to change behavior (beyond the obvious dependencies updates)

Note: I did not run `nixfmt` against the test nix queries because they're not intended for semi-regular editing and maintenance the same way the regular nix files are, we don't care as much at all for their formatting

---

- nix: run `nixfmt`

   [`nixfmt`][1] is the official nix formatter.

   It's especially nice if Helix's nix file are formtted with it since it's configured by default in `languages.toml` so that any call to `:fmt` on save or manually does not change a lot of unrelated lines.

   [1]: https://github.com/NixOS/nixfmt

- flake: update inputs to latest

- flake: move nixConfig before outputs

   It's more idiomatic to put it there both for alphanumerical ordering and also to give users a warning that this uses a third-party cache independent of nixpkgs they may (not) want to trust.
