### PR TITLE
Fix the prompt line stopping short of the right edge

### DIFF
--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -570,6 +570,24 @@ impl Prompt {
                     .unwrap();
             }
 
+            // Without this, the text can stop short of the right edge, down to just `…`.
+            if self.anchor > 0 && self.line[self.anchor..].width() < line_width {
+                let mut width = 0;
+                self.anchor = self
+                    .line
+                    .grapheme_indices(true)
+                    .rev()
+                    .find_map(|(idx, g)| {
+                        width += g.width();
+                        if width > line_width {
+                            Some(idx + g.len())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_default();
+            }
+
             self.truncate_start = self.anchor > 0;
             self.truncate_end = self.line[self.anchor..].width() > line_width;
 


### PR DESCRIPTION
With a long enough prompt line, deleting backwards leaves only `…` on screen. The text is still there, but none of it is visible. It reappears once the line is short enough to fit.

Widening the terminal does the same: the visible text keeps its old width and leaves a gap at the right edge.

### To reproduce

1. Press `$` (`shell_keep_pipe`)
2. Type a command more than twice as long as the prompt area is wide
3. Hold `<backspace>`, or press `<C-w>` a few times

### Before

<img width="800" height="300" alt="before" src="https://github.com/user-attachments/assets/428cdf36-9dbb-4ec7-90ab-2aea3bbc0cc4" />

### After

<img width="800" height="300" alt="after" src="https://github.com/user-attachments/assets/6678c117-5cf3-4e77-a580-b5acbcb9edf7" />

