### PR TITLE
perf: outline `Editor::set_error|warning` and make lazy

### DIFF
--- a/helix-term/src/application.rs
+++ b/helix-term/src/application.rs
@@ -387,7 +387,7 @@ impl Application {
                 let mut app_config = (*self.config.load().clone()).clone();
                 app_config.editor = *editor_config;
                 if let Err(err) = self.terminal.reconfigure((&app_config.editor).into()) {
-                    self.editor.set_error(err.to_string());
+                    self.editor.set_error(|| err.to_string());
                 };
                 self.config.store(Arc::new(app_config));
             }
@@ -461,7 +461,7 @@ impl Application {
                 self.editor.set_status("Config refreshed");
             }
             Err(err) => {
-                self.editor.set_error(err.to_string());
+                self.editor.set_error(|| err.to_string());
             }
         }
     }
@@ -592,7 +592,7 @@ impl Application {
         let doc_save_event = match doc_save_event {
             Ok(event) => event,
             Err(err) => {
-                self.editor.set_error(err.to_string());
+                self.editor.set_error(|| err.to_string());
                 return;
             }
         };
@@ -1191,8 +1191,8 @@ impl Application {
     fn handle_show_message(&mut self, message_type: lsp::MessageType, message: String) {
         if self.config.load().editor.lsp.display_messages {
             match message_type {
-                lsp::MessageType::ERROR => self.editor.set_error(message),
-                lsp::MessageType::WARNING => self.editor.set_warning(message),
+                lsp::MessageType::ERROR => self.editor.set_error(|| message),
+                lsp::MessageType::WARNING => self.editor.set_warning(|| message),
                 _ => self.editor.set_status(message),
             }
         }

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -255,22 +255,22 @@ impl MappableCommand {
                         jobs: cx.jobs,
                         scroll: None,
                     };
-                    if let Err(e) =
+                    if let Err(err) =
                         typed::execute_command(&mut cx, command, args, PromptEvent::Validate)
                     {
-                        cx.editor.set_error(format!("{}", e));
+                        cx.editor.set_error(|| format!("{}", err));
                     }
                 } else {
-                    cx.editor.set_error(format!("no such command: '{name}'"));
+                    cx.editor.set_error(|| format!("no such command: '{name}'"));
                 }
             }
             Self::Static { fun, .. } => (fun)(cx),
             Self::Macro { keys, .. } => {
                 // Protect against recursive macros.
                 if cx.editor.macro_replaying.contains(&'@') {
-                    cx.editor.set_error(
-                        "Cannot execute macro because the [@] register is already playing a macro",
-                    );
+                    cx.editor.set_error(|| {
+                        "Cannot execute macro because the [@] register is already playing a macro"
+                    });
                     return;
                 }
                 cx.editor.macro_replaying.push('@');
@@ -1082,7 +1082,7 @@ fn align_selections(cx: &mut Context) {
 
         if coords.row != anchor_coords.row {
             cx.editor
-                .set_error("align cannot work with multi line selections");
+                .set_error(|| "align cannot work with multi line selections");
             return;
         }
         if coords.row != previous_line {
@@ -1506,8 +1506,9 @@ fn goto_file_impl(cx: &mut Context, action: Action) {
         if path.is_dir() {
             let picker = ui::file_picker(cx.editor, path.into());
             cx.push_layer(Box::new(overlaid(picker)));
-        } else if let Err(e) = cx.editor.open(path, action) {
-            cx.editor.set_error(format!("Open file failed: {:?}", e));
+        } else if let Err(err) = cx.editor.open(path, action) {
+            cx.editor
+                .set_error(|| format!("Open file failed: {:?}", err));
         }
     }
 }
@@ -1529,8 +1530,9 @@ fn open_url(cx: &mut Context, url: Url, action: Action) {
     if path.is_dir() {
         let picker = ui::file_picker(cx.editor, path.into());
         cx.push_layer(Box::new(overlaid(picker)));
-    } else if let Err(e) = cx.editor.open(path, action) {
-        cx.editor.set_error(format!("Open file failed: {:?}", e));
+    } else if let Err(err) = cx.editor.open(path, action) {
+        cx.editor
+            .set_error(|| format!("Open file failed: {:?}", err));
     }
 }
 
@@ -1560,8 +1562,8 @@ fn open_url_in_callback(
     if path.is_dir() {
         let picker = ui::file_picker(editor, path.into());
         compositor.push(Box::new(overlaid(picker)));
-    } else if let Err(e) = editor.open(path, action) {
-        editor.set_error(format!("Open file failed: {:?}", e));
+    } else if let Err(err) = editor.open(path, action) {
+        editor.set_error(|| format!("Open file failed: {:?}", err));
     }
 }
 
@@ -2206,7 +2208,7 @@ fn select_regex(cx: &mut Context) {
             {
                 doc.set_selection(view.id, selection);
             } else if event == PromptEvent::Validate {
-                cx.editor.set_error("nothing selected");
+                cx.editor.set_error(|| "nothing selected");
             }
         },
     );
@@ -2301,7 +2303,7 @@ fn search_impl(
             if wrap_around && mat.is_some() {
                 editor.set_status("Wrapped around document");
             } else {
-                editor.set_error("No more matches");
+                editor.set_error(|| "No more matches");
             }
         }
     }
@@ -2402,6 +2404,15 @@ fn search_next_or_prev_impl(cx: &mut Context, movement: Movement, direction: Dir
     let config = cx.editor.config();
     let scrolloff = config.scrolloff;
     if let Some(query) = cx.editor.registers.first(register, cx.editor) {
+        // TODO: `query` holds the shared lifetime of `cx.editor`, so the else
+        // branch cannot call `set_error` which takes a `&mut self` on `cx.editor`
+        // as its held.
+        //
+        // As view types don't exist, we could probably change the signature of
+        // `first` (and its inner `read`) to take the needed fields of `Editor`
+        // instead of borrowing the whole editor for the duration of the lifetime.
+        let query = query.into_owned();
+
         let search_config = &config.search;
         let case_insensitive = if search_config.smart_case {
             !query.chars().any(char::is_uppercase)
@@ -2431,8 +2442,7 @@ fn search_next_or_prev_impl(cx: &mut Context, movement: Movement, direction: Dir
                 );
             }
         } else {
-            let error = format!("Invalid regex: {}", query);
-            cx.editor.set_error(error);
+            cx.editor.set_error(|| format!("Invalid regex: {}", query));
         }
     }
 }
@@ -2517,7 +2527,7 @@ fn search_selection_impl(cx: &mut Context, detect_word_boundaries: bool) {
             cx.editor.registers.last_search_register = register;
             cx.editor.set_status(msg)
         }
-        Err(err) => cx.editor.set_error(err.to_string()),
+        Err(err) => cx.editor.set_error(|| err.to_string()),
     }
 }
 
@@ -2557,7 +2567,7 @@ fn make_search_word_bounded(cx: &mut Context) {
             cx.editor.registers.last_search_register = register;
             cx.editor.set_status(msg)
         }
-        Err(err) => cx.editor.set_error(err.to_string()),
+        Err(err) => cx.editor.set_error(|| err.to_string()),
     }
 }
 
@@ -2748,9 +2758,9 @@ fn global_search(cx: &mut Context) {
               action| {
             let doc = match cx.editor.open(path, action) {
                 Ok(id) => doc_mut!(cx.editor, &id),
-                Err(e) => {
+                Err(err) => {
                     cx.editor
-                        .set_error(format!("Failed to open file '{}': {}", path.display(), e));
+                        .set_error(|| format!("Failed to open file '{}': {}", path.display(), err));
                     return;
                 }
             };
@@ -2760,9 +2770,9 @@ fn global_search(cx: &mut Context) {
             let view = view_mut!(cx.editor);
             let text = doc.text();
             if line_start >= text.len_lines() {
-                cx.editor.set_error(
-                    "The line you jumped to does not exist anymore because the file has changed.",
-                );
+                cx.editor.set_error(|| {
+                    "The line you jumped to does not exist anymore because the file has changed."
+                });
                 return;
             }
             let start = text.line_to_char(line_start);
@@ -2994,7 +3004,7 @@ fn delete_selection_impl(cx: &mut Context, op: Operation, yank: YankAction) {
             .register
             .unwrap_or_else(|| cx.editor.config.load().default_yank_register);
         if let Err(err) = cx.editor.registers.write(reg_name, values) {
-            cx.editor.set_error(err.to_string());
+            cx.editor.set_error(|| err.to_string());
             return;
         }
     }
@@ -3170,7 +3180,7 @@ fn append_mode(cx: &mut Context) {
 fn file_picker(cx: &mut Context) {
     let root = find_workspace().0;
     if !root.exists() {
-        cx.editor.set_error("Workspace directory does not exist");
+        cx.editor.set_error(|| "Workspace directory does not exist");
         return;
     }
     let picker = ui::file_picker(cx.editor, root);
@@ -3187,14 +3197,14 @@ fn file_picker_in_current_buffer_directory(cx: &mut Context) {
         None => {
             let cwd = helix_stdx::env::current_working_dir();
             if !cwd.exists() {
-                cx.editor.set_error(
-                    "Current buffer has no parent and current working directory does not exist",
-                );
+                cx.editor.set_error(|| {
+                    "Current buffer has no parent and current working directory does not exist"
+                });
                 return;
             }
-            cx.editor.set_error(
-                "Current buffer has no parent, opening file picker in current working directory",
-            );
+            cx.editor.set_error(|| {
+                "Current buffer has no parent, opening file picker in current working directory"
+            });
             cwd
         }
     };
@@ -3207,7 +3217,7 @@ fn file_picker_in_current_directory(cx: &mut Context) {
     let cwd = helix_stdx::env::current_working_dir();
     if !cwd.exists() {
         cx.editor
-            .set_error("Current working directory does not exist");
+            .set_error(|| "Current working directory does not exist");
         return;
     }
     let picker = ui::file_picker(cx.editor, cwd);
@@ -3217,7 +3227,7 @@ fn file_picker_in_current_directory(cx: &mut Context) {
 fn file_explorer(cx: &mut Context) {
     let root = find_workspace().0;
     if !root.exists() {
-        cx.editor.set_error("Workspace directory does not exist");
+        cx.editor.set_error(|| "Workspace directory does not exist");
         return;
     }
 
@@ -3236,14 +3246,14 @@ fn file_explorer_in_current_buffer_directory(cx: &mut Context) {
         None => {
             let cwd = helix_stdx::env::current_working_dir();
             if !cwd.exists() {
-                cx.editor.set_error(
-                    "Current buffer has no parent and current working directory does not exist",
-                );
+                cx.editor.set_error(|| {
+                    "Current buffer has no parent and current working directory does not exist"
+                });
                 return;
             }
-            cx.editor.set_error(
-                "Current buffer has no parent, opening file explorer in current working directory",
-            );
+            cx.editor.set_error(|| {
+                "Current buffer has no parent, opening file explorer in current working directory"
+            });
             cwd
         }
     };
@@ -3257,7 +3267,7 @@ fn file_explorer_in_current_directory(cx: &mut Context) {
     let cwd = helix_stdx::env::current_working_dir();
     if !cwd.exists() {
         cx.editor
-            .set_error("Current working directory does not exist");
+            .set_error(|| "Current working directory does not exist");
         return;
     }
 
@@ -3492,7 +3502,7 @@ fn changed_file_picker(cx: &mut Context) {
     let cwd = helix_stdx::env::current_working_dir();
     if !cwd.exists() {
         cx.editor
-            .set_error("Current working directory does not exist");
+            .set_error(|| "Current working directory does not exist");
         return;
     }
 
@@ -3547,13 +3557,14 @@ fn changed_file_picker(cx: &mut Context) {
         },
         |cx, meta: &FileChange, action| {
             let path_to_open = meta.path();
-            if let Err(e) = cx.editor.open(path_to_open, action) {
-                let err = if let Some(err) = e.source() {
-                    format!("{}", err)
-                } else {
-                    format!("unable to open \"{}\"", path_to_open.display())
-                };
-                cx.editor.set_error(err);
+            if let Err(err) = cx.editor.open(path_to_open, action) {
+                cx.editor.set_error(|| {
+                    if let Some(err) = err.source() {
+                        format!("{}", err)
+                    } else {
+                        format!("unable to open \"{}\"", path_to_open.display())
+                    }
+                });
             }
         },
     )
@@ -3669,7 +3680,7 @@ fn last_picker(cx: &mut Context) {
         if let Some(picker) = compositor.last_picker.take() {
             compositor.push(picker);
         } else {
-            cx.editor.set_error("no last picker")
+            cx.editor.set_error(|| "no last picker")
         }
     }));
 }
@@ -3795,7 +3806,7 @@ async fn make_format_callback(
             }
             Err(err) => {
                 if write.is_none() {
-                    editor.set_error(err.to_string());
+                    editor.set_error(|| err.to_string());
                     return;
                 }
                 log::info!("failed to format '{}': {err}", doc.display_name());
@@ -3805,7 +3816,7 @@ async fn make_format_callback(
         if let Some((path, force)) = write {
             let id = doc.id();
             if let Err(err) = editor.save(id, path, force) {
-                editor.set_error(format!("Error saving: {}", err));
+                editor.set_error(|| format!("Error saving: {}", err));
             }
         }
     }));
@@ -4084,7 +4095,7 @@ fn goto_last_accessed_file(cx: &mut Context) {
     if let Some(alt) = view.docs_access_history.pop() {
         cx.editor.switch(alt, Action::Replace);
     } else {
-        cx.editor.set_error("no last accessed buffer")
+        cx.editor.set_error(|| "no last accessed buffer")
     }
 }
 
@@ -4112,7 +4123,7 @@ fn goto_last_modified_file(cx: &mut Context) {
     if let Some(alt) = alternate_file {
         cx.editor.switch(alt, Action::Replace);
     } else {
-        cx.editor.set_error("no last modified buffer")
+        cx.editor.set_error(|| "no last modified buffer")
     }
 }
 
@@ -4460,7 +4471,7 @@ pub mod insert {
                 key!(Enter) => {
                     if count != 1 {
                         cx.editor
-                            .set_error("inserting multiple newlines not yet supported");
+                            .set_error(|| "inserting multiple newlines not yet supported");
                         return;
                     }
                     insert_newline(cx)
@@ -4855,7 +4866,7 @@ fn yank_impl(editor: &mut Editor, register: char) {
             "yanked {selections} selection{} to register {register}",
             if selections == 1 { "" } else { "s" }
         )),
-        Err(err) => editor.set_error(err.to_string()),
+        Err(err) => editor.set_error(|| err.to_string()),
     }
 }
 
@@ -4880,7 +4891,7 @@ fn yank_joined_impl(editor: &mut Editor, separator: &str, register: char) {
             "joined and yanked {selections} selection{} to register {register}",
             if selections == 1 { "" } else { "s" }
         )),
-        Err(err) => editor.set_error(err.to_string()),
+        Err(err) => editor.set_error(|| err.to_string()),
     }
 }
 
@@ -4915,7 +4926,7 @@ pub(crate) fn yank_main_selection_to_register(editor: &mut Editor, register: cha
 
     match editor.registers.write(register, vec![selection]) {
         Ok(_) => editor.set_status(format!("yanked primary selection to register {register}",)),
-        Err(err) => editor.set_error(err.to_string()),
+        Err(err) => editor.set_error(|| err.to_string()),
     }
 }
 
@@ -5246,7 +5257,7 @@ fn format_selections(cx: &mut Context) {
 
     if doc.selection(view_id).len() != 1 {
         cx.editor
-            .set_error("format_selections only supports a single selection for now");
+            .set_error(|| "format_selections only supports a single selection for now");
         return;
     }
 
@@ -5262,7 +5273,7 @@ fn format_selections(cx: &mut Context) {
         })
     else {
         cx.editor
-            .set_error("No configured language server supports range formatting");
+            .set_error(|| "No configured language server supports range formatting");
         return;
     };
 
@@ -5440,7 +5451,7 @@ fn keep_or_remove_selections_impl(cx: &mut Context, remove: bool) {
             {
                 doc.set_selection(view.id, selection);
             } else if event == PromptEvent::Validate {
-                cx.editor.set_error("no selections remaining");
+                cx.editor.set_error(|| "no selections remaining");
             }
         },
     )
@@ -5476,7 +5487,7 @@ fn remove_primary_selection(cx: &mut Context) {
 
     let selection = doc.selection(view.id);
     if selection.len() == 1 {
-        cx.editor.set_error("no selections remaining");
+        cx.editor.set_error(|| "no selections remaining");
         return;
     }
     let index = selection.primary_index();
@@ -6011,7 +6022,7 @@ fn vsplit_new(cx: &mut Context) {
 fn wclose(cx: &mut Context) {
     if cx.editor.tree.views().count() == 1 {
         if let Err(err) = typed::buffers_remaining_impl(cx.editor) {
-            cx.editor.set_error(err.to_string());
+            cx.editor.set_error(|| err.to_string());
             return;
         }
     }
@@ -6083,7 +6094,8 @@ fn copy_between_registers(cx: &mut Context) {
         };
 
         let Some(values) = cx.editor.registers.read(source, cx.editor) else {
-            cx.editor.set_error(format!("register {source} is empty"));
+            cx.editor
+                .set_error(|| format!("register {source} is empty"));
             return;
         };
         let values: Vec<_> = values.map(|value| value.to_string()).collect();
@@ -6105,7 +6117,7 @@ fn copy_between_registers(cx: &mut Context) {
                     "yanked {n_values} value{} from register {source} to {dest}",
                     if n_values == 1 { "" } else { "s" }
                 )),
-                Err(err) => cx.editor.set_error(err.to_string()),
+                Err(err) => cx.editor.set_error(|| err.to_string()),
             }
         });
     });
@@ -6439,7 +6451,7 @@ fn surround_replace(cx: &mut Context) {
             match surround::get_surround_pos(doc.syntax(), text, selection, surround_ch, count) {
                 Ok(c) => c,
                 Err(err) => {
-                    cx.editor.set_error(err.to_string());
+                    cx.editor.set_error(|| err.to_string());
                     return;
                 }
             };
@@ -6510,7 +6522,7 @@ fn surround_delete(cx: &mut Context) {
             match surround::get_surround_pos(doc.syntax(), text, selection, surround_ch, count) {
                 Ok(c) => c,
                 Err(err) => {
-                    cx.editor.set_error(err.to_string());
+                    cx.editor.set_error(|| err.to_string());
                     return;
                 }
             };
@@ -6572,7 +6584,7 @@ fn shell_keep_pipe(cx: &mut Context) {
         }
 
         if ranges.is_empty() {
-            cx.editor.set_error("No selections remaining");
+            cx.editor.set_error(|| "No selections remaining");
             return;
         }
 
@@ -6689,7 +6701,7 @@ fn shell(cx: &mut compositor::Context, cmd: &str, behavior: &ShellBehavior) {
                     output
                 }
                 Err(err) => {
-                    cx.editor.set_error(err.to_string());
+                    cx.editor.set_error(|| err.to_string());
                     return;
                 }
             }
@@ -6750,7 +6762,7 @@ where
                 expansion::expand(cx.editor, token).map_err(|err| err.into())
             }) {
                 Ok(args) => callback_fn(cx, args),
-                Err(err) => cx.editor.set_error(err.to_string()),
+                Err(err) => cx.editor.set_error(|| err.to_string()),
             }
         },
     );
@@ -6892,7 +6904,7 @@ fn goto_next_tabstop_impl(cx: &mut Context, direction: Direction) {
     let (view, doc) = current!(cx.editor);
     let view_id = view.id;
     let Some(mut snippet) = doc.active_snippet.take() else {
-        cx.editor.set_error("no snippet is currently active");
+        cx.editor.set_error(|| "no snippet is currently active");
         return;
     };
     let tabstop = match direction {
@@ -6940,7 +6952,7 @@ fn record_macro(cx: &mut Context) {
             Ok(_) => cx
                 .editor
                 .set_status(format!("Recorded to register [{}]", reg)),
-            Err(err) => cx.editor.set_error(err.to_string()),
+            Err(err) => cx.editor.set_error(|| err.to_string()),
         }
     } else {
         let reg = cx.register.take().unwrap_or('@');
@@ -6954,10 +6966,12 @@ fn replay_macro(cx: &mut Context) {
     let reg = cx.register.unwrap_or('@');
 
     if cx.editor.macro_replaying.contains(&reg) {
-        cx.editor.set_error(format!(
-            "Cannot replay from register [{}] because already replaying from same register",
-            reg
-        ));
+        cx.editor.set_error(|| {
+            format!(
+                "Cannot replay from register [{}] because already replaying from same register",
+                reg
+            )
+        });
         return;
     }
 
@@ -6971,12 +6985,12 @@ fn replay_macro(cx: &mut Context) {
         match helix_view::input::parse_macro(&keys) {
             Ok(keys) => keys,
             Err(err) => {
-                cx.editor.set_error(format!("Invalid macro: {}", err));
+                cx.editor.set_error(|| format!("Invalid macro: {}", err));
                 return;
             }
         }
     } else {
-        cx.editor.set_error(format!("Register [{}] empty", reg));
+        cx.editor.set_error(|| format!("Register [{}] empty", reg));
         return;
     };
 
@@ -7208,8 +7222,9 @@ fn lsp_or_syntax_symbol_picker(cx: &mut Context) {
     } else if doc.syntax().is_some() {
         syntax_symbol_picker(cx);
     } else {
-        cx.editor
-            .set_error("No language server supporting document symbols or syntax info available");
+        cx.editor.set_error(|| {
+            "No language server supporting document symbols or syntax info available"
+        });
     }
 }
 

--- a/helix-term/src/commands/dap.rs
+++ b/helix-term/src/commands/dap.rs
@@ -245,7 +245,7 @@ fn map_value(value: &Value, params: &[String]) -> Value {
 pub fn dap_launch(cx: &mut Context) {
     // TODO: Now that we support multiple Clients, we could run multiple debuggers at once but for now keep this as is
     if cx.editor.debug_adapters.get_active_client().is_some() {
-        cx.editor.set_error("Debugger is already running");
+        cx.editor.set_error(|| "Debugger is already running");
         return;
     }
 
@@ -258,7 +258,7 @@ pub fn dap_launch(cx: &mut Context) {
         Some(c) => c,
         None => {
             cx.editor
-                .set_error("No debug adapter available for language");
+                .set_error(|| "No debug adapter available for language");
             return;
         }
     };
@@ -278,7 +278,7 @@ pub fn dap_launch(cx: &mut Context) {
         |cx, template, _action| {
             if template.completion.is_empty() {
                 if let Err(err) = dap_start_impl(cx, Some(&template.name), None, None) {
-                    cx.editor.set_error(err.to_string());
+                    cx.editor.set_error(|| err.to_string());
                 }
             } else {
                 let completions = template.completion.clone();
@@ -301,7 +301,7 @@ pub fn dap_restart(cx: &mut Context) {
     let debugger = match cx.editor.debug_adapters.get_active_client() {
         Some(debugger) => debugger,
         None => {
-            cx.editor.set_error("Debugger is not running");
+            cx.editor.set_error(|| "Debugger is not running");
             return;
         }
     };
@@ -311,12 +311,12 @@ pub fn dap_restart(cx: &mut Context) {
         .unwrap_or(false)
     {
         cx.editor
-            .set_error("Debugger does not support session restarts");
+            .set_error(|| "Debugger does not support session restarts");
         return;
     }
     if debugger.starting_request_args().is_none() {
         cx.editor
-            .set_error("No arguments found with which to restart the sessions");
+            .set_error(|| "No arguments found with which to restart the sessions");
         return;
     }
 
@@ -392,7 +392,7 @@ fn debug_parameter_prompt(
                 None,
                 Some(params.iter().map(|x| x.into()).collect()),
             ) {
-                cx.editor.set_error(err.to_string());
+                cx.editor.set_error(|| err.to_string());
             }
         },
     )
@@ -403,7 +403,7 @@ pub fn dap_toggle_breakpoint(cx: &mut Context) {
 
     let Some(path) = doc.path().map(ToOwned::to_owned) else {
         cx.editor
-            .set_error("Can't set breakpoint: document has no path");
+            .set_error(|| "Can't set breakpoint: document has no path");
         return;
     };
 
@@ -434,7 +434,7 @@ pub fn dap_toggle_breakpoint_impl(cx: &mut Context, path: PathBuf, line: usize) 
 
     if let Err(e) = breakpoints_changed(debugger, path, breakpoints) {
         cx.editor
-            .set_error(format!("Failed to set breakpoints: {}", e));
+            .set_error(|| format!("Failed to set breakpoints: {}", e));
     }
 }
 
@@ -453,7 +453,7 @@ pub fn dap_continue(cx: &mut Context) {
         );
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(|| "Currently active thread is not stopped. Switch the thread.");
     }
 }
 
@@ -463,7 +463,7 @@ pub fn dap_pause(cx: &mut Context) {
         let request = debugger.pause(thread.id);
         // NOTE: we don't need to set active thread id here because DAP will emit a "stopped" event
         if let Err(e) = block_on(request) {
-            editor.set_error(format!("Failed to pause: {}", e));
+            editor.set_error(|| format!("Failed to pause: {}", e));
         }
     })
 }
@@ -479,7 +479,7 @@ pub fn dap_step_in(cx: &mut Context) {
         });
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(|| "Currently active thread is not stopped. Switch the thread.");
     }
 }
 
@@ -493,7 +493,7 @@ pub fn dap_step_out(cx: &mut Context) {
         });
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(|| "Currently active thread is not stopped. Switch the thread.");
     }
 }
 
@@ -507,7 +507,7 @@ pub fn dap_next(cx: &mut Context) {
         });
     } else {
         cx.editor
-            .set_error("Currently active thread is not stopped. Switch the thread.");
+            .set_error(|| "Currently active thread is not stopped. Switch the thread.");
     }
 }
 
@@ -532,16 +532,16 @@ pub fn dap_variables(cx: &mut Context) {
         Some(thread_frame) => thread_frame,
         None => {
             cx.editor
-                .set_error(format!("Failed to get stack frame for thread: {thread_id}"));
+                .set_error(|| format!("Failed to get stack frame for thread: {thread_id}"));
             return;
         }
     };
     let stack_frame = match thread_frame.get(frame) {
         Some(stack_frame) => stack_frame,
         None => {
-            cx.editor.set_error(format!(
-                "Failed to get stack frame for thread {thread_id} and frame {frame}."
-            ));
+            cx.editor.set_error(|| {
+                format!("Failed to get stack frame for thread {thread_id} and frame {frame}.")
+            });
             return;
         }
     };
@@ -550,7 +550,8 @@ pub fn dap_variables(cx: &mut Context) {
     let scopes = match block_on(debugger.scopes(frame_id)) {
         Ok(s) => s,
         Err(e) => {
-            cx.editor.set_error(format!("Failed to get scopes: {}", e));
+            cx.editor
+                .set_error(|| format!("Failed to get scopes: {}", e));
             return;
         }
     };
@@ -678,7 +679,7 @@ pub fn dap_edit_condition(cx: &mut Context) {
 
                         if let Err(e) = breakpoints_changed(debugger, path.clone(), breakpoints) {
                             cx.editor
-                                .set_error(format!("Failed to set breakpoints: {}", e));
+                                .set_error(|| format!("Failed to set breakpoints: {}", e));
                         }
                     },
                 );
@@ -718,7 +719,7 @@ pub fn dap_edit_log(cx: &mut Context) {
                         let debugger = debugger!(cx.editor);
                         if let Err(e) = breakpoints_changed(debugger, path.clone(), breakpoints) {
                             cx.editor
-                                .set_error(format!("Failed to set breakpoints: {}", e));
+                                .set_error(|| format!("Failed to set breakpoints: {}", e));
                         }
                     },
                 );
@@ -744,7 +745,7 @@ pub fn dap_switch_stack_frame(cx: &mut Context) {
     let thread_id = match debugger.thread_id {
         Some(thread_id) => thread_id,
         None => {
-            cx.editor.set_error("No thread is currently active");
+            cx.editor.set_error(|| "No thread is currently active");
             return;
         }
     };

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -52,10 +52,8 @@ macro_rules! language_server_with_feature {
         match language_server {
             Some(language_server) => language_server,
             None => {
-                $editor.set_error(format!(
-                    "No configured language server supports {}",
-                    $feature
-                ));
+                $editor
+                    .set_error(|| format!("No configured language server supports {}", $feature));
                 return;
             }
         }
@@ -120,8 +118,7 @@ fn jump_to_location(editor: &mut Editor, location: &Location, action: Action) {
     push_jump(view, doc);
 
     let Some(path) = location.uri.as_path() else {
-        let err = format!("unable to convert URI to filepath: {:?}", location.uri);
-        editor.set_error(err);
+        editor.set_error(|| format!("unable to convert URI to filepath: {:?}", location.uri));
         return;
     };
     jump_to_position(
@@ -143,8 +140,7 @@ fn jump_to_position(
     let doc = match editor.open(path, action) {
         Ok(id) => doc_mut!(editor, &id),
         Err(err) => {
-            let err = format!("failed to open path: {:?}: {:?}", path, err);
-            editor.set_error(err);
+            editor.set_error(|| format!("failed to open path: {:?}: {:?}", path, err));
             return;
         }
     };
@@ -398,7 +394,7 @@ pub fn symbol_picker(cx: &mut Context) {
 
     if futures.is_empty() {
         cx.editor
-            .set_error("No configured language server supports document symbols");
+            .set_error(|| "No configured language server supports document symbols");
         return;
     }
 
@@ -459,7 +455,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
         == 0
     {
         cx.editor
-            .set_error("No configured language server supports workspace symbols");
+            .set_error(|| "No configured language server supports workspace symbols");
         return;
     }
 
@@ -510,7 +506,7 @@ pub fn workspace_symbol_picker(cx: &mut Context) {
             .collect();
 
         if futures.is_empty() {
-            editor.set_error("No configured language server supports workspace symbols");
+            editor.set_error(|| "No configured language server supports workspace symbols");
         }
 
         let injector = injector.clone();
@@ -626,7 +622,7 @@ pub fn code_action(cx: &mut Context) {
 
     if futures.is_empty() {
         cx.editor
-            .set_error("No configured language server supports code actions");
+            .set_error(|| "No configured language server supports code actions");
         return;
     }
 
@@ -646,7 +642,7 @@ pub fn code_action(cx: &mut Context) {
 
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if actions.is_empty() {
-                editor.set_error("No code actions available");
+                editor.set_error(|| "No code actions available");
                 return;
             }
             let mut picker = ui::Menu::new(actions, (), move |editor, action, event| {
@@ -994,7 +990,7 @@ where
         }
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if locations.is_empty() {
-                editor.set_error(match feature {
+                editor.set_error(|| match feature {
                     LanguageServerFeature::GotoDeclaration => "No declaration found.",
                     LanguageServerFeature::GotoDefinition => "No definition found.",
                     LanguageServerFeature::GotoTypeDefinition => "No type definition found.",
@@ -1077,7 +1073,7 @@ pub fn goto_reference(cx: &mut Context) {
         }
         let call = move |editor: &mut Editor, compositor: &mut Compositor| {
             if locations.is_empty() {
-                editor.set_error("No references found.");
+                editor.set_error(|| "No references found.");
             } else {
                 goto_impl(editor, compositor, locations);
             }
@@ -1102,7 +1098,7 @@ pub fn hover(cx: &mut Context) {
         == 0
     {
         cx.editor
-            .set_error("No configured language server supports hover");
+            .set_error(|| "No configured language server supports hover");
         return;
     }
 
@@ -1208,7 +1204,7 @@ pub fn rename_symbol(cx: &mut Context) {
                     .find(|ls| language_server_id.is_none_or(|id| id == ls.id()))
                 else {
                     cx.editor
-                        .set_error("No configured language server supports symbol renaming");
+                        .set_error(|| "No configured language server supports symbol renaming");
                     return;
                 };
 
@@ -1224,7 +1220,7 @@ pub fn rename_symbol(cx: &mut Context) {
                             .editor
                             .apply_workspace_edit(offset_encoding, &edits.unwrap_or_default());
                     }
-                    Err(err) => cx.editor.set_error(err.to_string()),
+                    Err(err) => cx.editor.set_error(|| err.to_string()),
                 }
             },
         )
@@ -1242,7 +1238,7 @@ pub fn rename_symbol(cx: &mut Context) {
         .is_none()
     {
         cx.editor
-            .set_error("No configured language server supports symbol renaming");
+            .set_error(|| "No configured language server supports symbol renaming");
         return;
     }
 
@@ -1271,8 +1267,8 @@ pub fn rename_symbol(cx: &mut Context) {
                 let prefill = match get_prefill_from_lsp_response(editor, offset_encoding, response)
                 {
                     Ok(p) => p,
-                    Err(e) => {
-                        editor.set_error(e);
+                    Err(err) => {
+                        editor.set_error(|| err);
                         return;
                     }
                 };

--- a/helix-term/src/commands/syntax.rs
+++ b/helix-term/src/commands/syntax.rs
@@ -183,7 +183,7 @@ pub fn syntax_symbol_picker(cx: &mut Context) {
     let doc = doc!(cx.editor);
     let Some(syntax) = doc.syntax() else {
         cx.editor
-            .set_error("Syntax tree is not available on this buffer");
+            .set_error(|| "Syntax tree is not available on this buffer");
         return;
     };
     let doc_id = doc.id();
@@ -433,9 +433,9 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
                 UriOrDocumentId::Id(id) => *id,
                 UriOrDocumentId::Uri(uri) => match cx.editor.open(uri.as_path().expect(""), action) {
                     Ok(id) => id,
-                    Err(e) => {
+                    Err(err) => {
                         cx.editor
-                            .set_error(format!("Failed to open file '{uri:?}': {e}"));
+                            .set_error(|| format!("Failed to open file '{uri:?}': {err}"));
                         return;
                     }
                 }
@@ -444,7 +444,7 @@ pub fn syntax_workspace_symbol_picker(cx: &mut Context) {
             let view = view_mut!(cx.editor);
             let len_chars = doc.text().len_chars();
             if tag.start >= len_chars || tag.end > len_chars {
-                cx.editor.set_error("The location you jumped to does not exist anymore because the file has changed.");
+                cx.editor.set_error(|| "The location you jumped to does not exist anymore because the file has changed.");
                 return;
             }
             doc.set_selection(view.id, Selection::single(tag.start, tag.end));

--- a/helix-term/src/commands/typed.rs
+++ b/helix-term/src/commands/typed.rs
@@ -238,10 +238,12 @@ fn buffer_gather_paths_impl(editor: &mut Editor, args: Args) -> Vec<DocumentId> 
     }
 
     if !nonexistent_buffers.is_empty() {
-        editor.set_error(format!(
-            "cannot close non-existent buffers: {}",
-            nonexistent_buffers.join(", ")
-        ));
+        editor.set_error(|| {
+            format!(
+                "cannot close non-existent buffers: {}",
+                nonexistent_buffers.join(", ")
+            )
+        });
     }
 
     document_ids
@@ -439,7 +441,7 @@ fn write_impl(
                 });
             if fmt_job.is_none() {
                 if let Err(err) = editor.save(doc_id, path, force) {
-                    editor.set_error(format!("Error saving: {}", err));
+                    editor.set_error(|| format!("Error saving: {}", err));
                 }
             }
             fmt_job
@@ -938,7 +940,7 @@ pub fn write_all_impl(
                     });
                 if fmt_job.is_none() {
                     if let Err(err) = editor.save::<PathBuf>(doc_id, None, force) {
-                        editor.set_error(format!("Error saving: {}", err));
+                        editor.set_error(|| format!("Error saving: {}", err));
                     }
                 }
                 fmt_job
@@ -1374,7 +1376,7 @@ fn show_directory_stack(
     if !serialized_stack.is_empty() {
         cx.editor.set_status(serialized_stack);
     } else {
-        cx.editor.set_error("Stack is empty");
+        cx.editor.set_error(|| "Stack is empty");
     }
 
     Ok(())
@@ -1413,7 +1415,7 @@ fn pop_directory(
     if let Some(dir) = cx.editor.dir_stack.pop_front() {
         apply_directory_change(cx, &dir)?;
     } else {
-        cx.editor.set_error("Stack is empty");
+        cx.editor.set_error(|| "Stack is empty");
     }
 
     Ok(())
@@ -1434,7 +1436,7 @@ fn show_current_directory(
     if cwd.exists() {
         cx.editor.set_status(message);
     } else {
-        cx.editor.set_error(format!("{} (deleted)", message));
+        cx.editor.set_error(|| format!("{} (deleted)", message));
     }
     Ok(())
 }
@@ -1647,8 +1649,8 @@ fn reload_all(cx: &mut compositor::Context, _args: Args, event: PromptEvent) -> 
                 helix_loader::workspace_trust::TrustQuery::Git,
             )
             .is_trusted();
-        if let Err(error) = doc.reload(view, &cx.editor.diff_providers, trust_full) {
-            cx.editor.set_error(format!("{}", error));
+        if let Err(err) = doc.reload(view, &cx.editor.diff_providers, trust_full) {
+            cx.editor.set_error(|| format!("{}", err));
             continue;
         }
 
@@ -2762,7 +2764,7 @@ fn clear_register(
             .set_status(format!("Register {} cleared", register));
     } else {
         cx.editor
-            .set_error(format!("Register {} not found", register));
+            .set_error(|| format!("Register {} not found", register));
     }
     Ok(())
 }
@@ -4172,7 +4174,7 @@ pub(super) fn command_mode(cx: &mut Context) {
         complete_command_line,
         move |cx: &mut compositor::Context, input: &str, event: PromptEvent| {
             if let Err(err) = execute_command_line(cx, input, event) {
-                cx.editor.set_error(err.to_string());
+                cx.editor.set_error(|| err.to_string());
             }
         },
     );

--- a/helix-term/src/handlers/auto_save.rs
+++ b/helix-term/src/handlers/auto_save.rs
@@ -94,8 +94,8 @@ fn request_auto_save(editor: &mut Editor) {
         code_actions: false,
     };
 
-    if let Err(e) = commands::typed::write_all_impl(context, options) {
-        context.editor.set_error(format!("{}", e));
+    if let Err(err) = commands::typed::write_all_impl(context, options) {
+        context.editor.set_error(|| format!("{}", err));
     }
 }
 

--- a/helix-term/src/handlers/signature_help.rs
+++ b/helix-term/src/handlers/signature_help.rs
@@ -118,7 +118,7 @@ pub fn request_signature_help(
         // Do not show the message if signature help was invoked
         // automatically on backspace, trigger characters, etc.
         if invoked == SignatureHelpInvoked::Manual {
-            editor.set_error("No configured language server supports signature-help");
+            editor.set_error(|| "No configured language server supports signature-help");
         }
         return;
     };

--- a/helix-term/src/job.rs
+++ b/helix-term/src/job.rs
@@ -120,8 +120,8 @@ impl Jobs {
                 }
                 Callback::Followup(call) => call(editor),
             },
-            Err(e) => {
-                editor.set_error(format!("Async job failed: {}", e));
+            Err(err) => {
+                editor.set_error(|| format!("Async job failed: {}", err));
                 None
             }
         }

--- a/helix-term/src/lib.rs
+++ b/helix-term/src/lib.rs
@@ -128,7 +128,7 @@ fn open_external_url_callback(
             );
         }
         Ok(job::Callback::Editor(Box::new(move |editor| {
-            editor.set_error("Opening URL in external program failed")
+            editor.set_error(|| "Opening URL in external program failed");
         })))
     }
 }

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -147,7 +147,7 @@ impl Completion {
                     {
                         Some(ls) => ls,
                         None => {
-                            editor.set_error("completions are outdated");
+                            editor.set_error(|| "completions are outdated");
                             // TODO close the completion menu somehow,
                             // currently there is no trivial way to access the EditorView to close the completion menu
                             return;

--- a/helix-term/src/ui/editor.rs
+++ b/helix-term/src/ui/editor.rs
@@ -1605,8 +1605,8 @@ impl Component for EditorView {
                         auto_format: false,
                         code_actions: false,
                     };
-                    if let Err(e) = commands::typed::write_all_impl(context, options) {
-                        context.editor.set_error(format!("{}", e));
+                    if let Err(err) = commands::typed::write_all_impl(context, options) {
+                        context.editor.set_error(|| format!("{}", err));
                     }
                 }
                 self.terminal_focused = false;

--- a/helix-term/src/ui/mod.rs
+++ b/helix-term/src/ui/mod.rs
@@ -278,13 +278,14 @@ pub fn file_picker(editor: &Editor, root: PathBuf) -> FilePicker {
         },
     )];
     let picker = Picker::new(columns, 0, [], data, move |cx, path: &PathBuf, action| {
-        if let Err(e) = cx.editor.open(path, action) {
-            let err = if let Some(err) = e.source() {
-                format!("{}", err)
-            } else {
-                format!("unable to open \"{}\"", path.display())
-            };
-            cx.editor.set_error(err);
+        if let Err(err) = cx.editor.open(path, action) {
+            cx.editor.set_error(|| {
+                if let Some(err) = err.source() {
+                    format!("{}", err)
+                } else {
+                    format!("unable to open \"{}\"", path.display())
+                }
+            });
         }
     })
     .with_preview(|_editor, path| Some((path.as_path().into(), None)));
@@ -348,13 +349,14 @@ pub fn file_explorer(root: PathBuf, editor: &Editor) -> Result<FileExplorer, std
                     Ok(call)
                 });
                 cx.jobs.callback(callback);
-            } else if let Err(e) = cx.editor.open(path, action) {
-                let err = if let Some(err) = e.source() {
-                    format!("{}", err)
-                } else {
-                    format!("unable to open \"{}\"", path.display())
-                };
-                cx.editor.set_error(err);
+            } else if let Err(err) = cx.editor.open(path, action) {
+                cx.editor.set_error(|| {
+                    if let Some(err) = err.source() {
+                        format!("{}", err)
+                    } else {
+                        format!("unable to open \"{}\"", path.display())
+                    }
+                });
             }
         },
     )

--- a/helix-term/src/ui/picker.rs
+++ b/helix-term/src/ui/picker.rs
@@ -1140,7 +1140,7 @@ impl<I: 'static + Send + Sync, D: 'static + Send + Sync> Component for Picker<I,
                             .registers
                             .push(history_register, self.primary_query().to_string())
                         {
-                            ctx.editor.set_error(err.to_string());
+                            ctx.editor.set_error(|| err.to_string());
                         }
                     }
                     return close_fn(self);

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -695,7 +695,7 @@ impl Component for Prompt {
                                 if let Err(err) =
                                     cx.editor.registers.push(register, self.line.clone())
                                 {
-                                    cx.editor.set_error(err.to_string());
+                                    cx.editor.set_error(|| err.to_string());
                                 }
                             };
                         }

--- a/helix-view/src/action.rs
+++ b/helix-view/src/action.rs
@@ -56,7 +56,7 @@ impl Action {
 
         Self::new(title, priority, move |editor| {
             let Some(language_server) = editor.language_server_by_id(server_id) else {
-                editor.set_error("Language Server disappeared");
+                editor.set_error(|| "Language Server disappeared");
                 return;
             };
             let offset_encoding = language_server.offset_encoding();

--- a/helix-view/src/editor.rs
+++ b/helix-view/src/editor.rs
@@ -1542,16 +1542,26 @@ impl Editor {
         self.status_msg = Some((status, Severity::Info));
     }
 
-    #[inline]
-    pub fn set_error<T: Into<Cow<'static, str>>>(&mut self, error: T) {
-        let error = error.into();
+    #[cold]
+    #[inline(never)]
+    pub fn set_error<C, M>(&mut self, message: M)
+    where
+        C: Into<Cow<'static, str>>,
+        M: FnOnce() -> C,
+    {
+        let error = message().into();
         log::debug!("editor error: {}", error);
         self.status_msg = Some((error, Severity::Error));
     }
 
-    #[inline]
-    pub fn set_warning<T: Into<Cow<'static, str>>>(&mut self, warning: T) {
-        let warning = warning.into();
+    #[cold]
+    #[inline(never)]
+    pub fn set_warning<C, M>(&mut self, message: M)
+    where
+        C: Into<Cow<'static, str>>,
+        M: FnOnce() -> C,
+    {
+        let warning = message().into();
         log::warn!("editor warning: {}", warning);
         self.status_msg = Some((warning, Severity::Warning));
     }
@@ -2516,7 +2526,7 @@ impl Editor {
                 let save_event = match save_event {
                     Ok(event) => event,
                     Err(err) => {
-                        self.set_error(err.to_string());
+                        self.set_error(|| err.to_string());
                         bail!(err);
                     }
                 };

--- a/helix-view/src/handlers/dap.rs
+++ b/helix-view/src/handlers/dap.rs
@@ -68,8 +68,8 @@ pub fn jump_to_stack_frame(editor: &mut Editor, frame: &helix_dap::StackFrame) {
         return;
     };
 
-    if let Err(e) = editor.open(&path, Action::Replace) {
-        editor.set_error(format!("Unable to jump to stack frame: {}", e));
+    if let Err(err) = editor.open(&path, Action::Replace) {
+        editor.set_error(|| format!("Unable to jump to stack frame: {}", err));
         return;
     }
 
@@ -387,7 +387,7 @@ impl Editor {
                         // TODO: fetch breakpoints (in case we're attaching)
 
                         if let Err(err) = debugger.configuration_done().await {
-                            self.set_error(format!("Debugger configuration failed: {}", err));
+                            self.set_error(|| format!("Debugger configuration failed: {}", err));
                         } else {
                             self.set_status("Debugged application started");
                         }
@@ -417,10 +417,12 @@ impl Editor {
                         });
 
                         if let Err(err) = debugger.disconnect(disconnect_args).await {
-                            self.set_error(format!(
+                            self.set_error(|| {
+                                format!(
                                 "Cannot disconnect debugger upon terminated event receival {:?}",
                                 err
-                            ));
+                            )
+                            });
                             return false;
                         }
 
@@ -445,7 +447,7 @@ impl Editor {
                                 let connection_type = match debugger.connection_type() {
                                     Some(connection_type) => connection_type,
                                     None => {
-                                        self.set_error("No starting request found, to be used in restarting the debugging session.");
+                                        self.set_error(|| "No starting request found, to be used in restarting the debugging session.");
                                         return false;
                                     }
                                 };
@@ -458,10 +460,9 @@ impl Editor {
                                 };
 
                                 if let Err(err) = relaunch_resp {
-                                    self.set_error(format!(
-                                        "Failed to restart debugging session: {:?}",
-                                        err
-                                    ));
+                                    self.set_error(|| {
+                                        format!("Failed to restart debugging session: {:?}", err)
+                                    });
                                 }
                             }
                         }
@@ -469,9 +470,11 @@ impl Editor {
                     Event::Exited(resp) => {
                         let exit_code = resp.exit_code;
                         if exit_code != 0 {
-                            self.set_error(format!(
+                            self.set_error(|| {
+                                format!(
                                 "Debuggee failed to exit successfully (exit code: {exit_code})."
-                            ));
+                            )
+                            });
                         }
                     }
                     ev => {
@@ -486,7 +489,7 @@ impl Editor {
                     Ok(Request::RunInTerminal(arguments)) => {
                         let config = self.config();
                         let Some(config) = config.terminal.as_ref() else {
-                            self.set_error("No external terminal defined");
+                            self.set_error(|| "No external terminal defined");
                             return true;
                         };
 
@@ -497,10 +500,9 @@ impl Editor {
                         {
                             Ok(process) => process,
                             Err(err) => {
-                                self.set_error(format!(
-                                    "Error starting external terminal: {}",
-                                    err
-                                ));
+                                self.set_error(|| {
+                                    format!("Error starting external terminal: {}", err)
+                                });
                                 return true;
                             }
                         };
@@ -514,7 +516,7 @@ impl Editor {
                         let debugger = match self.debug_adapters.get_client_mut(id) {
                             Some(debugger) => debugger,
                             None => {
-                                self.set_error("No active debugger found.");
+                                self.set_error(|| "No active debugger found.");
                                 return true;
                             }
                         };
@@ -522,7 +524,7 @@ impl Editor {
                         let socket = match debugger.socket {
                             Some(socket) => socket,
                             None => {
-                                self.set_error("Child debugger can only be started if the parent debugger is using TCP transport.");
+                                self.set_error(||"Child debugger can only be started if the parent debugger is using TCP transport.");
                                 return true;
                             }
                         };
@@ -540,10 +542,9 @@ impl Editor {
                         let client_id = match result {
                             Ok(child) => child,
                             Err(err) => {
-                                self.set_error(format!(
-                                    "Failed to create child debugger: {:?}",
-                                    err
-                                ));
+                                self.set_error(|| {
+                                    format!("Failed to create child debugger: {:?}", err)
+                                });
                                 return true;
                             }
                         };
@@ -551,7 +552,7 @@ impl Editor {
                         let client = match self.debug_adapters.get_client_mut(client_id) {
                             Some(child) => child,
                             None => {
-                                self.set_error("Failed to get child debugger.");
+                                self.set_error(|| "Failed to get child debugger.");
                                 return true;
                             }
                         };
@@ -562,7 +563,9 @@ impl Editor {
                             client.attach(arguments.configuration).await
                         };
                         if let Err(err) = relaunch_resp {
-                            self.set_error(format!("Failed to start debugging session: {:?}", err));
+                            self.set_error(|| {
+                                format!("Failed to start debugging session: {:?}", err)
+                            });
                             return true;
                         }
 

--- a/helix-view/src/handlers/lsp.rs
+++ b/helix-view/src/handlers/lsp.rs
@@ -104,23 +104,28 @@ impl Editor {
         let doc_id = match self.open(path, Action::Load) {
             Ok(doc_id) => doc_id,
             Err(err) => {
-                let err = format!(
-                    "failed to open document: {}: {}",
-                    path.to_string_lossy(),
+                self.set_error(|| {
+                    let err = format!(
+                        "failed to open document: {}: {}",
+                        path.to_string_lossy(),
+                        err
+                    );
+                    log::error!("{}", err);
                     err
-                );
-                log::error!("{}", err);
-                self.set_error(err);
+                });
                 return Err(ApplyEditErrorKind::FileNotFound);
             }
         };
 
         let doc = doc_mut!(self, &doc_id);
         if let Some(version) = version {
-            if version != doc.version() {
-                let err = format!("outdated workspace edit for {path:?}");
-                log::error!("{err}, expected {} but got {version}", doc.version());
-                self.set_error(err);
+            let doc_version = doc.version();
+            if version != doc_version {
+                self.set_error(|| {
+                    let err = format!("outdated workspace edit for {path:?}");
+                    log::error!("{err}, expected {} but got {version}", doc_version);
+                    err
+                });
                 return Err(ApplyEditErrorKind::DocumentChanged);
             }
         }
@@ -376,7 +381,7 @@ impl Editor {
             .language_server_by_id(server_id)
             .and_then(|server| server.command(command))
         else {
-            self.set_error("Language server does not support executing commands");
+            self.set_error(|| "Language server does not support executing commands");
             return;
         };
 


### PR DESCRIPTION
This changes an error path function to be cold and outlined, which should hopefully lead to better codegen. There are no performance measurements here, but this is a known pattern. This can change inline heuristics, whereas previously this could have been inlined, other always called functions could now be inlined instead. Changes from outlining can be hard to predict, as this affects binary layout, and could make the compiler/linker move blocks around in intuitive ways.

This is another change that something like PGO could optimize for, but as we don't have any build process for this, this kind of selective specializing is all we can do for now (and for platforms that build helix themselves, this would be a change felt even by more basic build processes).