### PR TITLE
build!: error out when building on non-unix|windows platforms

### DIFF
--- a/helix-term/src/main.rs
+++ b/helix-term/src/main.rs
@@ -4,6 +4,9 @@ use helix_term::application::Application;
 use helix_term::args::Args;
 use helix_term::config::{Config, ConfigLoadError};
 
+#[cfg(not(any(unix, windows)))]
+compile_error!("Helix only supports Unix and Windows platforms. Building for other targets may succeed, but will likely encounter runtime issues. This build-time error makes that expectation explicit.");
+
 fn setup_logging(verbosity: u64) -> Result<()> {
     let level = match verbosity {
         0 => log::LevelFilter::Warn,


### PR DESCRIPTION
When looking at #16186, it became clear that unless there are deeper changes to actively support other platforms, there really shouldn't be any expectations that helix will work, even if it happens to compile. This change makes that expectation explicit, now failing to build on these platforms. As support is added over time, we can update the conditional to allow compilation on other targets.

Hopefully this makes it clear that superficial changes most likely wont be enough to add support for other platforms, and prevents someone from making a slop PR trying to one shot a "fix", as this error would be encountered first.

There are areas where we can remove fallback code, but that can be cleaned up in later refactors.