### PR TITLE
refactor: relax strictness in grammar build

### DIFF
--- a/helix-term/build.rs
+++ b/helix-term/build.rs
@@ -1,6 +1,6 @@
 use helix_loader::grammar::{build_grammars, fetch_grammars};
 
-const STRICT: bool = true;
+const STRICT: bool = false;
 
 fn main() {
     if std::env::var("HELIX_DISABLE_AUTO_GRAMMAR_BUILD").is_err() {


### PR DESCRIPTION
In #15548 it was assumed that `helix-term/build.rs` should also be strict, as the worry was for releases could have missing grammars. However, it seems that this uses the `helix-loader/main.rs` binary, and not the `helix-term/build.rs` for this:

https://github.com/helix-editor/helix/blob/079a789e8cb08ead67f19e1971a1b7438b37354b/.github/workflows/release.yml#L42-L43

Thus, it should be fine to relax the strictness here. This will (hopefully) make it so that a `cargo install` will no longer choke on grammar builds. 

Follow-up of: #15548
Closes: #16191