### PR TITLE
refactor: disable prompts when shelling out to git

### DIFF
--- a/helix-loader/src/grammar.rs
+++ b/helix-loader/src/grammar.rs
@@ -477,6 +477,11 @@ where
 {
     let output = Command::new("git")
         .args(args)
+        // `GIT_TERMINAL_PROMPT`:
+        //      If this Boolean environment variable is set to false, git will
+        //      not prompt on the terminal (e.g., when asking for HTTP authentication).
+        // https://git-scm.com/docs/git.html#Documentation/git.txt-GITTERMINALPROMPT
+        .env("GIT_TERMINAL_PROMPT", "0")
         .current_dir(repository_dir)
         .output()?;
 


### PR DESCRIPTION
There are situations (like a private repo) that would have the git cli prompt for credentials. This is bad for us, as it would hang until a timeout, so we want to disable this behavior and error out instead.

Git provides an environment variable [GIT_TERMINAL_PROMPT](https://git-scm.com/docs/git.html#Documentation/git.txt-GITTERMINALPROMPT), which does exactly this:
> If this Boolean environment variable is set to false, git will not prompt on the terminal (e.g., when asking for HTTP authentication).