### PR TITLE
feat: configurable word characters

### DIFF
--- a/book/src/languages.md
+++ b/book/src/languages.md
@@ -72,6 +72,7 @@ These configuration keys are available:
 | `rulers`              | Overrides the `editor.rulers` config key for the language. |
 | `path-completion`     | Overrides the `editor.path-completion` config key for the language. |
 | `word-completion`     | Overrides the [`editor.word-completion`](./editor.md#editorword-completion-section) configuration for the language. |
+| `extra-word-characters` | Extra characters treated as word characters. |
 | `workspace-lsp-roots`     | Directories (relative to the workspace root) that stop the upward root search early. Meant for project-specific hard overrides in a local `.helix/config.toml`; |
 | `persistent-diagnostic-sources` | An array of LSP diagnostic sources assumed unchanged when the language server resends the same set of diagnostics. Helix can track the position for these diagnostics internally instead. Useful for diagnostics that are recomputed on save.
 | `rainbow-brackets` | Overrides the `editor.rainbow-brackets` config key for the language |

--- a/helix-core/src/chars.rs
+++ b/helix-core/src/chars.rs
@@ -1,6 +1,51 @@
 //! Utility functions to categorize a `char`.
 
+use std::borrow::Cow;
+
 use crate::LineEnding;
+
+pub static DEFAULT_WORD_CHARS: WordChars = WordChars::new("");
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WordChars(Cow<'static, str>);
+
+impl WordChars {
+    pub const fn new(chars: &'static str) -> Self {
+        Self(Cow::Borrowed(chars))
+    }
+
+    #[inline]
+    pub fn is_word(&self, ch: char) -> bool {
+        char_is_word(ch) || self.0.contains(ch)
+    }
+
+    #[inline]
+    pub fn categorize(&self, ch: char) -> CharCategory {
+        if char_is_line_ending(ch) {
+            CharCategory::Eol
+        } else if ch.is_whitespace() {
+            CharCategory::Whitespace
+        } else if self.is_word(ch) {
+            CharCategory::Word
+        } else if char_is_punctuation(ch) {
+            CharCategory::Punctuation
+        } else {
+            CharCategory::Unknown
+        }
+    }
+}
+
+impl Default for WordChars {
+    fn default() -> Self {
+        Self::new("")
+    }
+}
+
+impl From<String> for WordChars {
+    fn from(value: String) -> Self {
+        Self(Cow::Owned(value))
+    }
+}
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum CharCategory {
@@ -13,17 +58,7 @@ pub enum CharCategory {
 
 #[inline]
 pub fn categorize_char(ch: char) -> CharCategory {
-    if char_is_line_ending(ch) {
-        CharCategory::Eol
-    } else if ch.is_whitespace() {
-        CharCategory::Whitespace
-    } else if char_is_word(ch) {
-        CharCategory::Word
-    } else if char_is_punctuation(ch) {
-        CharCategory::Punctuation
-    } else {
-        CharCategory::Unknown
-    }
+    DEFAULT_WORD_CHARS.categorize(ch)
 }
 
 /// Determine whether a character is a line ending.

--- a/helix-core/src/movement.rs
+++ b/helix-core/src/movement.rs
@@ -4,7 +4,7 @@ use ropey::iter::Chars;
 
 use crate::{
     char_idx_at_visual_offset,
-    chars::{categorize_char, char_is_line_ending, CharCategory},
+    chars::{categorize_char, char_is_line_ending, CharCategory, WordChars},
     doc_formatter::TextFormat,
     graphemes::{
         next_grapheme_boundary, nth_next_grapheme_boundary, nth_prev_grapheme_boundary,
@@ -165,20 +165,60 @@ pub fn move_vertically(
     new_range
 }
 
-pub fn move_next_word_start(slice: RopeSlice, range: Range, count: usize) -> Range {
-    word_move(slice, range, count, WordMotionTarget::NextWordStart)
+pub fn move_next_word_start(
+    slice: RopeSlice,
+    range: Range,
+    count: usize,
+    word_chars: &WordChars,
+) -> Range {
+    word_move(
+        slice,
+        range,
+        count,
+        WordMotionTarget::NextWordStart(word_chars),
+    )
 }
 
-pub fn move_next_word_end(slice: RopeSlice, range: Range, count: usize) -> Range {
-    word_move(slice, range, count, WordMotionTarget::NextWordEnd)
+pub fn move_next_word_end(
+    slice: RopeSlice,
+    range: Range,
+    count: usize,
+    word_chars: &WordChars,
+) -> Range {
+    word_move(
+        slice,
+        range,
+        count,
+        WordMotionTarget::NextWordEnd(word_chars),
+    )
 }
 
-pub fn move_prev_word_start(slice: RopeSlice, range: Range, count: usize) -> Range {
-    word_move(slice, range, count, WordMotionTarget::PrevWordStart)
+pub fn move_prev_word_start(
+    slice: RopeSlice,
+    range: Range,
+    count: usize,
+    word_chars: &WordChars,
+) -> Range {
+    word_move(
+        slice,
+        range,
+        count,
+        WordMotionTarget::PrevWordStart(word_chars),
+    )
 }
 
-pub fn move_prev_word_end(slice: RopeSlice, range: Range, count: usize) -> Range {
-    word_move(slice, range, count, WordMotionTarget::PrevWordEnd)
+pub fn move_prev_word_end(
+    slice: RopeSlice,
+    range: Range,
+    count: usize,
+    word_chars: &WordChars,
+) -> Range {
+    word_move(
+        slice,
+        range,
+        count,
+        WordMotionTarget::PrevWordEnd(word_chars),
+    )
 }
 
 pub fn move_next_long_word_start(slice: RopeSlice, range: Range, count: usize) -> Range {
@@ -216,10 +256,10 @@ pub fn move_prev_sub_word_end(slice: RopeSlice, range: Range, count: usize) -> R
 fn word_move(slice: RopeSlice, range: Range, count: usize, target: WordMotionTarget) -> Range {
     let is_prev = matches!(
         target,
-        WordMotionTarget::PrevWordStart
+        WordMotionTarget::PrevWordStart(_)
             | WordMotionTarget::PrevLongWordStart
             | WordMotionTarget::PrevSubWordStart
-            | WordMotionTarget::PrevWordEnd
+            | WordMotionTarget::PrevWordEnd(_)
             | WordMotionTarget::PrevLongWordEnd
             | WordMotionTarget::PrevSubWordEnd
     );
@@ -389,11 +429,11 @@ where
 
 /// Possible targets of a word motion
 #[derive(Copy, Clone, Debug)]
-pub enum WordMotionTarget {
-    NextWordStart,
-    NextWordEnd,
-    PrevWordStart,
-    PrevWordEnd,
+pub enum WordMotionTarget<'a> {
+    NextWordStart(&'a WordChars),
+    NextWordEnd(&'a WordChars),
+    PrevWordStart(&'a WordChars),
+    PrevWordEnd(&'a WordChars),
     // A "Long word" (also known as a WORD in Vim/Kakoune) is strictly
     // delimited by whitespace, and can consist of punctuation as well
     // as alphanumerics.
@@ -420,10 +460,10 @@ impl CharHelpers for Chars<'_> {
     fn range_to_target(&mut self, target: WordMotionTarget, origin: Range) -> Range {
         let is_prev = matches!(
             target,
-            WordMotionTarget::PrevWordStart
+            WordMotionTarget::PrevWordStart(_)
                 | WordMotionTarget::PrevLongWordStart
                 | WordMotionTarget::PrevSubWordStart
-                | WordMotionTarget::PrevWordEnd
+                | WordMotionTarget::PrevWordEnd(_)
                 | WordMotionTarget::PrevLongWordEnd
                 | WordMotionTarget::PrevSubWordEnd
         );
@@ -489,8 +529,8 @@ impl CharHelpers for Chars<'_> {
     }
 }
 
-fn is_word_boundary(a: char, b: char) -> bool {
-    categorize_char(a) != categorize_char(b)
+fn is_word_boundary(a: char, b: char, word_chars: &WordChars) -> bool {
+    word_chars.categorize(a) != word_chars.categorize(b)
 }
 
 fn is_long_word_boundary(a: char, b: char) -> bool {
@@ -523,12 +563,12 @@ fn is_sub_word_boundary(a: char, b: char, dir: Direction) -> bool {
 
 fn reached_target(target: WordMotionTarget, prev_ch: char, next_ch: char) -> bool {
     match target {
-        WordMotionTarget::NextWordStart | WordMotionTarget::PrevWordEnd => {
-            is_word_boundary(prev_ch, next_ch)
+        WordMotionTarget::NextWordStart(word_chars) | WordMotionTarget::PrevWordEnd(word_chars) => {
+            is_word_boundary(prev_ch, next_ch, word_chars)
                 && (char_is_line_ending(next_ch) || !next_ch.is_whitespace())
         }
-        WordMotionTarget::NextWordEnd | WordMotionTarget::PrevWordStart => {
-            is_word_boundary(prev_ch, next_ch)
+        WordMotionTarget::NextWordEnd(word_chars) | WordMotionTarget::PrevWordStart(word_chars) => {
+            is_word_boundary(prev_ch, next_ch, word_chars)
                 && (!prev_ch.is_whitespace() || char_is_line_ending(next_ch))
         }
         WordMotionTarget::NextLongWordStart | WordMotionTarget::PrevLongWordEnd => {
@@ -979,19 +1019,37 @@ mod test {
     #[test]
     #[should_panic]
     fn nonsensical_ranges_panic_on_forward_movement_attempt_in_debug_mode() {
-        move_next_word_start(Rope::from("Sample").slice(..), Range::point(99999999), 1);
+        let word_chars = WordChars::default();
+        move_next_word_start(
+            Rope::from("Sample").slice(..),
+            Range::point(99999999),
+            1,
+            &word_chars,
+        );
     }
 
     #[test]
     #[should_panic]
     fn nonsensical_ranges_panic_on_forward_to_end_movement_attempt_in_debug_mode() {
-        move_next_word_end(Rope::from("Sample").slice(..), Range::point(99999999), 1);
+        let word_chars = WordChars::default();
+        move_next_word_end(
+            Rope::from("Sample").slice(..),
+            Range::point(99999999),
+            1,
+            &word_chars,
+        );
     }
 
     #[test]
     #[should_panic]
     fn nonsensical_ranges_panic_on_backwards_movement_attempt_in_debug_mode() {
-        move_prev_word_start(Rope::from("Sample").slice(..), Range::point(99999999), 1);
+        let word_chars = WordChars::default();
+        move_prev_word_start(
+            Rope::from("Sample").slice(..),
+            Range::point(99999999),
+            1,
+            &word_chars,
+        );
     }
 
     #[test]
@@ -1071,10 +1129,12 @@ mod test {
                     (1, Range::new(0, 0), Range::new(0, 6)),
                 ]),
         ];
+        let word_chars = WordChars::default();
 
         for (sample, scenario) in tests {
             for (count, begin, expected_end) in scenario.into_iter() {
-                let range = move_next_word_start(Rope::from(sample).slice(..), begin, count);
+                let range =
+                    move_next_word_start(Rope::from(sample).slice(..), begin, count, &word_chars);
                 assert_eq!(range, expected_end, "Case failed: [{}]", sample);
             }
         }
@@ -1412,10 +1472,12 @@ mod test {
                     (1, Range::new(0, 6), Range::new(6, 0)),
                 ]),
         ];
+        let word_chars = WordChars::default();
 
         for (sample, scenario) in tests {
             for (count, begin, expected_end) in scenario.into_iter() {
-                let range = move_prev_word_start(Rope::from(sample).slice(..), begin, count);
+                let range =
+                    move_prev_word_start(Rope::from(sample).slice(..), begin, count, &word_chars);
                 assert_eq!(range, expected_end, "Case failed: [{}]", sample);
             }
         }
@@ -1679,10 +1741,12 @@ mod test {
                     (1, Range::new(0, 0), Range::new(0, 5)),
                 ]),
         ];
+        let word_chars = WordChars::default();
 
         for (sample, scenario) in tests {
             for (count, begin, expected_end) in scenario.into_iter() {
-                let range = move_next_word_end(Rope::from(sample).slice(..), begin, count);
+                let range =
+                    move_next_word_end(Rope::from(sample).slice(..), begin, count, &word_chars);
                 assert_eq!(range, expected_end, "Case failed: [{}]", sample);
             }
         }
@@ -1761,10 +1825,12 @@ mod test {
                     (1, Range::new(0, 10), Range::new(10, 4)),
                 ]),
         ];
+        let word_chars = WordChars::default();
 
         for (sample, scenario) in tests {
             for (count, begin, expected_end) in scenario.into_iter() {
-                let range = move_prev_word_end(Rope::from(sample).slice(..), begin, count);
+                let range =
+                    move_prev_word_end(Rope::from(sample).slice(..), begin, count, &word_chars);
                 assert_eq!(range, expected_end, "Case failed: [{}]", sample);
             }
         }

--- a/helix-core/src/syntax/config.rs
+++ b/helix-core/src/syntax/config.rs
@@ -1,4 +1,4 @@
-use crate::{auto_pairs::AutoPairs, diagnostic::Severity, Language};
+use crate::{auto_pairs::AutoPairs, chars::WordChars, diagnostic::Severity, Language};
 
 use helix_stdx::rope;
 use serde::{ser::SerializeSeq as _, Deserialize, Serialize};
@@ -66,6 +66,14 @@ pub struct LanguageConfiguration {
     pub path_completion: Option<bool>,
     /// If set, overrides `editor.word-completion`.
     pub word_completion: Option<WordCompletion>,
+
+    #[serde(
+        default,
+        rename = "extra-word-characters",
+        skip_serializing,
+        deserialize_with = "deserialize_word_chars"
+    )]
+    pub word_chars: WordChars,
 
     #[serde(default)]
     pub diagnostic_severity: Severity,
@@ -648,6 +656,13 @@ where
     D: serde::Deserializer<'de>,
 {
     Ok(Option::<AutoPairConfig>::deserialize(deserializer)?.and_then(AutoPairConfig::into))
+}
+
+pub fn deserialize_word_chars<'de, D>(deserializer: D) -> Result<WordChars, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    String::deserialize(deserializer).map(WordChars::from)
 }
 
 fn default_timeout() -> u64 {

--- a/helix-core/src/textobject.rs
+++ b/helix-core/src/textobject.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use ropey::RopeSlice;
 
-use crate::chars::{categorize_char, char_is_whitespace, CharCategory};
+use crate::chars::{char_is_whitespace, CharCategory, WordChars};
 use crate::graphemes::{next_grapheme_boundary, prev_grapheme_boundary};
 use crate::line_ending::rope_is_line_ending;
 use crate::movement::Direction;
@@ -10,7 +10,13 @@ use crate::syntax;
 use crate::Range;
 use crate::{surround, Syntax};
 
-fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction, long: bool) -> usize {
+fn find_word_boundary(
+    slice: RopeSlice,
+    mut pos: usize,
+    direction: Direction,
+    long: bool,
+    word_chars: &WordChars,
+) -> usize {
     use CharCategory::{Eol, Whitespace};
 
     let iter = match direction {
@@ -24,13 +30,13 @@ fn find_word_boundary(slice: RopeSlice, mut pos: usize, direction: Direction, lo
 
     let mut prev_category = match direction {
         Direction::Forward if pos == 0 => Whitespace,
-        Direction::Forward => categorize_char(slice.char(pos - 1)),
+        Direction::Forward => word_chars.categorize(slice.char(pos - 1)),
         Direction::Backward if pos == slice.len_chars() => Whitespace,
-        Direction::Backward => categorize_char(slice.char(pos)),
+        Direction::Backward => word_chars.categorize(slice.char(pos)),
     };
 
     for ch in iter {
-        match categorize_char(ch) {
+        match word_chars.categorize(ch) {
             Eol | Whitespace => return pos,
             category => {
                 if !long && category != prev_category && pos != 0 && pos != slice.len_chars() {
@@ -74,13 +80,14 @@ pub fn textobject_word(
     textobject: TextObject,
     _count: usize,
     long: bool,
+    word_chars: &WordChars,
 ) -> Range {
     let pos = range.cursor(slice);
 
-    let word_start = find_word_boundary(slice, pos, Direction::Backward, long);
-    let word_end = match slice.get_char(pos).map(categorize_char) {
+    let word_start = find_word_boundary(slice, pos, Direction::Backward, long, word_chars);
+    let word_end = match slice.get_char(pos).map(|ch| word_chars.categorize(ch)) {
         None | Some(CharCategory::Whitespace | CharCategory::Eol) => pos,
-        _ => find_word_boundary(slice, pos + 1, Direction::Forward, long),
+        _ => find_word_boundary(slice, pos + 1, Direction::Forward, long, word_chars),
     };
 
     // Special case.
@@ -395,6 +402,7 @@ mod test {
                 vec![(19, Inside, (17, 20)), (19, Around, (16, 20))],
             ),
         ];
+        let word_chars = WordChars::default();
 
         for (sample, scenario) in tests {
             let doc = Rope::from(*sample);
@@ -403,7 +411,7 @@ mod test {
                 let (pos, objtype, expected_range) = case;
                 // cursor is a single width selection
                 let range = Range::new(pos, pos + 1);
-                let result = textobject_word(slice, range, objtype, 1, false);
+                let result = textobject_word(slice, range, objtype, 1, false, &word_chars);
                 assert_eq!(
                     result,
                     expected_range.into(),

--- a/helix-lsp/src/lib.rs
+++ b/helix-lsp/src/lib.rs
@@ -79,9 +79,10 @@ pub enum OffsetEncoding {
 
 pub mod util {
     use super::*;
+    use helix_core::chars::WordChars;
     use helix_core::line_ending::{line_end_byte_index, line_end_char_index};
     use helix_core::snippets::{RenderedSnippet, Snippet, SnippetRenderCtx};
-    use helix_core::{chars, RopeSlice};
+    use helix_core::RopeSlice;
     use helix_core::{diagnostic::NumberOrString, Range, Rope, Selection, Tendril, Transaction};
 
     /// Converts a diagnostic in the document to [`lsp::Diagnostic`].
@@ -287,18 +288,23 @@ pub mod util {
     /// If the LS did not provide a range for the completion or the range of the
     /// primary cursor can not be used for the secondary cursor, this function
     /// can be used to find the completion range for a cursor
-    fn find_completion_range(text: RopeSlice, replace_mode: bool, cursor: usize) -> (usize, usize) {
+    fn find_completion_range(
+        text: RopeSlice,
+        replace_mode: bool,
+        cursor: usize,
+        word_chars: &WordChars,
+    ) -> (usize, usize) {
         let start = cursor
             - text
                 .chars_at(cursor)
                 .reversed()
-                .take_while(|ch| chars::char_is_word(*ch))
+                .take_while(|ch| word_chars.is_word(*ch))
                 .count();
         let mut end = cursor;
         if replace_mode {
             end += text
                 .chars_at(cursor)
-                .take_while(|ch| chars::char_is_word(*ch))
+                .take_while(|ch| word_chars.is_word(*ch))
                 .count();
         }
         (start, end)
@@ -308,6 +314,7 @@ pub mod util {
         edit_offset: Option<(i128, i128)>,
         replace_mode: bool,
         cursor: usize,
+        word_chars: &WordChars,
     ) -> Option<(usize, usize)> {
         let res = match edit_offset {
             Some((start_offset, end_offset)) => {
@@ -321,7 +328,7 @@ pub mod util {
                 }
                 (start_offset as usize, end_offset as usize)
             }
-            None => find_completion_range(text, replace_mode, cursor),
+            None => find_completion_range(text, replace_mode, cursor, word_chars),
         };
         Some(res)
     }
@@ -334,6 +341,7 @@ pub mod util {
         edit_offset: Option<(i128, i128)>,
         replace_mode: bool,
         new_text: String,
+        word_chars: &WordChars,
     ) -> Transaction {
         let replacement: Option<Tendril> = if new_text.is_empty() {
             None
@@ -347,6 +355,7 @@ pub mod util {
             edit_offset,
             replace_mode,
             selection.primary().cursor(text),
+            word_chars,
         )
         .expect("transaction must be valid for primary selection");
         let removed_text = text.slice(removed_start..removed_end);
@@ -356,9 +365,11 @@ pub mod util {
             selection,
             |range| {
                 let cursor = range.cursor(text);
-                completion_range(text, edit_offset, replace_mode, cursor)
+                completion_range(text, edit_offset, replace_mode, cursor, word_chars)
                     .filter(|(start, end)| text.slice(start..end) == removed_text)
-                    .unwrap_or_else(|| find_completion_range(text, replace_mode, cursor))
+                    .unwrap_or_else(|| {
+                        find_completion_range(text, replace_mode, cursor, word_chars)
+                    })
             },
             |_, _| replacement.clone(),
         );
@@ -378,6 +389,7 @@ pub mod util {
         replace_mode: bool,
         snippet: Snippet,
         cx: &mut SnippetRenderCtx,
+        word_chars: &WordChars,
     ) -> (Transaction, RenderedSnippet) {
         let text = doc.slice(..);
         let (removed_start, removed_end) = completion_range(
@@ -385,6 +397,7 @@ pub mod util {
             edit_offset,
             replace_mode,
             selection.primary().cursor(text),
+            word_chars,
         )
         .expect("transaction must be valid for primary selection");
         let removed_text = text.slice(removed_start..removed_end);
@@ -393,9 +406,11 @@ pub mod util {
             selection,
             |range| {
                 let cursor = range.cursor(text);
-                completion_range(text, edit_offset, replace_mode, cursor)
+                completion_range(text, edit_offset, replace_mode, cursor, word_chars)
                     .filter(|(start, end)| text.slice(start..end) == removed_text)
-                    .unwrap_or_else(|| find_completion_range(text, replace_mode, cursor))
+                    .unwrap_or_else(|| {
+                        find_completion_range(text, replace_mode, cursor, word_chars)
+                    })
             },
             cx,
         );

--- a/helix-term/src/commands.rs
+++ b/helix-term/src/commands.rs
@@ -21,7 +21,7 @@ pub use typed::*;
 
 use helix_core::{
     char_idx_at_visual_offset,
-    chars::char_is_word,
+    chars::{char_is_word, WordChars, DEFAULT_WORD_CHARS},
     command_line::{self, Args},
     comment,
     doc_formatter::TextFormat,
@@ -1192,7 +1192,7 @@ fn goto_window_bottom(cx: &mut Context) {
     goto_window(cx, Align::Bottom)
 }
 
-fn move_word_impl<F>(cx: &mut Context, move_fn: F)
+fn move_word_impl<F>(cx: &mut Context, move_fn: F, behaviour: Movement)
 where
     F: Fn(RopeSlice, Range, usize) -> Range,
 {
@@ -1200,59 +1200,90 @@ where
     let (view, doc) = current!(cx.editor);
     let text = doc.text().slice(..);
 
-    let selection = doc
-        .selection(view.id)
-        .clone()
-        .transform(|range| move_fn(text, range, count));
+    let selection = match behaviour {
+        Movement::Move => doc
+            .selection(view.id)
+            .clone()
+            .transform(|range| move_fn(text, range, count)),
+        Movement::Extend => doc.selection(view.id).clone().transform(|range| {
+            let word = move_fn(text, range, count);
+            let pos = word.cursor(text);
+            range.put_cursor(text, pos, true)
+        }),
+    };
+
+    doc.set_selection(view.id, selection);
+}
+
+fn move_language_word_impl<F>(cx: &mut Context, move_fn: F, behaviour: Movement)
+where
+    F: Fn(RopeSlice, Range, usize, &WordChars) -> Range,
+{
+    let count = cx.count();
+    let (view, doc) = current!(cx.editor);
+    let text = doc.text().slice(..);
+    let loader = cx.editor.syn_loader.load();
+
+    let selection = doc.selection(view.id).clone().transform(|range| {
+        let byte_pos = text.char_to_byte(range.cursor(text));
+        let word_chars = doc.word_chars_at(&loader, byte_pos);
+        let word = move_fn(text, range, count, word_chars);
+
+        match behaviour {
+            Movement::Move => word,
+            Movement::Extend => range.put_cursor(text, word.cursor(text), true),
+        }
+    });
+
     doc.set_selection(view.id, selection);
 }
 
 fn move_next_word_start(cx: &mut Context) {
-    move_word_impl(cx, movement::move_next_word_start)
+    move_language_word_impl(cx, movement::move_next_word_start, Movement::Move)
 }
 
 fn move_prev_word_start(cx: &mut Context) {
-    move_word_impl(cx, movement::move_prev_word_start)
+    move_language_word_impl(cx, movement::move_prev_word_start, Movement::Move)
 }
 
 fn move_prev_word_end(cx: &mut Context) {
-    move_word_impl(cx, movement::move_prev_word_end)
+    move_language_word_impl(cx, movement::move_prev_word_end, Movement::Move)
 }
 
 fn move_next_word_end(cx: &mut Context) {
-    move_word_impl(cx, movement::move_next_word_end)
+    move_language_word_impl(cx, movement::move_next_word_end, Movement::Move)
 }
 
 fn move_next_long_word_start(cx: &mut Context) {
-    move_word_impl(cx, movement::move_next_long_word_start)
+    move_word_impl(cx, movement::move_next_long_word_start, Movement::Move)
 }
 
 fn move_prev_long_word_start(cx: &mut Context) {
-    move_word_impl(cx, movement::move_prev_long_word_start)
+    move_word_impl(cx, movement::move_prev_long_word_start, Movement::Move)
 }
 
 fn move_prev_long_word_end(cx: &mut Context) {
-    move_word_impl(cx, movement::move_prev_long_word_end)
+    move_word_impl(cx, movement::move_prev_long_word_end, Movement::Move)
 }
 
 fn move_next_long_word_end(cx: &mut Context) {
-    move_word_impl(cx, movement::move_next_long_word_end)
+    move_word_impl(cx, movement::move_next_long_word_end, Movement::Move)
 }
 
 fn move_next_sub_word_start(cx: &mut Context) {
-    move_word_impl(cx, movement::move_next_sub_word_start)
+    move_word_impl(cx, movement::move_next_sub_word_start, Movement::Move)
 }
 
 fn move_prev_sub_word_start(cx: &mut Context) {
-    move_word_impl(cx, movement::move_prev_sub_word_start)
+    move_word_impl(cx, movement::move_prev_sub_word_start, Movement::Move)
 }
 
 fn move_prev_sub_word_end(cx: &mut Context) {
-    move_word_impl(cx, movement::move_prev_sub_word_end)
+    move_word_impl(cx, movement::move_prev_sub_word_end, Movement::Move)
 }
 
 fn move_next_sub_word_end(cx: &mut Context) {
-    move_word_impl(cx, movement::move_next_sub_word_end)
+    move_word_impl(cx, movement::move_next_sub_word_end, Movement::Move)
 }
 
 fn goto_para_impl<F>(cx: &mut Context, move_fn: F)
@@ -1585,68 +1616,52 @@ fn should_open_url_externally(url: &Url) -> bool {
     matches!(is_binary, Ok(true))
 }
 
-fn extend_word_impl<F>(cx: &mut Context, extend_fn: F)
-where
-    F: Fn(RopeSlice, Range, usize) -> Range,
-{
-    let count = cx.count();
-    let (view, doc) = current!(cx.editor);
-    let text = doc.text().slice(..);
-
-    let selection = doc.selection(view.id).clone().transform(|range| {
-        let word = extend_fn(text, range, count);
-        let pos = word.cursor(text);
-        range.put_cursor(text, pos, true)
-    });
-    doc.set_selection(view.id, selection);
-}
-
 fn extend_next_word_start(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_next_word_start)
+    move_language_word_impl(cx, movement::move_next_word_start, Movement::Extend)
 }
 
 fn extend_prev_word_start(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_prev_word_start)
+    move_language_word_impl(cx, movement::move_prev_word_start, Movement::Extend)
 }
 
 fn extend_next_word_end(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_next_word_end)
+    move_language_word_impl(cx, movement::move_next_word_end, Movement::Extend)
 }
 
 fn extend_prev_word_end(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_prev_word_end)
+    move_language_word_impl(cx, movement::move_prev_word_end, Movement::Extend)
 }
 
 fn extend_next_long_word_start(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_next_long_word_start)
+    move_word_impl(cx, movement::move_next_long_word_start, Movement::Extend)
 }
 
 fn extend_prev_long_word_start(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_prev_long_word_start)
+    move_word_impl(cx, movement::move_prev_long_word_start, Movement::Extend)
 }
 
 fn extend_prev_long_word_end(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_prev_long_word_end)
+    move_word_impl(cx, movement::move_prev_long_word_end, Movement::Extend)
 }
 
 fn extend_next_long_word_end(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_next_long_word_end)
+    move_word_impl(cx, movement::move_next_long_word_end, Movement::Extend)
 }
 
 fn extend_next_sub_word_start(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_next_sub_word_start)
+    move_word_impl(cx, movement::move_next_sub_word_start, Movement::Extend)
 }
 
 fn extend_prev_sub_word_start(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_prev_sub_word_start)
+    move_word_impl(cx, movement::move_prev_sub_word_start, Movement::Extend)
 }
 
 fn extend_prev_sub_word_end(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_prev_sub_word_end)
+    move_word_impl(cx, movement::move_prev_sub_word_end, Movement::Extend)
 }
 
 fn extend_next_sub_word_end(cx: &mut Context) {
-    extend_word_impl(cx, movement::move_next_sub_word_end)
+    move_word_impl(cx, movement::move_next_sub_word_end, Movement::Extend)
 }
 
 /// Separate branch to find_char designed only for `<ret>` char.
@@ -4740,10 +4755,12 @@ pub mod insert {
 
     pub fn delete_word_backward(cx: &mut Context) {
         let count = cx.count();
+        let word_chars = doc!(cx.editor).word_chars().clone();
         delete_by_selection_insert_mode(
             cx,
             |text, range| {
-                let anchor = movement::move_prev_word_start(text, *range, count).from();
+                let anchor =
+                    movement::move_prev_word_start(text, *range, count, &word_chars).from();
                 let next = Range::new(anchor, range.cursor(text));
                 let range = exclude_cursor(text, next, *range);
                 (range.from(), range.to())
@@ -4754,10 +4771,11 @@ pub mod insert {
 
     pub fn delete_word_forward(cx: &mut Context) {
         let count = cx.count();
+        let word_chars = doc!(cx.editor).word_chars().clone();
         delete_by_selection_insert_mode(
             cx,
             |text, range| {
-                let head = movement::move_next_word_end(text, *range, count).to();
+                let head = movement::move_next_word_end(text, *range, count, &word_chars).to();
                 (range.cursor(text), head)
             },
             Direction::Forward,
@@ -6301,9 +6319,15 @@ fn select_textobject(cx: &mut Context, objtype: textobject::TextObject) {
                 };
 
                 let selection = doc.selection(view.id).clone().transform(|range| {
+                    let byte_pos = text.char_to_byte(range.cursor(text));
+                    let word_chars = doc.word_chars_at(&loader, byte_pos);
                     match ch {
-                        'w' => textobject::textobject_word(text, range, objtype, count, false),
-                        'W' => textobject::textobject_word(text, range, objtype, count, true),
+                        'w' => textobject::textobject_word(
+                            text, range, objtype, count, false, word_chars,
+                        ),
+                        'W' => textobject::textobject_word(
+                            text, range, objtype, count, true, word_chars,
+                        ),
                         't' => textobject_treesitter("class", range),
                         'f' => textobject_treesitter("function", range),
                         'a' => textobject_treesitter("parameter", range),
@@ -7111,6 +7135,8 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
     let (view, doc) = current_ref!(cx.editor);
     let text = doc.text().slice(..);
 
+    let word_chars = &DEFAULT_WORD_CHARS;
+
     // This is not necessarily exact if there is virtual text like soft wrap.
     // It's ok though because the extra jump labels will not be rendered.
     let start = text.line_to_char(text.char_to_line(doc.view_offset(view.id).anchor));
@@ -7121,12 +7147,12 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
     let mut cursor_fwd = Range::point(cursor);
     let mut cursor_rev = Range::point(cursor);
     if text.get_char(cursor).is_some_and(|c| !c.is_whitespace()) {
-        let cursor_word_end = movement::move_next_word_end(text, cursor_fwd, 1);
+        let cursor_word_end = movement::move_next_word_end(text, cursor_fwd, 1, word_chars);
         //  single grapheme words need a special case
         if cursor_word_end.anchor == cursor {
             cursor_fwd = cursor_word_end;
         }
-        let cursor_word_start = movement::move_prev_word_start(text, cursor_rev, 1);
+        let cursor_word_start = movement::move_prev_word_start(text, cursor_rev, 1, word_chars);
         if cursor_word_start.anchor == next_grapheme_boundary(text, cursor) {
             cursor_rev = cursor_word_start;
         }
@@ -7134,7 +7160,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
     'outer: loop {
         let mut changed = false;
         while cursor_fwd.head < end {
-            cursor_fwd = movement::move_next_word_end(text, cursor_fwd, 1);
+            cursor_fwd = movement::move_next_word_end(text, cursor_fwd, 1, word_chars);
             // The cursor is on a word that is atleast two graphemes long and
             // madeup of word characters. The latter condition is needed because
             // move_next_word_end simply treats a sequence of characters from
@@ -7143,7 +7169,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
                 .slice(..cursor_fwd.head)
                 .graphemes_rev()
                 .take(2)
-                .take_while(|g| g.chars().all(char_is_word))
+                .take_while(|g| g.chars().all(|ch| word_chars.is_word(ch)))
                 .count()
                 == 2;
             if !add_label {
@@ -7153,7 +7179,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
             // skip any leading whitespace
             cursor_fwd.anchor += text
                 .chars_at(cursor_fwd.anchor)
-                .take_while(|&c| !char_is_word(c))
+                .take_while(|&c| !word_chars.is_word(c))
                 .count();
             words.push(cursor_fwd);
             if words.len() == jump_label_limit {
@@ -7162,7 +7188,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
             break;
         }
         while cursor_rev.head > start {
-            cursor_rev = movement::move_prev_word_start(text, cursor_rev, 1);
+            cursor_rev = movement::move_prev_word_start(text, cursor_rev, 1, word_chars);
             // The cursor is on a word that is atleast two graphemes long and
             // madeup of word characters. The latter condition is needed because
             // move_prev_word_start simply treats a sequence of characters from
@@ -7171,7 +7197,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
                 .slice(cursor_rev.head..)
                 .graphemes()
                 .take(2)
-                .take_while(|g| g.chars().all(char_is_word))
+                .take_while(|g| g.chars().all(|ch| word_chars.is_word(ch)))
                 .count()
                 == 2;
             if !add_label {
@@ -7181,7 +7207,7 @@ fn jump_to_word(cx: &mut Context, behaviour: Movement) {
             cursor_rev.anchor -= text
                 .chars_at(cursor_rev.anchor)
                 .reversed()
-                .take_while(|&c| !char_is_word(c))
+                .take_while(|&c| !word_chars.is_word(c))
                 .count();
             words.push(cursor_rev);
             if words.len() == jump_label_limit {

--- a/helix-term/src/commands/lsp.rs
+++ b/helix-term/src/commands/lsp.rs
@@ -1157,7 +1157,14 @@ pub fn rename_symbol(cx: &mut Context) {
             primary_selection
         } else {
             use helix_core::textobject::{textobject_word, TextObject};
-            textobject_word(text, primary_selection, TextObject::Inside, 1, false)
+            textobject_word(
+                text,
+                primary_selection,
+                TextObject::Inside,
+                1,
+                false,
+                &doc.word_chars(),
+            )
         }
         .fragment(text)
         .into()

--- a/helix-term/src/handlers/completion.rs
+++ b/helix-term/src/handlers/completion.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 
-use helix_core::chars::char_is_word;
 use helix_core::completion::CompletionProvider;
 use helix_core::syntax::config::LanguageServerFeature;
 use helix_event::{register_hook, TaskHandle};
@@ -153,13 +152,14 @@ pub fn trigger_auto_completion(editor: &Editor, trigger_char_only: bool) {
         return;
     }
 
+    let word_chars = doc.word_chars();
     let is_auto_trigger = !trigger_char_only
         && doc
             .text()
             .chars_at(cursor)
             .reversed()
             .take(config.completion_trigger_len as usize)
-            .all(char_is_word);
+            .all(|ch| word_chars.is_word(ch));
 
     if is_auto_trigger {
         handler.event(CompletionEvent::AutoTrigger {
@@ -172,10 +172,11 @@ pub fn trigger_auto_completion(editor: &Editor, trigger_char_only: bool) {
 
 fn update_completion_filter(cx: &mut commands::Context, c: Option<char>) {
     cx.callback.push(Box::new(move |compositor, cx| {
+        let word_chars = doc!(cx.editor).word_chars();
         let editor_view = compositor.find::<ui::EditorView>().unwrap();
         if let Some(completion) = &mut editor_view.completion {
             completion.update_filter(c);
-            if completion.is_empty() || c.is_some_and(|c| !char_is_word(c)) {
+            if completion.is_empty() || c.is_some_and(|c| !word_chars.is_word(c)) {
                 editor_view.clear_completion(cx.editor);
                 // clearing completions might mean we want to immediately rerequest them (usually
                 // this occurs if typing a trigger char)

--- a/helix-term/src/handlers/completion/word.rs
+++ b/helix-term/src/handlers/completion/word.rs
@@ -1,8 +1,6 @@
 use std::{borrow::Cow, sync::Arc};
 
-use helix_core::{
-    self as core, chars::char_is_word, completion::CompletionProvider, movement, Transaction,
-};
+use helix_core::{self as core, completion::CompletionProvider, Transaction};
 use helix_event::TaskHandle;
 use helix_stdx::rope::RopeSliceExt as _;
 use helix_view::{
@@ -37,24 +35,30 @@ pub(super) fn completion(
     let text = doc.text().slice(..);
     let selection = doc.selection(view.id).clone();
     let pos = selection.primary().cursor(text);
+    let word_chars = doc.word_chars();
 
-    let cursor = movement::move_prev_word_start(text, core::Range::point(pos), 1);
-    if cursor.head == pos {
+    let word_start = pos
+        - text
+            .chars_at(pos)
+            .reversed()
+            .take_while(|&ch| word_chars.is_word(ch))
+            .count();
+    if word_start == pos {
         return None;
     }
     if trigger.kind != TriggerKind::Manual
         && text
-            .slice(cursor.head..)
+            .slice(word_start..)
             .graphemes()
             .take(trigger_length)
-            .take_while(|g| g.chars().all(char_is_word))
+            .take_while(|g| g.chars().all(|ch| word_chars.is_word(ch)))
             .count()
             != trigger_length
     {
         return None;
     }
 
-    let typed_word_range = cursor.head..pos;
+    let typed_word_range = word_start..pos;
     let typed_word = text.slice(typed_word_range.clone());
     let edit_diff = if typed_word
         .char(typed_word.len_chars().saturating_sub(1))

--- a/helix-term/src/ui/completion.rs
+++ b/helix-term/src/ui/completion.rs
@@ -7,7 +7,7 @@ use crate::{
     },
 };
 use helix_core::snippets::{ActiveSnippet, RenderedSnippet, Snippet};
-use helix_core::{self as core, chars, fuzzy::MATCHER, Change, Transaction};
+use helix_core::{self as core, fuzzy::MATCHER, Change, Transaction};
 use helix_lsp::{lsp, util, OffsetEncoding};
 use helix_view::{
     editor::CompleteAction,
@@ -297,10 +297,11 @@ impl Completion {
         let (view, doc) = current_ref!(editor);
         let text = doc.text().slice(..);
         let cursor = doc.selection(view.id).primary().cursor(text);
+        let word_chars = doc.word_chars();
         let offset = text
             .chars_at(cursor)
             .reversed()
-            .take_while(|ch| chars::char_is_word(*ch))
+            .take_while(|&ch| word_chars.is_word(ch))
             .count();
         let start_offset = cursor.saturating_sub(offset);
 
@@ -590,6 +591,7 @@ fn lsp_item_to_transaction(
     let selection = doc.selection(view_id);
     let text = doc.text().slice(..);
     let primary_cursor = selection.primary().cursor(text);
+    let word_chars = doc.word_chars();
 
     let (edit_offset, new_text) = if let Some(edit) = &item.text_edit {
         let edit = match edit {
@@ -642,6 +644,7 @@ fn lsp_item_to_transaction(
             replace_mode,
             snippet,
             &mut doc.snippet_ctx(),
+            word_chars,
         );
         (transaction, Some(snippet))
     } else {
@@ -651,6 +654,7 @@ fn lsp_item_to_transaction(
             edit_offset,
             replace_mode,
             new_text,
+            word_chars,
         );
         (transaction, None)
     }

--- a/helix-term/src/ui/prompt.rs
+++ b/helix-term/src/ui/prompt.rs
@@ -669,6 +669,7 @@ impl Component for Prompt {
                     textobject::TextObject::Inside,
                     1,
                     false,
+                    doc.word_chars(),
                 );
                 let line = text.slice(range.from()..range.to()).to_string();
                 if !line.is_empty() {

--- a/helix-view/src/document.rs
+++ b/helix-view/src/document.rs
@@ -4,7 +4,7 @@ use arc_swap::ArcSwap;
 use futures_util::future::BoxFuture;
 use futures_util::FutureExt;
 use helix_core::auto_pairs::AutoPairs;
-use helix_core::chars::char_is_word;
+use helix_core::chars::{WordChars, DEFAULT_WORD_CHARS};
 use helix_core::command_line::Token;
 use helix_core::diagnostic::DiagnosticProvider;
 use helix_core::doc_formatter::TextFormat;
@@ -1926,6 +1926,22 @@ impl Document {
         self.version
     }
 
+    pub fn word_chars(&self) -> &WordChars {
+        self.language_config()
+            .map(|config| &config.word_chars)
+            .unwrap_or(&DEFAULT_WORD_CHARS)
+    }
+
+    pub fn word_chars_at<'a>(
+        &'a self,
+        loader: &'a syntax::Loader,
+        byte_pos: usize,
+    ) -> &'a WordChars {
+        self.language_config_at(loader, byte_pos)
+            .map(|config| &config.word_chars)
+            .unwrap_or(&DEFAULT_WORD_CHARS)
+    }
+
     pub fn word_completion_enabled(&self) -> bool {
         self.language_config()
             .and_then(|lang_config| lang_config.word_completion.and_then(|c| c.enable))
@@ -2230,9 +2246,19 @@ impl Document {
             Vec::new()
         };
 
-        let ends_at_word =
-            start != end && end != 0 && text.get_char(end - 1).is_some_and(char_is_word);
-        let starts_at_word = start != end && text.get_char(start).is_some_and(char_is_word);
+        let word_chars = language_config
+            .map(|config| &config.word_chars)
+            .unwrap_or(&DEFAULT_WORD_CHARS);
+
+        let ends_at_word = start != end
+            && end != 0
+            && text
+                .get_char(end - 1)
+                .is_some_and(|ch| word_chars.is_word(ch));
+        let starts_at_word = start != end
+            && text
+                .get_char(start)
+                .is_some_and(|ch| word_chars.is_word(ch));
 
         Some(Diagnostic {
             range: Range { start, end },

--- a/languages.toml
+++ b/languages.toml
@@ -231,6 +231,7 @@ constantValues = true
 functionTypeParameters = true
 parameterNames = true
 rangeVariableTypes = true
+extra-word-characters = "-"
 
 [language-server.golangci-lint-lsp]
 command = "golangci-lint-langserver"
@@ -432,6 +433,7 @@ file-types = [
 comment-token = "#"
 language-servers = [ "taplo", "tombi" ]
 indent = { tab-width = 2, unit = "  " }
+extra-word-characters = "-"
 
 [[grammar]]
 name = "toml"
@@ -499,6 +501,7 @@ roots = ["mix.exs", "mix.lock"]
 comment-token = "#"
 language-servers = [ "elixir-ls", "expert" ]
 indent = { tab-width = 2, unit = "  " }
+extra-word-characters = "!?"
 
 [[grammar]]
 name = "elixir"
@@ -529,6 +532,7 @@ language-servers = ["fish-lsp"]
 indent = { tab-width = 4, unit = "    " }
 auto-format = true
 formatter = { command = "fish_indent" }
+extra-word-characters = "@-."
 
 [[grammar]]
 name = "fish"
@@ -1093,6 +1097,7 @@ block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "vscode-css-language-server" ]
 auto-format = true
 indent = { tab-width = 2, unit = "  " }
+extra-word-characters = "-"
 
 [[grammar]]
 name = "css"
@@ -1215,6 +1220,7 @@ block-comment-tokens = { start = "/*", end = "*/" }
 language-servers = [ "nil", "nixd" ]
 indent = { tab-width = 2, unit = "  " }
 formatter = { command = "nixfmt" }
+extra-word-characters = "-"
 
 [[grammar]]
 name = "nix"
@@ -1606,6 +1612,7 @@ indent = { tab-width = 1, unit = " " }
 grammar = "scheme"
 auto-format = true
 formatter = { command = "dune", args = ["format-dune-file"] }
+extra-word-characters = "#?./"
 
 [language.auto-pairs]
 '(' = ')'
@@ -1801,6 +1808,7 @@ comment-tokens = ["//", "///", "//!"]
 language-servers = [ "zls" ]
 indent = { tab-width = 4, unit = "    " }
 formatter = { command = "zig" , args = ["fmt", "--stdin"] }
+extra-word-characters = "@"
 
 [language.debugger]
 name = "lldb-dap"
@@ -1952,6 +1960,7 @@ shebangs = ["perl"]
 comment-token = "#"
 language-servers = [ "perlnavigator" ]
 indent = { tab-width = 2, unit = "  " }
+extra-word-characters = ":"
 
 [[grammar]]
 name = "perl"
@@ -1989,6 +1998,7 @@ indent = { tab-width = 2, unit = "  " }
 block-comment-tokens = { start = "#|", end = "|#" }
 language-servers = [ "racket" ]
 grammar = "scheme"
+extra-word-characters = "@!#-'*-:<-~^"
 
 [[language]]
 name = "common-lisp"
@@ -1999,6 +2009,7 @@ comment-token = ";"
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "cl-lsp" ]
 grammar = "commonlisp"
+extra-word-characters = "+-*/%<=>:$?!@^"
 
 [[grammar]]
 name = "commonlisp"
@@ -2341,6 +2352,7 @@ language-servers = [ "graphql-language-service" ]
 comment-token = "#"
 block-comment-tokens = { start = "\"\"\"", end = "\"\"\"" }
 indent = { tab-width = 2, unit = "  " }
+extra-word-characters = "$@"
 
 [[grammar]]
 name = "graphql"
@@ -2538,6 +2550,7 @@ shebangs = ["r", "R"]
 comment-tokens = ["#", "#'"]
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "r" ]
+extra-word-characters = "@."
 
 [[grammar]]
 name = "r"
@@ -2553,6 +2566,7 @@ indent = { tab-width = 2, unit = "  " }
 grammar = "markdown"
 block-comment-tokens = { start = "<!--", end = "-->" }
 language-servers = [ "r" ]
+extra-word-characters = "@."
 
 [[language]]
 name = "swift"
@@ -2824,6 +2838,7 @@ shebangs = ["scheme", "guile", "chicken"]
 comment-token = ";"
 block-comment-tokens = { start = "#|", end = "|#" }
 indent = { tab-width = 2, unit = "  " }
+extra-word-characters = "!#$%&'*+-./:<=>?@^~"
 
 [language.auto-pairs]
 '(' = ')'
@@ -2938,6 +2953,7 @@ comment-token = ";"
 language-servers = [ "clojure-lsp" ]
 indent = { tab-width = 2, unit = "  " }
 formatter = { command = "cljfmt", args = ["fix", "-"] }
+extra-word-characters = "?-*!+/=<>.:$%&|"
 
 [[grammar]]
 name = "clojure"
@@ -3178,6 +3194,7 @@ file-types = ["astro"]
 block-comment-tokens = { start = "<!--", end = "-->" }
 indent = { tab-width = 2, unit = "  " }
 language-servers = [ "astro-ls" ]
+extra-word-characters = "-$%"
 
 [[grammar]]
 name = "astro"
@@ -3203,6 +3220,7 @@ comment-token = ";;"
 block-comment-tokens = { start = "(;", end = ";)" }
 file-types = ["wat"]
 language-servers = ["wasm-language-tools"]
+extra-word-characters = "$./"
 
 [[grammar]]
 name = "wat"
@@ -3864,6 +3882,7 @@ comment-token = "#"
 indent = { tab-width = 4, unit = "    " }
 language-servers = ["just-lsp"]
 formatter = { command = "just", args = ["--fmt", "--justfile", "-"] }
+extra-word-characters = "-"
 
 [[grammar]]
 name = "just"
@@ -3905,6 +3924,7 @@ file-types = ["fs", "forth", "fth", "4th"]
 comment-token = "\\"
 language-servers = [ "forth-lsp" ]
 indent = { tab-width = 3, unit = "   " }
+extra-word-characters = "!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~¡¢£¤¥¦§¨©ª«¬­®¯°±²³´µ¶·¸¹º»¼½¾¿"
 
 [[grammar]]
 name = "forth"
@@ -4083,6 +4103,7 @@ shebangs = []
 auto-format = false
 comment-token = "--"
 indent = { tab-width = 4, unit = "    " }
+extra-word-characters = "!'"
 
 [language.auto-pairs]
 '(' = ')'
@@ -4320,6 +4341,7 @@ shebangs = [ "pwsh", "powershell" ]
 comment-token = '#'
 block-comment-tokens = { start = "<#", end = "#>" }
 indent = { tab-width = 4, unit = "    " }
+extra-word-characters = "-"
 
 [[grammar]]
 name = "powershell"
@@ -5120,6 +5142,7 @@ scope = "source.pip-requirements"
 injection-regex = "(pip-)?requirements(\\.txt)?"
 grammar = "requirements"
 file-types = [{ glob = "requirements.txt" }, { glob = "constraints.txt" }]
+extra-word-characters = "-"
 
 [[grammar]]
 name = "requirements"


### PR DESCRIPTION
Adds `extra-word-characters` language option. Allows for language appropriate motions and completions. Similar to `extra_char_words` in kakoune, `iskeyword` in Vim, `word_characters` in Zed.

# Motions

Also works with injected languages:

https://github.com/user-attachments/assets/2e50cc92-0754-4bbd-a5cd-a4ad4d4cc911


# Completions
<details>
<summary>Completions</summary>

## Before
Note how it collapses the menu after inserting `-`

https://github.com/user-attachments/assets/334088f9-88fc-4fbf-9c3e-d7d8489140ee

## After
https://github.com/user-attachments/assets/0fedc79e-6d75-4233-bc80-14b7c05fa883

</details>

# Notes

- I dont think a global editor option for `extra-word-characters` is that useful. I grepped github and pretty much all results were language specific, or added a single `-` which is questionable.
- Only affects `{move/extend}_{next/prev}_word_{start/end}` commands, no subword or longwords.
- Current `extra-word-characters` settings are taken from Neovim.

## Closes
- #14225 
- #12540
## Related
- #8701