### PR TITLE
Add 'tsrx' to file-types for ripple language

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -5360,7 +5360,7 @@ source = { git = "https://github.com/lykahb/tree-sitter-sgf", rev = "b7e0fb713b2
 [[language]]
 name = "ripple"
 scope = "source.ripple"
-file-types = [ "ripple" ]
+file-types = [ "tsrx", "ripple" ]
 roots = [ "package.json" ]
 comment-token = "//"
 block-comment-tokens = { start = "/*", end = "*/" }


### PR DESCRIPTION
New versions of Ripple prefer Typescript and "tsrx" extension