### PR TITLE
path to readme is inferred

### DIFF
--- a/helix-lsp-types/Cargo.toml
+++ b/helix-lsp-types/Cargo.toml
@@ -14,8 +14,6 @@ description = "Types for interaction with a language server, using VSCode's Lang
 repository = "https://github.com/gluon-lang/lsp-types"
 documentation = "https://docs.rs/lsp-types"
 
-readme = "README.md"
-
 keywords = ["language", "server", "lsp", "vscode", "lsif"]
 
 license = "MIT"


### PR DESCRIPTION
Avoids this cli warning

```
warning: explicit `package.readme` can be inferred
  --> helix-lsp-types/Cargo.toml:17:1
   |
17 | readme = "README.md"
   | ^^^^^^^^^^^^^^^^^^^^