### PR TITLE
Specialize json into separate language for package.json files

### DIFF
--- a/book/src/generated/lang-support.md
+++ b/book/src/generated/lang-support.md
@@ -211,6 +211,7 @@
 | openscad | ✓ |  |  |  |  | `openscad-lsp` |
 | org | ✓ |  |  |  |  |  |
 | p | ✓ |  |  |  |  |  |
+| package-json | ✓ | ✓ | ✓ |  | ✓ | `package-version-server`, `vscode-json-language-server` |
 | pascal | ✓ | ✓ |  |  |  | `pasls` |
 | passwd | ✓ |  |  |  |  |  |
 | pem | ✓ |  |  |  |  |  |

--- a/languages.toml
+++ b/languages.toml
@@ -108,6 +108,7 @@ oxfmt-language-server = { command = "oxfmt", args = ["--lsp"] }
 oxlint-language-server = { command = "oxlint", args = ["--lsp"] }
 omnisharp = { command = "OmniSharp", args = [ "--languageserver" ] }
 openscad-lsp = { command = "openscad-lsp", args = ["--stdio"] }
+package-version-server = { command = "package-version-server" }  # https://github.com/zed-industries/package-version-server/
 pasls = { command = "pasls", args = [] }
 pbkit = { command = "pb", args = [ "lsp" ] }
 perlnavigator = { command = "perlnavigator", args= ["--stdio"] }
@@ -5655,3 +5656,19 @@ comment-tokens = ["REM", "::"]
 [[grammar]]
 name = "batch"
 source = { git = "https://github.com/wharflab/tree-sitter-batch", rev = "5fc5f54267ef9a78e7a5319b80e092194252aabf" }
+
+[[language]]
+name = "package-json"
+scope = "source.package-json"
+injection-regex = "package.json"
+file-types = [ {glob = "package.json"} ]
+grammar = "json"
+auto-format = true
+indent = { tab-width = 2, unit = "  " }
+# Have package-version-server before vscode-json-language-server
+# to have its hover action response have priority, as it is more
+# relevant when used package dependencies.
+language-servers = [
+  "package-version-server",
+  "vscode-json-language-server",
+]

--- a/runtime/queries/package-json/highlights.scm
+++ b/runtime/queries/package-json/highlights.scm
@@ -1,0 +1,1 @@
+; inherits: json

--- a/runtime/queries/package-json/indents.scm
+++ b/runtime/queries/package-json/indents.scm
@@ -1,0 +1,1 @@
+; inherits: json

--- a/runtime/queries/package-json/injections.scm
+++ b/runtime/queries/package-json/injections.scm
@@ -1,0 +1,20 @@
+; inherits: json
+
+; Inject bash in package.scripts
+; e.g.
+; ```
+; {
+;   "scripts": {
+;     "build": "vite build && tsc --project tsconfig.server.json",
+;               ^                                              ^
+;               └──────────────────────────────────────────────┘
+;   }
+; }
+; ```
+((pair
+  key: (string (string_content) @_scripts_key (#eq? @_scripts_key "scripts"))
+  value: (object
+    (pair
+      value:
+        (string (string_content) @injection.content))))
+  (#set! injection.language "bash"))

--- a/runtime/queries/package-json/rainbows.scm
+++ b/runtime/queries/package-json/rainbows.scm
@@ -1,0 +1,1 @@
+; inherits: json

--- a/runtime/queries/package-json/textobjects.scm
+++ b/runtime/queries/package-json/textobjects.scm
@@ -1,0 +1,1 @@
+; inherits: json


### PR DESCRIPTION
Done for two reasons:
1. Use https://github.com/zed-industries/package-version-server as language server
2. Inject bash into `jq ".scripts | to_entries | map(.value)" < package.json`

## Showcase

<img width="883" height="262" alt="image" src="https://github.com/user-attachments/assets/b0c531ae-103d-4313-8af0-5867be002087" />

<img width="1554" height="371" alt="image" src="https://github.com/user-attachments/assets/eb206b65-d7b6-4fdf-b7a9-311bfd2adc4d" />

